### PR TITLE
Add compatibility on reading bytea stored in escape mode, used by npgsql 1.0.0.0

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
@@ -9,6 +9,8 @@ using System.Collections;
 using GeneXus.Metadata;
 using System.Reflection;
 using System.IO;
+using System.Collections.Generic;
+using GeneXus.Configuration;
 #if NETCORE
 using GxClasses.Helpers;
 #endif
@@ -21,6 +23,7 @@ namespace GeneXus.Data
 		const string ConnectionStringEncoding = "encoding";
 		private byte[] _buffer;
 		static Assembly _npgsqlAssembly;
+		private bool _byteaOutputEscape;
 		const string NpgsqlDbTypeEnum = "NpgsqlTypes.NpgsqlDbType";
 
 		public static Assembly NpgsqlAssembly
@@ -61,6 +64,12 @@ namespace GeneXus.Data
 				}
 			}
 #endif
+			string cfgBuf;
+			if (Config.GetValueOf("postgresql_bytea_output", out cfgBuf))
+			{
+				if (cfgBuf.Equals("escape", StringComparison.OrdinalIgnoreCase))
+					_byteaOutputEscape = true;
+			}
 		}
 		public override GxAbstractConnectionWrapper GetConnection(bool showPrompt, string datasourceName, string userId,
 			string userPassword, string databaseName, string port, string schema, string extra, GxConnectionCache connectionCache)
@@ -251,7 +260,7 @@ namespace GeneXus.Data
 			{
 				if (fieldOffset == 0)
 				{
-					_buffer = (byte[])DR.GetValue(i);
+					_buffer = ByteaTextToByteArray((byte[])DR.GetValue(i));
 				}
 				int count = 0;
 				for (long index = fieldOffset; index < fieldOffset + length && index < _buffer.Length; index++)
@@ -260,6 +269,99 @@ namespace GeneXus.Data
 					count++;
 				}
 				return count;
+			}
+		}
+		//ByteArrayToByteaTextEscaped
+		protected override void SetBinary(IDbDataParameter parameter, byte[] byteArray)
+		{
+			if (_byteaOutputEscape)
+			{
+				List<byte> binary = new List<byte>(byteArray.Length * 5);
+				foreach (byte b in byteArray)
+					if (b >= 0x20 && b < 0x7F && b != 0x27 && b != 0x5C)
+						binary.Add(b);
+					else
+					{
+						binary.Add(ASCIIByteBackSlash);
+						binary.Add((byte)(ASCIIByteb0 + (7 & (b >> 6))));
+						binary.Add((byte)(ASCIIByteb0 + (7 & (b >> 3))));
+						binary.Add((byte)(ASCIIByteb0 + (7 & b)));
+					}
+				base.SetBinary(parameter, binary.ToArray());
+			}
+			else
+			{
+				base.SetBinary(parameter, byteArray);
+			}
+		}
+		byte ASCIIByteBackSlash = (byte)'\\';
+		byte ASCIIBytex = (byte)'x';
+		byte ASCIIByteb0 = (byte)'0';
+		byte ASCIIByteb7 = (byte)'7';
+
+		private byte[] ByteaTextToByteArray(byte[] BackendData)
+		{
+			try
+			{
+				int byteAPosition = 0;
+				int byteALength = BackendData.Length;
+				if (byteALength >= 2 && BackendData[0] == ASCIIByteBackSlash && BackendData[1] == ASCIIBytex)
+				{
+					// PostgreSQL 8.5+'s bytea_output=hex format
+					byte[] result = new byte[(byteALength - 2) / 2];
+					int k = 0;
+					for (byteAPosition = 2; byteAPosition < byteALength; byteAPosition += 2)
+					{
+						result[k] = FastConverter.ToByteHexFormat(BackendData, byteAPosition);
+						k++;
+					}
+					return result;
+				}
+				else
+				{
+					MemoryStream ms = new MemoryStream();
+					while (byteAPosition < byteALength)
+					{
+						byte octalValue;
+						if (BackendData[byteAPosition] == ASCIIByteBackSlash)
+						{
+							if (byteAPosition + 1 == byteALength)
+							{
+								octalValue = ASCIIByteBackSlash;
+								byteAPosition++;
+							}
+							else if (byteAPosition + 3 < byteALength &&
+								BackendData[byteAPosition + 1] >= ASCIIByteb0 && BackendData[byteAPosition + 1] <= ASCIIByteb7 &&
+								BackendData[byteAPosition + 2] >= ASCIIByteb0 && BackendData[byteAPosition + 2] <= ASCIIByteb7 &&
+								BackendData[byteAPosition + 3] >= ASCIIByteb0 && BackendData[byteAPosition + 3] <= ASCIIByteb7)
+							{
+								octalValue = FastConverter.ToByteEscapeFormat(BackendData, byteAPosition + 1);
+								byteAPosition += 4;
+							}
+							else if (BackendData[byteAPosition + 1] == ASCIIByteBackSlash)
+							{
+								octalValue = ASCIIByteBackSlash;
+								byteAPosition += 2;
+							}
+							else
+							{
+								octalValue = ASCIIByteBackSlash;
+								byteAPosition++;
+							}
+						}
+						else
+						{
+							octalValue = BackendData[byteAPosition];
+							byteAPosition++;
+						}
+						ms.WriteByte((Byte)octalValue);
+					}
+					return ms.ToArray();
+				}
+			}catch(Exception ex)
+			{
+				GXLogging.Error(log, "ByteaTextToByteArray error", ex);
+				return BackendData;
 			}
 		}
 		public override void DisposeCommand(IDbCommand command)
@@ -523,5 +625,65 @@ namespace GeneXus.Data
 			reader = memoryDataReader;
 		}
 	}
+	internal class FastConverter
+	{
+		private static readonly byte[] HexFormatLookupTableLow = new byte[] {
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+		};
+		private static readonly byte[] HexFormatLookupTableHigh = new byte[] {
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0x00, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+		};
+		private static readonly byte[] EscapeFormatLookupTable = new byte[] {
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+		};
+		public static byte ToByteHexFormat(byte[] str, int index)
+		{
+			byte b1 = HexFormatLookupTableHigh[str[index]];
+			if (b1 == 255)
+				throw new IOException(string.Format("Expected a hex character, got {0}", str[index]));
 
+			byte b2 = HexFormatLookupTableLow[str[++index]];
+			if (b2 == 255)
+				throw new IOException(string.Format("Expected a hex character, got {0}", str[index]));
+
+			return (byte)(b1 | b2);
+		}
+		public static byte ToByteEscapeFormat(byte[] str, int index)
+		{
+			byte b1 = (byte)(EscapeFormatLookupTable[str[index]] << 6);
+			if (b1 == 255)
+				throw new IOException(string.Format("Expected an octal character, got {0}", str[index]));
+
+			byte b2 = (byte)(EscapeFormatLookupTable[str[++index]] << 3);
+			if (b2 == 255)
+				throw new IOException(string.Format("Expected an octal character, got {0}", str[index]));
+
+			byte b3 = EscapeFormatLookupTable[str[++index]];
+			if (b3 == 255)
+				throw new IOException(string.Format("Expected an octal character, got {0}", str[index]));
+
+			return (byte)(b1 | b2 | b3);
+		}
+	}
 }

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
@@ -323,38 +323,27 @@ namespace GeneXus.Data
 					while (byteAPosition < byteALength)
 					{
 						byte octalValue;
-						if (BackendData[byteAPosition] == ASCIIByteBackSlash)
-						{
-							if (byteAPosition + 1 == byteALength)
-							{
-								octalValue = ASCIIByteBackSlash;
-								byteAPosition++;
-							}
-							else if (byteAPosition + 3 < byteALength &&
-								BackendData[byteAPosition + 1] >= ASCIIByteb0 && BackendData[byteAPosition + 1] <= ASCIIByteb7 &&
-								BackendData[byteAPosition + 2] >= ASCIIByteb0 && BackendData[byteAPosition + 2] <= ASCIIByteb7 &&
-								BackendData[byteAPosition + 3] >= ASCIIByteb0 && BackendData[byteAPosition + 3] <= ASCIIByteb7)
-							{
-								octalValue = FastConverter.ToByteEscapeFormat(BackendData, byteAPosition + 1);
-								byteAPosition += 4;
-							}
-							else if (BackendData[byteAPosition + 1] == ASCIIByteBackSlash)
-							{
-								octalValue = ASCIIByteBackSlash;
-								byteAPosition += 2;
-							}
-							else
-							{
-								octalValue = ASCIIByteBackSlash;
-								byteAPosition++;
-							}
-						}
-						else
+						byte b = BackendData[byteAPosition];
+						if (b >= 0x20 && b < 0x7F && b != 0x27 && b != 0x5C)
 						{
 							octalValue = BackendData[byteAPosition];
 							byteAPosition++;
+							ms.WriteByte((Byte)octalValue);
 						}
-						ms.WriteByte((Byte)octalValue);
+						else if (BackendData[byteAPosition] == ASCIIByteBackSlash &&
+								byteAPosition + 3 < byteALength &&
+								BackendData[byteAPosition + 1] >= ASCIIByteb0 && BackendData[byteAPosition + 1] <= ASCIIByteb7 &&
+								BackendData[byteAPosition + 2] >= ASCIIByteb0 && BackendData[byteAPosition + 2] <= ASCIIByteb7 &&
+								BackendData[byteAPosition + 3] >= ASCIIByteb0 && BackendData[byteAPosition + 3] <= ASCIIByteb7)
+						{
+							octalValue = FastConverter.ToByteEscapeFormat(BackendData, byteAPosition + 1);
+							byteAPosition += 4;
+							ms.WriteByte((Byte)octalValue);
+						}
+						else
+						{
+							return BackendData;
+						}
 					}
 					return ms.ToArray();
 				}


### PR DESCRIPTION
Issue:88810