### PR TITLE
Fix error json returned on 403 errors for rest services

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
@@ -148,7 +148,7 @@ namespace GeneXus.Http
 		{
 			SetResponseStatus(httpContext, statusCode, statusDescription);
 			httpContext.Response.ContentType = MediaTypesNames.ApplicationJson;
-			var jsonError = new HttpJsonError() { Code = statusCode, Message = statusDescription };
+			var jsonError = new WrappedJsonError() { Error = new HttpJsonError() { Code = statusCode, Message = statusDescription } };
 #if NETCORE
 			return httpContext.Response.WriteAsync(JSONHelper.Serialize(jsonError));
 #else


### PR DESCRIPTION
Issue: 81537
Rest services (case 287 from test 5786 in fullgx) returned 
{"code":"103","message":"Token expired, login again."}
instead of 
{"error":{"code":"103","message":"Token expired, login again."}}