### PR TITLE
Headers in .net core rest services were empty because of null httpcontext

### DIFF
--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -446,6 +446,7 @@ namespace GeneXus.Application
 		{
 
 			GxContext gxContext = new GxContext();
+			gxContext.HttpContext = context;
 			DataStoreUtil.LoadDataStores(gxContext);
 			context.NewSessionCheck();
 			string nspace;


### PR DESCRIPTION
Issue:81532