### PR TITLE
Soporte para modulos en api object

### DIFF
--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -501,9 +501,23 @@ namespace GeneXus.Application
 			context.NewSessionCheck();
 			string nspace;
 			Config.GetValueOf("AppMainNamespace", out nspace);
-			if (File.Exists(Path.Combine(ContentRootPath, $"{controller.ToLower()}.grp.json")))
+
+			String tmpController = controller;
+			String addNspace =  "";
+			String asssemblycontroller = tmpController;
+
+
+			if (controller.Contains("\\"))
 			{
-				var controllerInstance = ClassLoader.FindInstance(controller, nspace, controller, new Object[] { gxContext }, Assembly.GetEntryAssembly());
+				tmpController = controller.Substring(controller.LastIndexOf("\\") + 1);
+				addNspace = (controller.Contains("\\")) ? controller.Substring(0, controller.LastIndexOf("\\")).Replace("\\", ".") ;
+				asssemblycontroller = (controller.Contains("\\")) ? addNspace + "." + tmpController ;
+				nspace += "." + addNspace;
+			}
+			if (File.Exists(Path.Combine(ContentRootPath, $"{asssemblycontroller.ToLower()}.grp.json")))
+			{
+				controller = tmpController;
+				var controllerInstance = ClassLoader.FindInstance(asssemblycontroller, nspace, controller, new Object[] { gxContext }, Assembly.GetEntryAssembly());
 				GXProcedure proc = controllerInstance as GXProcedure;
 				if (proc != null)
 					return new GxRestWrapper(proc, context, gxContext, methodName);

--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -510,8 +510,8 @@ namespace GeneXus.Application
 			if (controller.Contains("\\"))
 			{
 				tmpController = controller.Substring(controller.LastIndexOf("\\") + 1);
-				addNspace = (controller.Contains("\\")) ? controller.Substring(0, controller.LastIndexOf("\\")).Replace("\\", ".") ;
-				asssemblycontroller = (controller.Contains("\\")) ? addNspace + "." + tmpController ;
+				addNspace =  controller.Substring(0, controller.LastIndexOf("\\")).Replace("\\", ".") ;
+				asssemblycontroller = addNspace + "." + tmpController ;
 				nspace += "." + addNspace;
 			}
 			if (File.Exists(Path.Combine(ContentRootPath, $"{asssemblycontroller.ToLower()}.grp.json")))

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/HandlerFactory.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/HandlerFactory.cs
@@ -69,7 +69,17 @@ namespace GeneXus.HttpHandlerFactory
 						if (httpVerb !=null && !(requestType.Equals(httpVerb)))
 							   return null;
 					}
-					var handler = ClassLoader.FindInstance(objClass, nspace, objClass, null, null);
+					String tmpController = objClass;
+					String addNspace = "";
+					String asssemblycontroller =  tmpController;
+					if (objClass.Contains("\\"))
+					{
+						tmpController = objClass.Substring(objClass.LastIndexOf("\\") + 1);
+						addNspace =  objClass.Substring(0, objClass.LastIndexOf("\\")).Replace("\\", ".") ;
+						asssemblycontroller = addNspace + "." + tmpController ;
+						nspace += "." + addNspace;
+					}					
+					var handler = ClassLoader.FindInstance(asssemblycontroller, nspace, tmpController, null, null);
 					var gxContext = new GxContext();
 					GxRestWrapper restWrapper = new Application.GxRestWrapper(handler as GXProcedure, context, gxContext, value);					
 					return restWrapper ;


### PR DESCRIPTION
Agrego soporte para modulos en api object.
Issue: 74617
LAs URL del APi Object son configurables por lo que puede no usar el formato module.Objeto que se usa en el resto de los servicios.

