### PR TITLE
Make each context delete Temporary files created by itself 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -672,8 +672,9 @@ namespace GeneXus.Application
 			return string.Empty;
 		}
 
-		public static bool GetHttpRequestPostedFile(HttpContext httpContext, string varName, out string fileToken)
+		public static bool GetHttpRequestPostedFile(IGxContext gxContext, string varName, out string fileToken)
 		{
+			var httpContext = gxContext.HttpContext;
 			fileToken = null;
 			if (httpContext != null)
 			{
@@ -694,7 +695,7 @@ namespace GeneXus.Application
 					string fileGuid = GxUploadHelper.GetUploadFileGuid();
 					fileToken = GxUploadHelper.GetUploadFileId(fileGuid);
 
-					GxUploadHelper.CacheUploadFile(fileGuid, filePath, pf.FileName, ext, file, httpContext);
+					GxUploadHelper.CacheUploadFile(fileGuid, filePath, pf.FileName, ext, file, gxContext);
 
 				return true;
 				}
@@ -3213,7 +3214,7 @@ namespace GeneXus.Application
 		~GxContext()
 		{
 			GxUserInfo.RemoveHandle(_handle);
-			GXFileWatcher.Instance.DeleteTemporaryFiles();
+			GXFileWatcher.Instance.DeleteTemporaryFiles(_handle);
 		}
 		public void SetProperty(string key, string value)
 		{
@@ -3751,7 +3752,7 @@ namespace GeneXus.Application
 			string filePath = Path.Combine(Preferences.getTMP_MEDIA_PATH(), "Blob" + tmpFileName);
 			GxFile auxFile = new GxFile(GetPhysicalPath(), filePath, GxFileType.Private);
 			auxFile.FromBase64(b64);
-			GXFileWatcher.Instance.AddTemporaryFile(new GxFile("", new GxFileInfo(filePath, "")), HttpContext);
+			GXFileWatcher.Instance.AddTemporaryFile(new GxFile("", new GxFileInfo(filePath, "")), this);
 			return filePath;
 		}
 
@@ -3768,7 +3769,7 @@ namespace GeneXus.Application
 			string filePath = Path.Combine(Preferences.getTMP_MEDIA_PATH(), "Blob" + tmpFileName);
 			GxFile auxFile = new GxFile(GetPhysicalPath(), filePath, GxFileType.Private);
 			auxFile.FromByteArray(bArray);
-			GXFileWatcher.Instance.AddTemporaryFile(new GxFile("", new GxFileInfo(filePath, "")), HttpContext);
+			GXFileWatcher.Instance.AddTemporaryFile(new GxFile("", new GxFileInfo(filePath, "")), this);
 			return filePath;
 		}
 

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTierADO.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTierADO.cs
@@ -127,7 +127,7 @@ namespace GeneXus.Data.NTier.ADO
 					}
 				}
 				if (temporary)
-                    GXFileWatcher.Instance.AddTemporaryFile(new GxFile(_gxDbCommand.Conn.BlobPath, new GxFileInfo(fileName, _gxDbCommand.Conn.BlobPath), GxFileType.PrivateAttribute), _gxDbCommand.Conn.DataStore.Context.HttpContext);
+                    GXFileWatcher.Instance.AddTemporaryFile(new GxFile(_gxDbCommand.Conn.BlobPath, new GxFileInfo(fileName, _gxDbCommand.Conn.BlobPath), GxFileType.PrivateAttribute), _gxDbCommand.Conn.DataStore.Context);
                 fileName = new FileInfo(fileName).FullName;
             }
             catch (IOException e)
@@ -386,7 +386,7 @@ namespace GeneXus.Data.NTier.ADO
 				TraceRow("GetBlobFile fileName:" + fileName + ", retval bytes:" + retval);
 
                 if (temporary)
-                    GXFileWatcher.Instance.AddTemporaryFile(file, _gxDbCommand.Conn.DataStore.Context.HttpContext);
+                    GXFileWatcher.Instance.AddTemporaryFile(file, _gxDbCommand.Conn.DataStore.Context);
 
 				fileName = file.GetURI();
             }

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
@@ -1577,7 +1577,7 @@ namespace GeneXus.Utils
 									MethodInfo setBlob = GetMethodInfo("gxtv_" + GetType().Name + "_" + name + "_setblob");
 									if (setBlob != null)
 									{
-										if (HttpHelper.GetHttpRequestPostedFile(context.HttpContext, sVar, out uploadPath))
+										if (HttpHelper.GetHttpRequestPostedFile(context, sVar, out uploadPath))
 										{
 											string fileName = HttpHelper.GetHttpRequestPostedFileName(this.context.HttpContext, sVar);
 											string fileType = HttpHelper.GetHttpRequestPostedFileType(this.context.HttpContext, sVar);

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/GXRestUtils.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/GXRestUtils.cs
@@ -29,10 +29,10 @@ namespace GeneXus.Utils
 		{
 			return httpContext.Request.GetRawUrl().EndsWith(HttpHelper.GXOBJECT, StringComparison.OrdinalIgnoreCase);
 		}
-		internal static void CacheUploadFile(string fileGuid, string savedFileName, string localfileName, string ext, GxFile file, HttpContext localHttpContext)
+		internal static void CacheUploadFile(string fileGuid, string savedFileName, string localfileName, string ext, GxFile file, IGxContext gxContext)
 		{
 			CacheAPI.FilesCache.Set(fileGuid, JSONHelper.Serialize(new UploadCachedFile() { path = savedFileName, fileExtension = ext, fileName = localfileName }), GxRestPrefix.UPLOAD_TIMEOUT);
-			GXFileWatcher.Instance.AddTemporaryFile(file, localHttpContext);
+			GXFileWatcher.Instance.AddTemporaryFile(file, gxContext);
 		}
 		internal static string GetUploadFileGuid()
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
@@ -215,9 +215,10 @@ namespace GeneXus.Http
 			return string.Empty;
 		}
 
-		public static bool GetHttpRequestPostedFile(HttpContext httpContext, string varName, out string filePath)
+		public static bool GetHttpRequestPostedFile(IGxContext gxContext, string varName, out string filePath)
 		{
 			filePath = null;
+			var httpContext = gxContext.HttpContext;
 			if (httpContext != null)
 			{
 				var pf = GetFormFile(httpContext, varName);
@@ -238,7 +239,7 @@ namespace GeneXus.Http
 #else
 					filePath = file.Create(pf.InputStream);
 #endif
-					GXFileWatcher.Instance.AddTemporaryFile(file, httpContext);
+					GXFileWatcher.Instance.AddTemporaryFile(file, gxContext);
 					return true;
 				}
 			}

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -2288,7 +2288,7 @@ namespace GeneXus.Http
 			string sValue = null;
 			try
 			{
-				if (GxContext.GetHttpRequestPostedFile(localHttpContext, sVar, out sValue))
+				if (GxContext.GetHttpRequestPostedFile(context, sVar, out sValue))
 					return sValue;
 
 				if (FormVars != null)

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
@@ -424,7 +424,7 @@ namespace GeneXus.Http
 							thumbnailUrl = url,
 							path = fileToken
 						});
-						GxUploadHelper.CacheUploadFile(fileGuid, savedFileName, fName, ext, gxFile, localHttpContext);
+						GxUploadHelper.CacheUploadFile(fileGuid, savedFileName, fName, ext, gxFile, context);
 					}
 					UploadFilesResult result = new UploadFilesResult() { files = r };
 					var jsonObj = JSONHelper.Serialize(result);
@@ -476,7 +476,7 @@ namespace GeneXus.Http
 			HttpHelper.SetResponseStatus(localHttpContext, ((int)HttpStatusCode.Created).ToString(), string.Empty);
 			localHttpContext.Response.Write(obj.ToString());
 
-			GxUploadHelper.CacheUploadFile(fileGuid, savedFileName, fName, ext, file, localHttpContext);
+			GxUploadHelper.CacheUploadFile(fileGuid, savedFileName, fName, ext, file, context);
 		}
 		protected override bool IntegratedSecurityEnabled
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
@@ -241,7 +241,7 @@ namespace GeneXus.Procedure
 			getPrinter().GxSetDocName(fileName);
             getPrinter().GxSetDocFormat(fileExtension);
 			context.PrintReportAtClient(fileName, printerRule);
-			GXFileWatcher.Instance.AddTemporaryFile(new GxFile(Preferences.getBLOB_PATH(), new GxFileInfo(fileName, Preferences.getBLOB_PATH())), context.HttpContext);
+			GXFileWatcher.Instance.AddTemporaryFile(new GxFile(Preferences.getBLOB_PATH(), new GxFileInfo(fileName, Preferences.getBLOB_PATH())), context);
 		}
 
 		protected bool initPrinter(String outputTo, int gxXPage, int gxYPage, string iniFile, string form, string printer, int mode, int orientation, int pageSize, int pageLength, int pageWidth, int scale, int copies, int defSrc, int quality, int color, int duplex)


### PR DESCRIPTION
Issue:88617
Make each context delete Temporary files created by itself and not the ones belonging to another context.

That is the case when a proc command line creates temporary files, at the same time that a new proc runs in a new utl which also creates temporary blobs => in that case the context destructor of new utl proc might destroy temporary files of the first procedure.