### PR TITLE
Fix SemVer 2.0 syntax in package versions

### DIFF
--- a/.github/workflows/PRBuild.yml
+++ b/.github/workflows/PRBuild.yml
@@ -27,6 +27,6 @@ jobs:
         # Get the FileVersion from the Build.props file
         $GetFileVersionOutput = dotnet msbuild dotnet/Directory.Build.props /t:GetFileVersion
         "$GetFileVersionOutput" -match "(?<=FileVersion:)(.*)"
-        $NuGetPackageVersion = $Matches[0] + "." + $CommitNumber 
+        $NuGetPackageVersion = $Matches[0] + "-" + $CommitNumber 
 
         dotnet pack dotnet\DotNetStandardClasses.sln --configuration $Env:Configuration /p:Version=$NuGetPackageVersion

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,9 @@ jobs:
         $GetFileVersionOutput = $Matches[0]
 
         $IsMaster = dotnet msbuild dotnet/Directory.Build.props /t:IsMaster
-        $VersionTag = if ($IsMaster -match "(?<=IsMaster:)(.*)") {"rc"} else {"beta"}
+        $VersionTag = if ($IsMaster -match "(?<=IsMaster:)(.*)") {"stable"} else {"trunk"}
 
-        $NuGetPackageVersion = $GetFileVersionOutput + "." + $CommitNumber + "-" + $VersionTag
+        $NuGetPackageVersion = $GetFileVersionOutput + "-" + $VersionTag + "." + $CommitNumber
 
         dotnet pack dotnet\DotNetStandardClasses.sln --configuration $Env:Configuration /p:Version=$NuGetPackageVersion
 

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -17,6 +17,7 @@
 		<CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)StandardClasses.ruleset</CodeAnalysisRuleSet>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/genexuslabs/dotnetClasses</RepositoryUrl>
+		<NoWarn>NU5105</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="!$(GITHUB_REF.EndsWith('master'))">


### PR DESCRIPTION
Move build number after prerelease tag
Use the string "stable" and "trunk" for pre-release versions.