### PR TITLE
Break page when HTML variable in PDF report overflows page height

### DIFF
--- a/dotnet/src/dotnetframework/GxPdfReportsCS/PDFReportItext.cs
+++ b/dotnet/src/dotnetframework/GxPdfReportsCS/PDFReportItext.cs
@@ -1233,17 +1233,12 @@ namespace com.genexus.reports
 				Col.SetSimpleColumn(rect);
 				simulationCol.SetSimpleColumn(rect);
 				
-				bool pageHeightExceeded = bottomAux > drawingPageHeight;
-
-				if (pageHeightExceeded)
-					bottomAux -= drawingPageHeight;
-
 				try
 				{
 					List<IElement> objects = HTMLWorker.ParseToList(new StringReader(sTxt), styles);
 					for (int k = 0; k < objects.Count; ++k)
 					{
-						if (pageHeightExceeded)
+						if (PageHeightExceeded(bottomAux, drawingPageHeight))
 						{
 							simulationCol.AddElement((IElement)objects[k]);
 							simulationCol.Go(true);
@@ -1252,9 +1247,7 @@ namespace com.genexus.reports
 							{
 								rect = new Rectangle(leftAux + leftMargin, drawingPageHeight - bottomAux, rightAux + leftMargin, drawingPageHeight - topAux);
 
-								pageHeightExceeded = bottomAux > drawingPageHeight;
-								if (pageHeightExceeded)
-									bottomAux -= drawingPageHeight;
+								bottomAux -= drawingPageHeight;
 
 								GxEndPage();
 								GxStartPage();
@@ -1509,6 +1502,10 @@ namespace com.genexus.reports
 					}
 				}
 			}
+		}
+		bool PageHeightExceeded(float bottomAux, float drawingPageHeight)
+		{
+			return bottomAux > drawingPageHeight;
 		}
 
 #pragma warning restore CS0612 // Type or member is obsolete

--- a/dotnet/src/dotnetframework/GxPdfReportsCS/PDFReportItext.cs
+++ b/dotnet/src/dotnetframework/GxPdfReportsCS/PDFReportItext.cs
@@ -1220,24 +1220,61 @@ namespace com.genexus.reports
 				bottomAux = (float)convertScale(bottom);
 				topAux = (float)convertScale(top);
 
+
 				ColumnText Col = new ColumnText(cb);
-				
-				Col.SetSimpleColumn(leftAux + leftMargin,
-				(float)this.pageSize.Top - bottomAux - topMargin - bottomMargin,
+				ColumnText simulationCol = new ColumnText(null);
+				float drawingPageHeight = (float)this.pageSize.Top - topMargin - bottomMargin;
+
+				Rectangle rect = new Rectangle(leftAux + leftMargin,
+				drawingPageHeight - bottomAux,
 				 rightAux + leftMargin,
-				(float)this.pageSize.Top - topAux - topMargin - bottomMargin);
+				drawingPageHeight - topAux);
+
+				Col.SetSimpleColumn(rect);
+				simulationCol.SetSimpleColumn(rect);
+				
+				bool pageHeightExceeded = bottomAux > drawingPageHeight;
+
+				if (pageHeightExceeded)
+					bottomAux -= drawingPageHeight;
 
 				try
 				{
 					List<IElement> objects = HTMLWorker.ParseToList(new StringReader(sTxt), styles);
 					for (int k = 0; k < objects.Count; ++k)
+					{
+						if (pageHeightExceeded)
+						{
+							simulationCol.AddElement((IElement)objects[k]);
+							simulationCol.Go(true);
+
+							if (simulationCol.YLine < bottomMargin)
+							{
+								rect = new Rectangle(leftAux + leftMargin, drawingPageHeight - bottomAux, rightAux + leftMargin, drawingPageHeight - topAux);
+
+								pageHeightExceeded = bottomAux > drawingPageHeight;
+								if (pageHeightExceeded)
+									bottomAux -= drawingPageHeight;
+
+								GxEndPage();
+								GxStartPage();
+								simulationCol = new ColumnText(null);
+								simulationCol.SetSimpleColumn(rect);
+								simulationCol.AddElement((IElement)objects[k]);
+
+								Col = new ColumnText(cb);
+								Col.SetSimpleColumn(rect);
+							}
+						}
 						Col.AddElement((IElement)objects[k]);
+						Col.Go();
+					}
 				}
 				catch (Exception ex1)
 				{
 					GXLogging.Debug(log, "Error adding html: ", ex1);
 				}
-				Col.Go();
+				
 			}
 			else if (barcode != null)
 			{
@@ -1473,7 +1510,9 @@ namespace com.genexus.reports
 				}
 			}
 		}
+
 #pragma warning restore CS0612 // Type or member is obsolete
+
 		ColumnText SimulateDrawColumnText(PdfContentByte cb, Rectangle rect, Paragraph p, float leading, int runDirection, int alignment)
 		{
 			ColumnText Col = new ColumnText(cb);


### PR DESCRIPTION
Issue:83697
When a control with HTML format exceeds current page height (in both: control height and html content height), a new page is created and the overflowed content is printed at that new page applying the same algorithm.