### PR TITLE
- Fix Latitude and Longitude properties in NET 4.X ( same as Net Core)

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Helpers/GXUtilsGeospatial.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/GXUtilsGeospatial.cs
@@ -324,7 +324,6 @@ namespace GeneXus.Utils
 			{
 				return this.PointList[0];
 			}
-
 		}
 
 
@@ -332,7 +331,10 @@ namespace GeneXus.Utils
 		{
 			get
 			{
-				return this.PointList[0].Longitude;
+				if (_innerValue == null)
+					return 0;
+				else
+					return SQLGeographyWrapper.Long(_innerValue);
 			}
 
 		}
@@ -341,7 +343,10 @@ namespace GeneXus.Utils
 		{
 			get
 			{
-				return this.PointList[0].Latitude;
+				if (_innerValue == null)
+					return 0;
+				else
+					return SQLGeographyWrapper.Lat(_innerValue);
 			}
 
 		}


### PR DESCRIPTION
- Latitude and Longitude properties failed with some Geographic constructors, previously fixed for net Core , now Fixed also for NET 4.x

Issue:89113