### PR TITLE
DateTime structure deserialized from session state (B1SESSION_EXPIRY)…

### DIFF
--- a/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.cs
+++ b/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.cs
@@ -333,7 +333,7 @@ namespace GeneXus.Data.NTier
 				if (gxSession.Get(SESSION_INFO_ID) != null)
 				{
 					if (sessionExpiry is DateTime)
-						expiryDT = (DateTime)sessionExpiry;
+						expiryDT = DateTime.SpecifyKind((DateTime)sessionExpiry, DateTimeKind.Local);
 					else
 					{
 						string sessionExpiryStr = sessionExpiry as string;


### PR DESCRIPTION
… loses Kind value. Now gets reinstated programmatically.
The problem can be reproduced by maintaining the session state in a State Server in IIS and following these steps when accessing a B1 server:
 - perform some query to the B1 server (this will issue a login and store the B1Session and expiry in the session)
 - restart IIS pool
 - perform again some query to the B1 server. 