### PR TITLE
Fix duplicate cache invalidation token

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -823,7 +823,7 @@ namespace GeneXus.Application
 
 		public string GetURLBuildNumber(string resourcePath, string urlBuildNumber)
 		{
-			if (string.IsNullOrEmpty(urlBuildNumber) && !PathUtil.IsAbsoluteUrl(resourcePath))
+			if (string.IsNullOrEmpty(urlBuildNumber) && !PathUtil.IsAbsoluteUrl(resourcePath) && !PathUtil.HasUrlQueryString(resourcePath))
 			{
 				return "?" + GetCacheInvalidationToken();
 			}

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -3520,6 +3520,11 @@ namespace GeneXus.Utils
 			return Uri.TryCreate(url, UriKind.Absolute, out result) && (result.Scheme == GXUri.UriSchemeHttp || result.Scheme == GXUri.UriSchemeHttps || result.Scheme == GXUri.UriSchemeFtp);
 		}
 
+		public static bool HasUrlQueryString(string url)
+		{
+			return url.Contains("?");
+		}
+
 		public static Uri GetBaseUri()
 		{
 			return new Uri(GxContext.StaticPhysicalPath() + Path.DirectorySeparatorChar.ToString());


### PR DESCRIPTION
The cache invalidation token was being added twice to deferred JavaScript files after the changes implemented in #260.

Related PR in Java: https://github.com/genexuslabs/JavaClasses/pull/308

#### Changes proposed in this Pull Request

- Verify that the resource URI doesn't already have a query string, before adding the cache invalidation token.

Issue:84288