### PR TITLE
Do not FetchEntireMessage after send since email.Id is null.

### DIFF
--- a/dotnet/src/dotnetframework/GxMail/Exchange/ExchangeSession.cs
+++ b/dotnet/src/dotnetframework/GxMail/Exchange/ExchangeSession.cs
@@ -198,7 +198,6 @@ namespace GeneXus.Mail.Exchange
                 try
                 {
                     email.SendAndSaveCopy(WellKnownFolderName.SentItems);
-					FetchEntireMessage(email, gxmessage);
 				}
                 catch (Exception e)
                 {


### PR DESCRIPTION
Issue:83105