### PR TITLE
Unify File.CopyTo behavior with java

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GXFileIO.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GXFileIO.cs
@@ -310,7 +310,11 @@ public class GxFileInfo : IGxFileInfo
     {
         filename = FileUtil.NormalizeSource(filename, _baseDirectory);
 
-        return new GxFileInfo(_file.CopyTo(filename, overwrite));
+		FileInfo targetFile = new FileInfo(filename);
+		if (!targetFile.Directory.Exists)
+			targetFile.Directory.Create();
+
+		return new GxFileInfo(_file.CopyTo(filename, overwrite));
     }
 
     public FileStream Create()


### PR DESCRIPTION
File.CopyTo: the directory holding the destination file is created if it does not exist.
Issue: 81569