### PR TITLE
GXObject Multipart Upload (FileUpload UC) was returning incorrect Path information

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
@@ -33,7 +33,6 @@ namespace GeneXus.Http
 	using GeneXus.Web.Security;
 	using System.Linq;
 	using GeneXus.Procedure;
-	using System.Security.Policy;
 #else
 	using System.Web.UI;
 	using System.Web.UI.WebControls;

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
@@ -33,6 +33,7 @@ namespace GeneXus.Http
 	using GeneXus.Web.Security;
 	using System.Linq;
 	using GeneXus.Procedure;
+	using System.Security.Policy;
 #else
 	using System.Web.UI;
 	using System.Web.UI.WebControls;
@@ -404,18 +405,20 @@ namespace GeneXus.Http
 						GxFile gxFile = new GxFile(Preferences.getTMP_MEDIA_PATH(), savedFileName);
 
 						gxFile.Create(hpf.InputStream);
-
 						GXFileWatcher.Instance.AddTemporaryFile(gxFile);
 
-                        r.Add(new UploadFile()
+						string uri = gxFile.GetURI();
+						string blobPath = uri;
+
+						r.Add(new UploadFile()
 						{
 							name = fileName,
 							size = gxFile.GetLength(),
-							url = gxFile.GetPath(),
+							url = uri,
 							type = context.GetContentType(ext),
 							extension = ext,
-							thumbnailUrl = gxFile.GetPath(),
-                            path = savedFileName
+							thumbnailUrl = uri,
+							path = blobPath
 						});
 					}
 					UploadFilesResult result = new UploadFilesResult() { files = r };

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
@@ -405,6 +405,7 @@ namespace GeneXus.Http
 
 						gxFile.Create(hpf.InputStream);
 						GXFileWatcher.Instance.AddTemporaryFile(gxFile);
+
 						string uri = gxFile.GetURI();
 						string url = (PathUtil.IsAbsoluteUrl(uri)) ? uri : context.PathToUrl(uri);
 
@@ -416,8 +417,7 @@ namespace GeneXus.Http
 							type = context.GetContentType(ext),
 							extension = ext,
 							thumbnailUrl = url,
-                            path = uri
-
+							path = uri
 						});
 					}
 					UploadFilesResult result = new UploadFilesResult() { files = r };

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
@@ -405,19 +405,19 @@ namespace GeneXus.Http
 
 						gxFile.Create(hpf.InputStream);
 						GXFileWatcher.Instance.AddTemporaryFile(gxFile);
-
 						string uri = gxFile.GetURI();
-						string blobPath = uri;
+						string url = (PathUtil.IsAbsoluteUrl(uri)) ? uri : context.PathToUrl(uri);
 
 						r.Add(new UploadFile()
 						{
 							name = fileName,
 							size = gxFile.GetLength(),
-							url = uri,
+							url = url,
 							type = context.GetContentType(ext),
 							extension = ext,
-							thumbnailUrl = uri,
-							path = blobPath
+							thumbnailUrl = url,
+                            path = uri
+
 						});
 					}
 					UploadFilesResult result = new UploadFilesResult() { files = r };


### PR DESCRIPTION
Issue: 84280

Issues:
**Local Storage (File System):**
Returned JSON information: 
- Thumbnail URL was incorrect (returning folder path)
- URL was incorrect (returning folder path)


**External Storage**:
Returned JSON information: 
- "Path" was incorrect, so later, the GeneXus User code * did not work properly. 


```
* 
&Blob = &FileUploadData.File
&File.Source = &Blob
msg(!"File.GetURI: " + &File.GetURI() + " - Blob: "+ &Blob + " Exists File? " + &File.Exists().ToString())
```




