### PR TITLE
- Return List parameters as wrapped in API Object as is done in JAVA

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
@@ -22,6 +22,7 @@ namespace GeneXus.Procedure
 	{
 		static readonly ILog log = log4net.LogManager.GetLogger(typeof(GeneXus.Procedure.GXProcedure));
 		protected bool _isMain;
+		protected bool _isApi;
 		public abstract void initialize();
 		public abstract void cleanup();
 
@@ -147,6 +148,11 @@ namespace GeneXus.Procedure
 		{
 			set	{ _isMain = value; }
 			get	{ return _isMain;  }
+		}
+		public bool IsApiObject
+		{
+			set { _isApi = value; }
+			get { return _isApi; }
 		}
 		public void setContextReportHandler()
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -50,6 +50,7 @@ namespace GeneXus.Application
 		private GXProcedure _procWorker;
 		private const string EXECUTE_METHOD = "execute";
 		public String ServiceMethod = "";
+		public bool WrappedParameter = false;
 
 
 		public GxRestWrapper(GXProcedure worker, HttpContext context, IGxContext gxContext, String serviceMethod) : this(worker, context, gxContext)
@@ -256,7 +257,15 @@ namespace GeneXus.Application
 				setWorkerStatus(_procWorker);
 				_procWorker.cleanup();
 				MakeRestTypes(outputParameters);
-				return Serialize(outputParameters, false);
+				bool wrapped = false;
+				if (_procWorker.IsApiObject)
+				{
+					if (outputParameters.Count == 1 && outputParameters.First().Value.GetType().GetInterfaces().Contains(typeof(ICollection)))
+					{
+						wrapped = true;
+					}
+				}
+				return Serialize(outputParameters, wrapped);
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
- When the return parameter is a List and is the only out parameter . The returned List is  wrapped in API Object as is done in JAVA  (Issue 86682)