### PR TITLE
Fix conversion of User Control's boolean properties to string

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/View/GXWebControls.cs
+++ b/dotnet/src/dotnetframework/GxClasses/View/GXWebControls.cs
@@ -2038,12 +2038,12 @@ namespace GeneXus.WebControls
 		public void SetProperty(String propertyName, object propertyValue)
 		{
 			string stringValue = propertyValue?.ToString();
-			if (propertyValue is Boolean)
+			if (propertyValue != null && !String.IsNullOrEmpty(stringValue))
 			{
-				stringValue = stringValue?.ToLower();
+				propertyBag[propertyName] = propertyValue is Boolean
+												? stringValue.ToLower()
+												: propertyValue;
 			}
-			if (!String.IsNullOrEmpty(stringValue))
-				propertyBag[propertyName] = stringValue;
 		}
 		public void SendProperty(IGxContext context, String componentPrefix, bool isMasterPage, String internalName, String propertyName, String propertyValue) 
 		{

--- a/dotnet/src/dotnetframework/GxClasses/View/GXWebControls.cs
+++ b/dotnet/src/dotnetframework/GxClasses/View/GXWebControls.cs
@@ -2037,8 +2037,13 @@ namespace GeneXus.WebControls
 		GxDictionary propertyBag = new GxDictionary();
 		public void SetProperty(String propertyName, object propertyValue)
 		{
-			if (propertyValue != null && !String.IsNullOrEmpty(propertyValue.ToString()))
-				propertyBag[propertyName] = propertyValue;
+			string stringValue = propertyValue?.ToString();
+			if (propertyValue is Boolean)
+			{
+				stringValue = stringValue?.ToLower();
+			}
+			if (!String.IsNullOrEmpty(stringValue))
+				propertyBag[propertyName] = stringValue;
 		}
 		public void SendProperty(IGxContext context, String componentPrefix, bool isMasterPage, String internalName, String propertyName, String propertyValue) 
 		{

--- a/dotnet/test/DotNetUnitTest/TestModule.MyControl.view
+++ b/dotnet/test/DotNetUnitTest/TestModule.MyControl.view
@@ -1,1 +1,2 @@
 <b> {{Message}} </b>{{#Items}} - {{gxTpr_Name}}{{Name}} - {{/Items}} prueba
+Boolean:{{Boolean}}

--- a/dotnet/test/DotNetUnitTest/UserControlRender.cs
+++ b/dotnet/test/DotNetUnitTest/UserControlRender.cs
@@ -57,11 +57,15 @@ namespace UnitTesting
 
 			string output = sb.ToString();
 
-			Assert.Contains(ONE, output, System.StringComparison.InvariantCulture);
-			Assert.Contains(TWO, output, System.StringComparison.InvariantCulture);
-			Assert.Contains(HELLO, output, System.StringComparison.InvariantCulture);
-			Assert.Contains("Boolean:true", output, System.StringComparison.InvariantCulture);
+			AssertContains(ONE, output);
+			AssertContains(TWO, output);
+			AssertContains(HELLO, output);
+			AssertContains("Boolean:true", output);
 		}
 
+		private static void AssertContains(string expectedSubstring, string actualString)
+		{
+			Assert.Contains(expectedSubstring, actualString, System.StringComparison.InvariantCulture);
+		}
 	}
 }

--- a/dotnet/test/DotNetUnitTest/UserControlRender.cs
+++ b/dotnet/test/DotNetUnitTest/UserControlRender.cs
@@ -52,9 +52,15 @@ namespace UnitTesting
 			ucMycontrol1.SetProperty("Items", AV6ItemCollection);
 
 			ucMycontrol1.SetProperty("Message", HELLO);
+			ucMycontrol1.SetProperty("Boolean", true);
 			ucMycontrol1.Render(context, "testmodule.mycontrol", "internalName", "MYCONTROL1Container");
 
-			Assert.True(sb.ToString().Contains(ONE) && sb.ToString().Contains(TWO) && sb.ToString().Contains(HELLO));
+			string output = sb.ToString();
+
+			Assert.Contains(ONE, output, System.StringComparison.InvariantCulture);
+			Assert.Contains(TWO, output, System.StringComparison.InvariantCulture);
+			Assert.Contains(HELLO, output, System.StringComparison.InvariantCulture);
+			Assert.Contains("Boolean:true", output, System.StringComparison.InvariantCulture);
 		}
 
 	}


### PR DESCRIPTION
DotNet serializes booleans as "True" and "False". When writing a screen template for a User Control Object, GeneXus users expect boolean values to be serialized as "true" and "false", so we must serialize boolean properties following this criterion, instead of the default one proposed by DotNet.

#### Changes proposed in this Pull Request

- Serialize boolean properties as "true" and "false", instead of "True" and "False"

Issue:85647
