### PR TITLE
Fix build error

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/GxClasses.csproj
+++ b/dotnet/src/dotnetframework/GxClasses/GxClasses.csproj
@@ -11,6 +11,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.6.0"/>
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0"/>
+		<PackageReference Include="Microsoft.Win32.Registry" Version="4.1.3.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 		<PackageReference Include="Nustache" Version="1.16.0.10" />
 		<PackageReference Include="SecurityCodeScan" PrivateAssets="all" Version="3.3.0" />


### PR DESCRIPTION
The type name 'RegistryKey' could not be found in the namespace 'Microsoft.Win32'.