### PR TITLE
Fix URL rewrite when key has query and the url is in the rewrite file

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
@@ -40,16 +40,21 @@ namespace GeneXus.Application
 				path = string.Format(routerKey, parameterValues);
 			}
 			string basePath = Preferences.RewriteEnabled ? scriptPath : string.Empty;
+			string result;
 
-			if (string.IsNullOrEmpty(query))
+			if (!string.IsNullOrEmpty(routerKey))
 			{
 				if (PatternHasParameters(routerKey))
-					return $"{basePath}{path}";
+					result = $"{basePath}{path}";
 				else
-					return $"{basePath}{path}{ConvertParmsToQueryString(parms, parmsName, path)}";
+					result = $"{basePath}{path}{ConvertParmsToQueryString(parms, parmsName, path)}";
 			}
+			else if (!string.IsNullOrEmpty(query))
+				result = $"{basePath}{path}?{query}";
 			else
-				return $"{basePath}{path}?{query}";
+				result = $"{basePath}{path}";
+
+			return result;
 		}
 
 		private static string StringizeParm(object objectParm)

--- a/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
@@ -36,21 +36,29 @@ namespace GeneXus.Application
 			string[] parameterValues= string.IsNullOrEmpty(query) ? parms : HttpHelper.GetParameterValues(query);
 
 			string routerKey;
-			if (routerList.TryGetValue(path, out routerKey)){
+			bool rewriteMatch = routerList.TryGetValue(path, out routerKey);
+			if (rewriteMatch)
+			{
 				path = string.Format(routerKey, parameterValues);
 			}
 			string basePath = Preferences.RewriteEnabled ? scriptPath : string.Empty;
 			string result;
 
-			if (!string.IsNullOrEmpty(routerKey))
+			if (rewriteMatch)
 			{
 				if (PatternHasParameters(routerKey))
 					result = $"{basePath}{path}";
 				else
 					result = $"{basePath}{path}{ConvertParmsToQueryString(parms, parmsName, path)}";
 			}
+			else if (parms.Length > 0)
+			{
+				result = $"{basePath}{path}{ConvertParmsToQueryString(parms, parmsName, path)}";
+			}
 			else if (!string.IsNullOrEmpty(query))
+			{
 				result = $"{basePath}{path}?{query}";
+			}
 			else
 				result = $"{basePath}{path}";
 


### PR DESCRIPTION
Issue:84987

When URLRouter receives a key with query, and the URL is mapped in .rewrite, it repeated twice the query in the url.