### PR TITLE
Add GitHub Package Registry to remote builds

### DIFF
--- a/.github/workflows/PRBuild.yml
+++ b/.github/workflows/PRBuild.yml
@@ -17,6 +17,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
+    - name: Setup Nuget.exe
+      uses: warrenbuckley/Setup-Nuget@v1
+
     - name: Setup GitHub NuGet Registry (GPR)
       run: nuget sources Add -Name "GPR" -Source "https://nuget.pkg.github.com/genexuslabs/index.json" -UserName %GITHUB_ACTOR% -Password ${{ secrets.GITHUB_TOKEN }} 
 


### PR DESCRIPTION
In order to build some projects on this REPO, the GXOdata.Client package is needed. However, when building on a GitHub-hosted runner, it's currently not accesible (it's hosted on GitHub Package Registry and our internal NuGet feeds).

This PR adds the Github Registry (GPR) as a NuGet source to remote builds in order to make the said package available