### PR TITLE
BC parameters at REST Procedures were not initialized property

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -107,7 +107,7 @@ namespace GeneXus.Application
 				{
 					innerMethod = this.ServiceMethod;
 				}
-				Dictionary<string, object> outputParameters = ReflectionHelper.CallMethod(_procWorker, innerMethod, bodyParameters);
+				Dictionary<string, object> outputParameters = ReflectionHelper.CallMethod(_procWorker, innerMethod, bodyParameters, _gxContext);
 				_procWorker.cleanup();
 				MakeRestTypes(outputParameters);
 				return Serialize(outputParameters, wrapped);


### PR DESCRIPTION
Issue:83439
When deserializing REST input parameters of a BusinessComponent type, create it with the context argument so the inner transaction is created. That inner transaction allows to execute BC operations as Insert, Update, InserOrUpdate, etc.
