### PR TITLE
Fix loading of assemblies without strong name

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
@@ -406,8 +406,16 @@ namespace GeneXus.Configuration
 				string fileName = Path.Combine(FileUtil.GetStartupDirectory(), ConfigurationManagerFileName);
 				if (File.Exists(fileName))
 				{
-					Assembly assembly = Assembly.LoadFrom(fileName);
-					return assembly;
+					return Assembly.LoadFrom(fileName);
+				}
+			}
+			else {
+				AssemblyName assName = new AssemblyName(args.Name);
+				bool strongNamedAssembly = assName.GetPublicKeyToken().Length > 0;
+				string fileName = Path.Combine(FileUtil.GetStartupDirectory(), $"{assName.Name}.dll");
+				if (!strongNamedAssembly && File.Exists(fileName))
+				{
+					return Assembly.LoadFrom(fileName);
 				}
 			}
 			return null;


### PR DESCRIPTION
When resolution using deps.json fails try to load assembly from the executing directory.
It happens when a module (p.e. gxtest.dll) references an external library (p.e. UITest_EO.dll). In that case the arunner.deps.json does not include the reference to UITest_EO.dll (because gxtest.dll is an Assemblyreference of arunner.csproj, it wouldn't happen if gxtest were a package reference).

Issue:82799