### PR TITLE
Replace deprecated set-env command

### DIFF
--- a/.github/workflows/PRBuild.yml
+++ b/.github/workflows/PRBuild.yml
@@ -33,7 +33,7 @@ jobs:
         $CommitNumber = git rev-list --no-merges --count HEAD
 
         dotnet build dotnet\DotNetStandardClasses.sln --no-restore --configuration $Env:Configuration /p:CommitNumber=$CommitNumber
-		echo "CommitNumber=$CommitNumber" >> $env:GITHUB_ENV
+        echo "CommitNumber=$CommitNumber" >> $env:GITHUB_ENV
         
     - name: Test
       run: dotnet test dotnet\DotNetStandardClasses.sln --no-restore --no-build --configuration $Env:Configuration /p:CommitNumber=$Env:CommitNumber

--- a/.github/workflows/PRBuild.yml
+++ b/.github/workflows/PRBuild.yml
@@ -33,7 +33,7 @@ jobs:
         $CommitNumber = git rev-list --no-merges --count HEAD
 
         dotnet build dotnet\DotNetStandardClasses.sln --no-restore --configuration $Env:Configuration /p:CommitNumber=$CommitNumber
-        echo "::set-env name=CommitNumber::$CommitNumber"
+		echo "CommitNumber=$CommitNumber" >> $env:GITHUB_ENV
         
     - name: Test
       run: dotnet test dotnet\DotNetStandardClasses.sln --no-restore --no-build --configuration $Env:Configuration /p:CommitNumber=$Env:CommitNumber

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         $CommitNumber = git rev-list --no-merges --count HEAD
 
         dotnet build dotnet\DotNetStandardClasses.sln --no-restore --configuration $Env:Configuration /p:CommitNumber=$CommitNumber
-        echo "::set-env name=CommitNumber::$CommitNumber"
+		echo "CommitNumber=$CommitNumber" >> $env:GITHUB_ENV
         
     - name: Test
       run: dotnet test dotnet\DotNetStandardClasses.sln --no-restore --no-build --configuration $Env:Configuration /p:CommitNumber=$Env:CommitNumber
@@ -61,7 +61,7 @@ jobs:
         $VersionTag = if ($IsMaster -match "(?<=IsMaster:)(.*)") {"stable"} else {"trunk"}
         $Timestamp = (Get-Date).ToString("yyyyMMddHHmmss")
         $NuGetPackageVersion = $GetFileVersionOutput + "-" + $VersionTag + "." + $Timestamp
-        echo "::set-env name=NuGetPackageVersion::$NuGetPackageVersion"
+		echo "NuGetPackageVersion=$NuGetPackageVersion" >> $env:GITHUB_ENV
 
         dotnet pack dotnet\DotNetStandardClasses.sln --no-restore --no-build --configuration $Env:Configuration /p:Version=$NuGetPackageVersion
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         $CommitNumber = git rev-list --no-merges --count HEAD
 
         dotnet build dotnet\DotNetStandardClasses.sln --no-restore --configuration $Env:Configuration /p:CommitNumber=$CommitNumber
-		echo "CommitNumber=$CommitNumber" >> $env:GITHUB_ENV
+        echo "CommitNumber=$CommitNumber" >> $env:GITHUB_ENV
         
     - name: Test
       run: dotnet test dotnet\DotNetStandardClasses.sln --no-restore --no-build --configuration $Env:Configuration /p:CommitNumber=$Env:CommitNumber
@@ -61,7 +61,7 @@ jobs:
         $VersionTag = if ($IsMaster -match "(?<=IsMaster:)(.*)") {"stable"} else {"trunk"}
         $Timestamp = (Get-Date).ToString("yyyyMMddHHmmss")
         $NuGetPackageVersion = $GetFileVersionOutput + "-" + $VersionTag + "." + $Timestamp
-		echo "NuGetPackageVersion=$NuGetPackageVersion" >> $env:GITHUB_ENV
+        echo "NuGetPackageVersion=$NuGetPackageVersion" >> $env:GITHUB_ENV
 
         dotnet pack dotnet\DotNetStandardClasses.sln --no-restore --no-build --configuration $Env:Configuration /p:Version=$NuGetPackageVersion
 

--- a/.github/workflows/releaseBuild.yml
+++ b/.github/workflows/releaseBuild.yml
@@ -46,7 +46,7 @@ jobs:
         $CommitNumber = git rev-list --no-merges --count HEAD
 
         dotnet build dotnet\DotNetStandardClasses.sln --no-restore --configuration $Env:Configuration /p:CommitNumber=$CommitNumber
-        echo "::set-env name=CommitNumber::$CommitNumber"
+		echo "CommitNumber=$CommitNumber" >> $env:GITHUB_ENV
         
     - name: Test
       run: dotnet test dotnet\DotNetStandardClasses.sln --no-restore --no-build --configuration $Env:Configuration /p:CommitNumber=$Env:CommitNumber
@@ -60,7 +60,7 @@ jobs:
         $GetFileVersionOutput = $Matches[0]
 
         $NuGetPackageVersion = $GetFileVersionOutput
-        echo "::set-env name=NuGetPackageVersion::$NuGetPackageVersion"
+		echo "NuGetPackageVersion=$NuGetPackageVersion" >> $env:GITHUB_ENV
 
         dotnet pack dotnet\DotNetStandardClasses.sln --no-restore --no-build --configuration $Env:Configuration /p:Version=$NuGetPackageVersion
 

--- a/.github/workflows/releaseBuild.yml
+++ b/.github/workflows/releaseBuild.yml
@@ -46,7 +46,7 @@ jobs:
         $CommitNumber = git rev-list --no-merges --count HEAD
 
         dotnet build dotnet\DotNetStandardClasses.sln --no-restore --configuration $Env:Configuration /p:CommitNumber=$CommitNumber
-		echo "CommitNumber=$CommitNumber" >> $env:GITHUB_ENV
+        echo "CommitNumber=$CommitNumber" >> $env:GITHUB_ENV
         
     - name: Test
       run: dotnet test dotnet\DotNetStandardClasses.sln --no-restore --no-build --configuration $Env:Configuration /p:CommitNumber=$Env:CommitNumber
@@ -60,7 +60,7 @@ jobs:
         $GetFileVersionOutput = $Matches[0]
 
         $NuGetPackageVersion = $GetFileVersionOutput
-		echo "NuGetPackageVersion=$NuGetPackageVersion" >> $env:GITHUB_ENV
+        echo "NuGetPackageVersion=$NuGetPackageVersion" >> $env:GITHUB_ENV
 
         dotnet pack dotnet\DotNetStandardClasses.sln --no-restore --no-build --configuration $Env:Configuration /p:Version=$NuGetPackageVersion
 


### PR DESCRIPTION
Replace deprecated set-env following: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/