### PR TITLE
Package versions should always follow a monotonic increment

### DIFF
--- a/.github/workflows/PRBuild.yml
+++ b/.github/workflows/PRBuild.yml
@@ -13,8 +13,8 @@ jobs:
       Configuration: Release
       NuGetRepository: http://nexus.genexus.com/repository/nuget-prereleases/
     
-      runs-on: windows-latest
-
+    runs-on: windows-latest
+   
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/PRBuild.yml
+++ b/.github/workflows/PRBuild.yml
@@ -1,4 +1,4 @@
-name: PR_Build
+name: PR-Build
 
 on: 
   push:
@@ -11,8 +11,9 @@ jobs:
   build:
     env:
       Configuration: Release
-
-    runs-on: windows-latest
+      NuGetRepository: http://nexus.genexus.com/repository/nuget-prereleases/
+    
+      runs-on: windows-latest
 
     steps:
     - name: Checkout
@@ -24,15 +25,21 @@ jobs:
     - name: Setup GitHub NuGet Registry (GPR)
       run: nuget sources Add -Name "GPR" -Source "https://nuget.pkg.github.com/genexuslabs/index.json" -UserName %GITHUB_ACTOR% -Password ${{ secrets.GITHUB_TOKEN }} 
 
-
     - name: Build and Pack
       run: |
         $CommitNumber = git rev-list --no-merges --count HEAD
 
         dotnet build dotnet\DotNetStandardClasses.sln --configuration $Env:Configuration /p:CommitNumber=$CommitNumber
+        
         # Get the FileVersion from the Build.props file
         $GetFileVersionOutput = dotnet msbuild dotnet/Directory.Build.props /t:GetFileVersionForPackage /p:CommitNumber=$CommitNumber
         "$GetFileVersionOutput" -match "(?<=FileVersion:)(.*)"
-        $NuGetPackageVersion = $Matches[0] + "-alpha" + $CommitNumber 
+        $GetFileVersionOutput = $Matches[0]
+
+        $IsMaster = dotnet msbuild dotnet/Directory.Build.props /t:IsMaster
+        $VersionTag = if ($IsMaster -match "(?<=IsMaster:)(.*)") {"stable"} else {"trunk"}
+
+        $Timestamp = (Get-Date).ToString("yyyyMMddHHmmss")
+        $NuGetPackageVersion = $GetFileVersionOutput + "-" + $VersionTag + "." + $Timestamp
 
         dotnet pack dotnet\DotNetStandardClasses.sln --no-build --configuration $Env:Configuration /p:Version=$NuGetPackageVersion

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
         Get-ChildItem .\dotnet\src\*\bin -Recurse -ErrorAction SilentlyContinue |
           ForEach-Object {
            rm -Recurse $_.FullName
-          }
+        }
         Get-ChildItem .\dotnet\src\*\obj -Recurse -ErrorAction SilentlyContinue |
           ForEach-Object {
            rm -Recurse $_.FullName
-          }
+        }
 
     - name: Build and Pack
       run: |
@@ -41,8 +41,8 @@ jobs:
 
         $IsMaster = dotnet msbuild dotnet/Directory.Build.props /t:IsMaster
         $VersionTag = if ($IsMaster -match "(?<=IsMaster:)(.*)") {"stable"} else {"trunk"}
-
-        $NuGetPackageVersion = $GetFileVersionOutput + "-" + $VersionTag + "." + $CommitNumber
+        $Timestamp = (Get-Date).ToString("yyyyMMddHHmmss")
+        $NuGetPackageVersion = $GetFileVersionOutput + "-" + $VersionTag + "." + $Timestamp
 
         dotnet pack dotnet\DotNetStandardClasses.sln --no-build --configuration $Env:Configuration /p:Version=$NuGetPackageVersion
 


### PR DESCRIPTION
Rather than using the commit number to number prerelease package versions, use the build timestamp instead.