### PR TITLE
Return complete task for failed authentication in rest services.

### DIFF
--- a/dotnet/src/dotnetcore/GxClasses/Services/CoreWebAPI/Controller/GXBCRestService.cs
+++ b/dotnet/src/dotnetcore/GxClasses/Services/CoreWebAPI/Controller/GXBCRestService.cs
@@ -30,7 +30,7 @@ namespace GeneXus.Application
 			{
 				if (!IsAuthenticated())
 				{
-					return null;
+					return Task.CompletedTask;
 				}
 				bool gxcheck = IsRestParameter(CHECK_PARAMETER);
 				bool gxinsertorupdate = IsRestParameter(INSERT_OR_UPDATE_PARAMETER);
@@ -96,7 +96,7 @@ namespace GeneXus.Application
 			{
 				if (!IsAuthenticated())
 				{
-					return null;
+					return Task.CompletedTask;
 				}
 				string[] key = SplitParameters(parameters);
 				if (key!=null)
@@ -139,7 +139,7 @@ namespace GeneXus.Application
 			{
 				if (!IsAuthenticated())
 				{
-					return null;
+					return Task.CompletedTask;
 				}
 				string[] key = SplitParameters(parameters);
 				if (key != null)
@@ -177,7 +177,7 @@ namespace GeneXus.Application
 			{
 				if (!IsAuthenticated())
 				{
-					return null;
+					return Task.CompletedTask;
 				}
 				string[] key = SplitParameters(parameters);
 				if (key != null)

--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -206,7 +206,7 @@ namespace GeneXus.Application
 			{
 				if (!IsAuthenticated())
 				{
-					return null;
+					return Task.CompletedTask; 
 				}
 				if (!ProcessHeaders(_procWorker.GetType().Name))
 					return Task.CompletedTask;

--- a/dotnet/src/dotnetframework/GxClasses/Services/ReflectionHelper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/ReflectionHelper.cs
@@ -131,7 +131,7 @@ namespace GeneXus.Application
 				outputParameters.Add(string.Empty, returnParm);
 			return outputParameters;
 		}
-		private static object[] ProcessParametersForInvoke(MethodInfo methodInfo, IDictionary<string, object> parameters)
+		internal static object[] ProcessParametersForInvoke(MethodInfo methodInfo, IDictionary<string, object> parameters)
 		{
 			var methodParameters = methodInfo.GetParameters();
 			object[] parametersForInvocation = new object[methodParameters.Length];


### PR DESCRIPTION
Fix offlineReplicator calls. 
Return complete task for failed authentication in rest services in order to send correctly the json error message.  
Fix Exception when returning null as a Task.
System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Session.SessionMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)
Issue:81537