### PR TITLE
Npgsql: Clear command parameters on dispose to void error when reusing the parameter collection

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
@@ -198,6 +198,11 @@ namespace GeneXus.Data
 				return count;
 			}
 		}
+		public override void DisposeCommand(IDbCommand command)
+		{
+			command.Parameters.Clear();
+			base.DisposeCommand(command);
+		}
 		public override Guid GetGuid(IGxDbCommand cmd, IDataRecord DR, int i)
 		{
 			string guid = base.GetString(cmd, DR, i);


### PR DESCRIPTION
Issue:84965