### PR TITLE
SMTP Authentication Method new Property

### DIFF
--- a/dotnet/src/dotnetframework/GxMail/GXSMTPSession.cs
+++ b/dotnet/src/dotnetframework/GxMail/GXSMTPSession.cs
@@ -15,6 +15,7 @@ namespace GeneXus.Mail
         private string attachDir;
         private short authentication;
         private short secure;
+		private string authenticationMethod;
 
         private string host;
         private string userName;
@@ -90,7 +91,19 @@ namespace GeneXus.Mail
             }
         }
 
-        public short Secure
+		public string AuthenticationMethod
+		{
+			get
+			{
+				return authenticationMethod;
+			}
+			set
+			{
+				authenticationMethod = value;
+			}
+		}
+
+		public short Secure
         {
             get
             {


### PR DESCRIPTION
Issue 82627

Not implemented in Net, as SMTPClient implementation does not support OAUTH.

This commit is only for java and .net cross compatibility generated code.

&SMTPSession.AuthenticationMetod = "XOAUTH2"