### PR TITLE
- Fix Latitude and Longiitude 

### DIFF
--- a/dotnet/src/dotnetcore/GxClasses/Helpers/GXGeographyCore.cs
+++ b/dotnet/src/dotnetcore/GxClasses/Helpers/GXGeographyCore.cs
@@ -412,7 +412,7 @@ namespace GeneXus.Utils
 		{
 			get
 			{
-				return this.PointList[0].Longitude;
+				return NTSGeographyWrapper.Long(this._innerValue);
 			}
 		}
 
@@ -420,7 +420,7 @@ namespace GeneXus.Utils
 		{
 			get
 			{
-				return this.PointList[0].Latitude;
+				return NTSGeographyWrapper.Lat(this._innerValue);				
 			}
 		}
 


### PR DESCRIPTION
Fixed Latitude and Longitude properties when Geopoint is created from Geopoint.New(Lat,Long)