### PR TITLE
Rest parameters must be read with invariant format.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Services/ReflectionHelper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/ReflectionHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using GeneXus.Utils;
@@ -89,7 +90,7 @@ namespace GeneXus.Application
 			}
 			else if (typeof(IConvertible).IsAssignableFrom(newType))
 			{
-				return Convert.ChangeType(value, newType);
+				return Convert.ChangeType(value, newType, CultureInfo.InvariantCulture);
 			}
 			else if (newType == typeof(Guid) && Guid.TryParse(value.ToString(), out Guid guidResult))
 			{


### PR DESCRIPTION
Otherwise, decimal numbers may be wrong when reading on a configuration with the Spanish region.
Issue:89816