### PR TITLE
Fix images path in rest services .net core

### DIFF
--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -493,11 +493,7 @@ namespace GeneXus.Application
 		private GxRestWrapper GetController(HttpContext context, string controller, string methodName)
 		{
 
-			GxContext gxContext = new GxContext
-			{
-				HttpContext = context
-			};
-			DataStoreUtil.LoadDataStores(gxContext);
+			GxContext gxContext = GxContext.CreateDefaultInstance();
 			context.NewSessionCheck();
 			string nspace;
 			Config.GetValueOf("AppMainNamespace", out nspace);

--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -494,6 +494,7 @@ namespace GeneXus.Application
 		{
 
 			GxContext gxContext = GxContext.CreateDefaultInstance();
+			gxContext.HttpContext = context;
 			context.NewSessionCheck();
 			string nspace;
 			Config.GetValueOf("AppMainNamespace", out nspace);

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -380,7 +380,15 @@ namespace GeneXus.Application
 				return _isWebAppManifestDefined == true;
 			}
 		}
-
+		public static GxContext CreateDefaultInstance()
+		{
+			GxContext context = new GxContext();
+			DataStoreUtil.LoadDataStores(context);
+			string theme = Preferences.GetDefaultTheme();
+			if (!string.IsNullOrEmpty(theme))
+				context.SetDefaultTheme(theme);
+			return context;
+		}
 		public GxContext()
 		{
 			_DataStores = new ArrayList(2);

--- a/dotnet/src/dotnetframework/GxClasses/Services/GXRestServices.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GXRestServices.cs
@@ -208,14 +208,10 @@ namespace GeneXus.Utils
 
         public GxRestService()
         {
-            context = new GxContext();
-            DataStoreUtil.LoadDataStores(context);
-            wcfContext = WebOperationContext.Current;
+			context = GxContext.CreateDefaultInstance();
+			wcfContext = WebOperationContext.Current;
             httpContext = HttpContext.Current;
-            string theme = Preferences.GetDefaultTheme();
-            if (!string.IsNullOrEmpty(theme))
-                context.SetDefaultTheme(theme);
-            if (GXUtil.CompressResponse())
+			if (GXUtil.CompressResponse())
                 GXUtil.SetGZip(httpContext);
         }
         public void Cleanup()

--- a/dotnet/src/dotnetframework/GxDataInitialization/GXDataInitialization.cs
+++ b/dotnet/src/dotnetframework/GxDataInitialization/GXDataInitialization.cs
@@ -30,12 +30,8 @@ namespace GeneXus.Utils
 
 		public GXDataInitialization()
 		{
-			context = new GxContext();
-			DataStoreUtil.LoadDataStores(context);
+			context = GxContext.CreateDefaultInstance();
 			IsMain = true;
-			string theme = Preferences.GetDefaultTheme();
-			if (!string.IsNullOrEmpty(theme))
-				context.SetDefaultTheme(theme);
 		}
 		public static int Main(string [] args)
 		{


### PR DESCRIPTION
Issue:83949
Encapsulate initialization of a default context instance and uses it from rest services. In .NET Core was missing the initialization of the default theme of a context in rest services thus images were not properly resolved.