### PR TITLE
Replace default nustache encoder (=html encoder) with no encoding

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/UserControls/UserControlGenerator.cs
+++ b/dotnet/src/dotnetframework/GxClasses/UserControls/UserControlGenerator.cs
@@ -31,7 +31,8 @@ namespace GeneXus.UserControls
 		{
 			if (!File.Exists(GetTemplateAction(m_Type)))
 				return String.Empty;
-			
+			Encoders.HtmlEncode = (input) => input;  
+
 			if (GetTemplateDateTime() > LastRenderTime || m_Template == null)
 			{
 				m_Template = new Template();


### PR DESCRIPTION
Replace the encoder by one that does not transform text then User Controls 2.0 content is not modified.
Issue:82107