### PR TITLE
Name and extension lost when a Blob was uploaded via FileUpload

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -3406,6 +3406,12 @@ namespace GeneXus.Utils
 		{
 			if (FileName.Trim().Length == 0)
 				return string.Empty;
+
+			if (GxUploadHelper.IsUpload(FileName))
+			{
+				return new GxFile(string.Empty, FileName, GxFileType.Private).GetExtension();
+			}
+
 			string extension = string.Empty;
 			try
 			{
@@ -3445,6 +3451,11 @@ namespace GeneXus.Utils
 		{
 			if (FileName.Trim().Length == 0)
 				return "";
+
+			if (GxUploadHelper.IsUpload(FileName))
+			{
+				FileName = new GxFile(string.Empty, FileName, GxFileType.Private).GetName();
+			}
 			try
 			{
 				return Path.GetFileNameWithoutExtension(FileName);//FileNames with URI or local (exist)


### PR DESCRIPTION
When a Blob was uploaded using FileUpload using the following * code, the FileName and Extension was not kept.
Issue 89598

```
Sub 'Process files'
	
	&idx = 1
	for &FileUploadData in &UploadedFiles
		 // Use &FileUploadData.File to get the file in a Blob.
		 // Use &FileUploadData.FullName to get the complete file name (name and extension).
		 // Use &FileUploadData.Name to get the file name (without extension).
		 // Use &FileUploadData.Extension to get the file extension.
		 // Use &FileUploadData.Size to get the file size in bytes.
		 
		 &TestBinary = new()
		 &TestBinary.TestBinaryId = &idx
		 &TestBinary.TestBinaryName = Format(!"%1.%2", &FileUploadData.Name, &FileUploadData.Extension)
		 &TestBinary.TestBinaryImage = &FileUploadData.File
		 &TestBinary.TestBinaryBlobFile = &FileUploadData.File
		 &TestBinary.TestBinaryBlob = &FileUploadData.File
		 &TestBinary.TestBinaryBlobUnknown = &FileUploadData.File
		 &TestBinary.Insert()
		 &idx+=1		 		 
	endfor
	commit
	
EndSub
```

Full GX Test Number: 1298