### PR TITLE
Fixed xml deserializtion memory issue related to Unknown nodes

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Helpers/XMLHelper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/XMLHelper.cs
@@ -199,7 +199,7 @@ namespace GeneXus.Utils
 		}
 		public void unknownNode(object sender, XmlNodeEventArgs e)
 		{
-			if (this.errorCount <= this.maxError)
+			if (this.errorCount < this.maxError)
 			{
 				this.errorCount++;
 				this.Add(string.Format("Unexpected node found ({0}): {1} (name: {2}, namespace: {3}", this.errorCount, e.Name, e.LocalName, e.NamespaceURI));


### PR DESCRIPTION
- Limit unknown nodes reporting to 10 by default
- Config unknown nodes reporting count using config key 'XmlSerialization-MaxErrorReporting'
Issue 82057