### PR TITLE
Update ProcessCommit.yml

### DIFF
--- a/.github/workflows/ProcessCommit.yml
+++ b/.github/workflows/ProcessCommit.yml
@@ -6,8 +6,6 @@ on:
       - 'master'
       - 'beta'
       - 'release-*'
-    paths:
-      - 'dotnet/**'
     ignore-paths:
       - '*.md'
 


### PR DESCRIPTION
When creating a new release branch, the _ProcessCommit_ workflow was not being started. This was because the workflow was only triggered when changes to source files were detected.