### PR TITLE
Fix DBNull value cannot be casted to string.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTier.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTier.cs
@@ -177,13 +177,12 @@ namespace GeneXus.Data.NTier
 						if (valueIsNull)
 						{
 							stmt.setNull(idxParmCollection, DBNull.Value);
-							parmsValues[idxParmCollection - 1] = DBNull.Value;
 						}
 						idx += 1;
 					}
+					parmsValues[idxParmCollection - 1] = parms[idx];
 					if (!valueIsNull)
 					{
-						parmsValues[idxParmCollection - 1] = parms[idx];
 						switch (pdef.GxType)
 						{
 							case GXType.Char:


### PR DESCRIPTION
Issue:88268
Set the right parmValue when isnullable is true.
