### PR TITLE
Fix 'for first' cache when query issues a 'record not found' response

### DIFF
--- a/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.cs
+++ b/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.cs
@@ -929,7 +929,10 @@ namespace GeneXus.Data.NTier
 					}
 					catch (WebRequestException e)
 					{
-						throw conn.GetWebRequestException(e);
+						Exception toThrow = conn.GetWebRequestException(e);
+						if (behavior == CommandBehavior.SingleRow && IsRecordNotFoundException(toThrow))
+							return false;
+						else throw toThrow;
 					}
 					if (data == null)
 					{
@@ -969,6 +972,8 @@ namespace GeneXus.Data.NTier
 			}
 			return false;
 		}
+
+		private bool IsRecordNotFoundException(Exception e) => (e as AggregateException)?.Message == ServiceError.RecordNotFound;
 
 		public object this[string name]
 		{


### PR DESCRIPTION
The OData query that requests an entity by key returns a 404 HTTP response that is wrapped inside a WebRequestException. 
This exception was captured by FetchData method and handled correctly by the ProcessError method of the OData service error handler. However the result (not found) was not cached because the datareader is not instantiated in this case (the result of a 'for first' request is cached upon return from ExecStmtFetch1 called from ExecuteReader.
The fix for OData is to avoid throwing an exception by acknowledging that the WebRequestException is due to a 'record not found' response
issue 82416