### PR TITLE
AWS S3 Add Support for using Custom Service URls such as: Minio, Orac…

### DIFF
--- a/dotnet/src/dotnetframework/Providers/Storage/GXAmazonS3/ExternalProviderS3.cs
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXAmazonS3/ExternalProviderS3.cs
@@ -21,6 +21,8 @@ namespace GeneXus.Storage.GXAmazonS3
 		const string SECRET_ACCESS_KEY = "STORAGE_PROVIDER_SECRETACCESSKEY";
 		const string REGION = "STORAGE_PROVIDER_REGION";
 		const string ENDPOINT = "STORAGE_ENDPOINT";
+		const string STORAGE_CUSTOM_ENDPOINT = "STORAGE_CUSTOM_ENDPOINT";
+		const string STORAGE_CUSTOM_ENDPOINT_VALUE = "custom";
 		const string BUCKET = "BUCKET_NAME";
 		const string FOLDER = "FOLDER_NAME";
 
@@ -29,9 +31,13 @@ namespace GeneXus.Storage.GXAmazonS3
 		string Folder { get; set; }
 		string Endpoint { get; set; }
 
+		bool ForcePathStyle = false;
+
 		public string StorageUri
 		{
-			get { return $"https://{Bucket}.{Endpoint}/"; }
+			get {
+				return (ForcePathStyle)? $"{Endpoint}/": $"https://{Bucket}.{Endpoint}/";
+			}
 		}
 
 		public string GetBaseURL()
@@ -55,14 +61,21 @@ namespace GeneXus.Storage.GXAmazonS3
 			}
 
 			var region = Amazon.RegionEndpoint.GetBySystemName(providerService.Properties.Get(REGION));
+
 			Endpoint = providerService.Properties.Get(ENDPOINT);
+			if (Endpoint == STORAGE_CUSTOM_ENDPOINT_VALUE)
+			{
+				Endpoint = providerService.Properties.Get(STORAGE_CUSTOM_ENDPOINT);
+				ForcePathStyle = true;
+			}
 
 			AmazonS3Config config = new AmazonS3Config()
 			{
+				RegionEndpoint = region,
 				ServiceURL = Endpoint,
-				RegionEndpoint = region
+				ForcePathStyle = ForcePathStyle
 			};
-
+						
 #if NETCORE
 			if (credentials != null)
 			{


### PR DESCRIPTION
Issue: 85648

Added Property: Custom Endpoint. 

GeneXus Sample Code: 

```
&Properties.set(!'STORAGE_PROVIDER_ACCESSKEYID', !'2be038125c3ca277cfdb4cea8677868692e9fa52')
&Properties.set(!'STORAGE_PROVIDER_SECRETACCESSKEY', !'kTnFOaOvE799NFpQC9Zl0NJfcdUfMNPrFOB7OgWAtJA=')
&Properties.set(!'STORAGE_ENDPOINT', !'custom')
&Properties.set(!'BUCKET_NAME', !'Hanel_FoccoLOJAS_Teste')
&Properties.set(!'STORAGE_CUSTOM_ENDPOINT', !'compat.objectstorage.sa-saopaulo-1.oraclecloud.com')

&ok =  &ExternalStorage.Create(StorageProviderType.Amazon_S3, &Properties, &StorageProvider, &Messages)
```