### PR TITLE
Fix error with aspnet core compression on large responses

### DIFF
--- a/dotnet/src/dotnetcore/GxClasses/Helpers/HtmlHelper.cs
+++ b/dotnet/src/dotnetcore/GxClasses/Helpers/HtmlHelper.cs
@@ -19,7 +19,9 @@ namespace GeneXus.Utils
 		}
 		public void Flush()
 		{
-			_context.Response.WriteAsync(_stream.ToString());
+			//Response.WriteAsync makes ResponseCompressor throws exception for big stream, use Response.Body.Write instead
+			_context.Response.Body.Write(Encoding.UTF8.GetBytes(_stream.ToString()));
+			_context.Response.Body.FlushAsync();
 		}
 	}
 


### PR DESCRIPTION
Issue:82291
Fix Error: System.InvalidOperationException: Only one asynchronous reader or writer is allowed time at one time. at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionBody.WriteAsync.
for large html responses.
It seems that Response.WriteAsync has an issue with large streams that does not happen with Response.Body.Write.
Honour Auto compress http traffic property.

