### PR TITLE
Fix to improve performance in azure functions execution

### DIFF
--- a/.github/workflows/External-Storage-Tests.yml
+++ b/.github/workflows/External-Storage-Tests.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         dotnet-version: '3.1.x'
 
-   - name: Install .NET Core 5.0
+    - name: Install .NET Core 5.0
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.x'

--- a/.github/workflows/External-Storage-Tests.yml
+++ b/.github/workflows/External-Storage-Tests.yml
@@ -33,10 +33,16 @@ jobs:
       with:
         dotnet-version: '3.1.x'
 
-    - name: Install .NET 6
-      uses: actions/setup-dotnet@v1.7.2
+   - name: Install .NET Core 5.0
+      uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.100-preview.3.21202.5'
+        dotnet-version: '5.0.x'
+
+    - name: Install .NET 6
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: True
         
     - uses: actions/setup-dotnet@v1
       with:

--- a/dotnet/DotNetStandardClasses.sln
+++ b/dotnet/DotNetStandardClasses.sln
@@ -133,6 +133,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{41E1D031-799
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeneXus.Deploy.AzureFunctions.Handlers", "src\extensions\Azure\Handlers\GeneXus.Deploy.AzureFunctions.Handlers.csproj", "{621ABC85-7479-4D0F-AB48-97A53E82C8B3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureFunctionsTest", "src\extensions\Azure\test\AzureFunctionsTest\AzureFunctionsTest.csproj", "{CF870FA0-AAEB-436D-A531-DD6D67838D31}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{7BA5A2CE-7992-4F87-9D84-91AE4D046F5A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "amyprochandler", "src\extensions\Azure\test\amyprocedurehandler\amyprochandler.csproj", "{B4B9E45E-052F-417D-87BF-0FB2E3C05CE1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -339,6 +345,14 @@ Global
 		{621ABC85-7479-4D0F-AB48-97A53E82C8B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{621ABC85-7479-4D0F-AB48-97A53E82C8B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{621ABC85-7479-4D0F-AB48-97A53E82C8B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF870FA0-AAEB-436D-A531-DD6D67838D31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF870FA0-AAEB-436D-A531-DD6D67838D31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF870FA0-AAEB-436D-A531-DD6D67838D31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF870FA0-AAEB-436D-A531-DD6D67838D31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4B9E45E-052F-417D-87BF-0FB2E3C05CE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4B9E45E-052F-417D-87BF-0FB2E3C05CE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4B9E45E-052F-417D-87BF-0FB2E3C05CE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4B9E45E-052F-417D-87BF-0FB2E3C05CE1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -404,6 +418,9 @@ Global
 		{BD804A75-9F3F-416C-BF6B-D3DF6C4A8DC0} = {C6AFB6A3-FF0B-4970-B1F1-10BCD3D932B2}
 		{41E1D031-799F-484F-85DE-7A30AF1A6FBA} = {BD804A75-9F3F-416C-BF6B-D3DF6C4A8DC0}
 		{621ABC85-7479-4D0F-AB48-97A53E82C8B3} = {41E1D031-799F-484F-85DE-7A30AF1A6FBA}
+		{CF870FA0-AAEB-436D-A531-DD6D67838D31} = {7BA5A2CE-7992-4F87-9D84-91AE4D046F5A}
+		{7BA5A2CE-7992-4F87-9D84-91AE4D046F5A} = {BD804A75-9F3F-416C-BF6B-D3DF6C4A8DC0}
+		{B4B9E45E-052F-417D-87BF-0FB2E3C05CE1} = {7BA5A2CE-7992-4F87-9D84-91AE4D046F5A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E18684C9-7D76-45CD-BF24-E3944B7F174C}

--- a/dotnet/src/extensions/Azure/Handlers/Helpers/GxAzMappings.cs
+++ b/dotnet/src/extensions/Azure/Handlers/Helpers/GxAzMappings.cs
@@ -1,5 +1,35 @@
+using System.Collections.Generic;
+using System.IO;
+using GeneXus.Utils;
+
 namespace GeneXus.Deploy.AzureFunctions.Handlers.Helpers
 {
+	public class CallMappings : ICallMappings
+	{
+		public List<GxAzMappings> mappings;
+
+		public CallMappings(string roothPath)
+		{
+			mappings = GetMappings(roothPath);
+		}
+		public List<GxAzMappings> GetMappings(string rootPath)
+		{	
+			string mappingsfile = Path.Combine(rootPath, FunctionReferences.MappingsFile);
+
+			if (File.Exists(mappingsfile))
+			{
+				string mapping = File.ReadAllText(mappingsfile);
+				List<GxAzMappings> gxMappingsList = JSONHelper.Deserialize<List<GxAzMappings>>(mapping);
+				return gxMappingsList;
+			}
+			else return null;
+		}
+	}
+	public interface ICallMappings
+	{
+		public List<GxAzMappings> GetMappings(string rootPath);
+	}
+
 	public class GxAzMappings
 	{
 		public string FunctionName

--- a/dotnet/src/extensions/Azure/Handlers/Program.cs
+++ b/dotnet/src/extensions/Azure/Handlers/Program.cs
@@ -2,18 +2,28 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Azure.Functions.Worker.Configuration;
+using System.Reflection;
+using System.IO;
+using Microsoft.Extensions.DependencyInjection;
+using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
 
-namespace AllFunctions
+namespace GeneXus.Deploy.AzureFunctions.Handlers
 {
     public class Program
     {
-        public static void Main()
+		static async Task Main()
         {
-            var host = new HostBuilder()
-                .ConfigureFunctionsWorkerDefaults()
-                .Build();
+			string roothPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-            host.Run();
+			var host = new HostBuilder()
+                .ConfigureFunctionsWorkerDefaults()
+				.ConfigureServices(services =>
+				{
+					services.AddSingleton<ICallMappings, CallMappings>(x => new CallMappings(roothPath));
+				})
+				.Build();
+
+            await host.RunAsync();
         }
     }
 }

--- a/dotnet/src/extensions/Azure/Handlers/QueueHandler/QueueTriggerHandler.cs
+++ b/dotnet/src/extensions/Azure/Handlers/QueueHandler/QueueTriggerHandler.cs
@@ -38,7 +38,7 @@ namespace GeneXus.Deploy.AzureFunctions.QueueHandler
 			catch (Exception ex) //Catch System exception and retry
 			{
 				log.LogError(ex.ToString());
-				throw ex;
+				throw;
 			}		
 		}
 		private QueueMessage SetupMessage(FunctionContext context, string item)
@@ -193,10 +193,10 @@ namespace GeneXus.Deploy.AzureFunctions.QueueHandler
 									log.LogInformation("(GX function handler) Function finished execution.");
 								}
 							}
-							catch (Exception ex)
+							catch (Exception)
 							{
 								log.LogError("{0} Error invoking the GX procedure for Message Id {1}.", FunctionExceptionType.SysRuntimeError, queueMessage.Id);
-								throw ex; //Throw the exception so the runtime can Retry the operation.
+								throw; //Throw the exception so the runtime can Retry the operation.
 							}
 						}
 					}
@@ -206,10 +206,10 @@ namespace GeneXus.Deploy.AzureFunctions.QueueHandler
 						throw new Exception(exMessage);
 					}
 				}
-				catch (Exception ex)
+				catch (Exception)
 				{
 					log.LogError("{0} Error processing Message Id {1}.", FunctionExceptionType.SysRuntimeError, queueMessage.Id);
-					throw ex; //Throw the exception so the runtime can Retry the operation.
+					throw; //Throw the exception so the runtime can Retry the operation.
 				}
 			}
 			else

--- a/dotnet/src/extensions/Azure/Handlers/QueueHandler/QueueTriggerHandler.cs
+++ b/dotnet/src/extensions/Azure/Handlers/QueueHandler/QueueTriggerHandler.cs
@@ -1,22 +1,29 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
-using Microsoft.Extensions.Logging;
-using Microsoft.Azure.Functions.Worker;
-using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
 using GeneXus.Application;
-using GeneXus.Utils;
-using System.Collections;
+using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
 using GeneXus.Metadata;
-using System.Collections.Generic;
-using System.Globalization;
+using GeneXus.Utils;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
 
 namespace GeneXus.Deploy.AzureFunctions.QueueHandler
 {
-	public static class QueueTriggerHandler
+	public class QueueTriggerHandler
 	{
-		public static void Run(string myQueueItem, FunctionContext context)
+		private ICallMappings _callmappings;
+
+		public QueueTriggerHandler(ICallMappings callMappings)
+		{
+			_callmappings = callMappings;
+		}
+
+		public void Run(string myQueueItem, FunctionContext context)
 		{
 			var log = context.GetLogger("QueueTriggerHandler");
 			string functionName = context.FunctionDefinition.Name;
@@ -34,7 +41,7 @@ namespace GeneXus.Deploy.AzureFunctions.QueueHandler
 				throw ex;
 			}		
 		}
-		private static QueueMessage SetupMessage(FunctionContext context, string item)
+		private QueueMessage SetupMessage(FunctionContext context, string item)
 		{
 			QueueMessage message = new QueueMessage();
 			message.MessageProperties = new List<QueueMessage.MessageProperty>();
@@ -67,9 +74,12 @@ namespace GeneXus.Deploy.AzureFunctions.QueueHandler
 			}
 			return message;
 		}
-		private static void ProcessMessage(FunctionContext context, ILogger log, QueueMessage queueMessage)
+		private void ProcessMessage(FunctionContext context, ILogger log, QueueMessage queueMessage)
 		{
-			string gxProcedure = FunctionReferences.GetFunctionEntryPoint(context, log, queueMessage.Id);
+			CallMappings callmap = (CallMappings)_callmappings;
+			GxAzMappings map = callmap.mappings is object ? callmap.mappings.First(m => m.FunctionName == context.FunctionDefinition.Name) : null;
+			string gxProcedure = map is object ? map.GXEntrypoint : string.Empty;
+
 			string exMessage;
 			if (!string.IsNullOrEmpty(gxProcedure))
 			{
@@ -208,7 +218,7 @@ namespace GeneXus.Deploy.AzureFunctions.QueueHandler
 				throw new Exception(exMessage);
 			}
 		}
-		private static GxUserType CreateCustomPayloadItem(Type customPayloadItemType, string propertyId, object propertyValue, GxContext gxContext)
+		private GxUserType CreateCustomPayloadItem(Type customPayloadItemType, string propertyId, object propertyValue, GxContext gxContext)
 		{
 			GxUserType CustomPayloadItem = (GxUserType)Activator.CreateInstance(customPayloadItemType, new object[] { gxContext });
 			ClassLoader.SetPropValue(CustomPayloadItem, "gxTpr_Propertyid", propertyId);

--- a/dotnet/src/extensions/Azure/Handlers/ServiceBusHandler/ServiceBusTriggerHandler.cs
+++ b/dotnet/src/extensions/Azure/Handlers/ServiceBusHandler/ServiceBusTriggerHandler.cs
@@ -39,7 +39,7 @@ namespace GeneXus.Deploy.AzureFunctions.ServiceBusHandler
 			catch (Exception ex) //Catch System exception and retry
 			{
 				log.LogError(ex.ToString());
-				throw ex;
+				throw;
 			}
 		}
 		private GxUserType CreateCustomPayloadItem(Type customPayloadItemType, string propertyId, object propertyValue, GxContext gxContext)
@@ -241,11 +241,11 @@ namespace GeneXus.Deploy.AzureFunctions.ServiceBusHandler
 										log.LogInformation("(GX function handler) Function finished execution.");
 									}
 								}
-								catch (Exception ex)
+								catch (Exception)
 								{
 									exMessage = string.Format("{0} Error invoking the GX procedure for Message Id {1}.", FunctionExceptionType.SysRuntimeError, message.MessageId);
 									log.LogError(exMessage);
-									throw (ex); //Throw the exception so the runtime can Retry the operation.
+									throw; //Throw the exception so the runtime can Retry the operation.
 								}
 							}
 						}
@@ -256,10 +256,10 @@ namespace GeneXus.Deploy.AzureFunctions.ServiceBusHandler
 						throw new Exception(exMessage);
 					}
 				}
-				catch (Exception ex)
+				catch (Exception)
 				{
 					log.LogError("{0} Error processing Message Id {1}.", FunctionExceptionType.SysRuntimeError, message.MessageId);
-					throw (ex); //Throw the exception so the runtime can Retry the operation.
+					throw; //Throw the exception so the runtime can Retry the operation.
 				}
 			}
 			else

--- a/dotnet/src/extensions/Azure/Handlers/ServiceBusHandler/ServiceBusTriggerHandler.cs
+++ b/dotnet/src/extensions/Azure/Handlers/ServiceBusHandler/ServiceBusTriggerHandler.cs
@@ -10,14 +10,21 @@ using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
 using GeneXus.Utils;
 using GeneXus.Metadata;
 using System.Collections;
+using System.Linq;
 
 //https://github.com/Azure/azure-functions-dotnet-worker/issues/384
 
 namespace GeneXus.Deploy.AzureFunctions.ServiceBusHandler
 {
-	public static class ServiceBusTriggerHandler
+	public class ServiceBusTriggerHandler
 	{
-		public static void Run(string myQueueItem, FunctionContext context)
+		private ICallMappings _callmappings;
+
+		public ServiceBusTriggerHandler(ICallMappings callMappings)
+		{
+			_callmappings = callMappings;
+		}
+		public void Run(string myQueueItem, FunctionContext context)
 		{
 			var log = context.GetLogger("ServiceBusTriggerHandler");
 			string functionName = context.FunctionDefinition.Name;
@@ -35,7 +42,7 @@ namespace GeneXus.Deploy.AzureFunctions.ServiceBusHandler
 				throw ex;
 			}
 		}
-		private static GxUserType CreateCustomPayloadItem(Type customPayloadItemType, string propertyId, object propertyValue, GxContext gxContext)
+		private GxUserType CreateCustomPayloadItem(Type customPayloadItemType, string propertyId, object propertyValue, GxContext gxContext)
 		{
 			GxUserType CustomPayloadItem = (GxUserType)Activator.CreateInstance(customPayloadItemType, new object[] { gxContext });
 			ClassLoader.SetPropValue(CustomPayloadItem, "gxTpr_Propertyid", propertyId);
@@ -43,7 +50,7 @@ namespace GeneXus.Deploy.AzureFunctions.ServiceBusHandler
 			return CustomPayloadItem;
 
 		}
-		private static Message SetupMessage(FunctionContext context, string item)
+		private Message SetupMessage(FunctionContext context, string item)
 		{
 			Message message = new Message();
 			message.MessageProperties = new List<Message.MessageProperty>();
@@ -91,10 +98,14 @@ namespace GeneXus.Deploy.AzureFunctions.ServiceBusHandler
 			}
 			return message;
 		}
-		private static void ProcessMessage(FunctionContext context, ILogger log, Message message)
+		private void ProcessMessage(FunctionContext context, ILogger log, Message message)
 		{
-			string gxProcedure = FunctionReferences.GetFunctionEntryPoint(context, log, message.MessageId);
+			CallMappings callmap = (CallMappings)_callmappings;
+			GxAzMappings map = callmap.mappings is object ? callmap.mappings.First(m => m.FunctionName == context.FunctionDefinition.Name) : null;
+			string gxProcedure = map is object ? map.GXEntrypoint : string.Empty;
+
 			string exMessage;
+
 			if (!string.IsNullOrEmpty(gxProcedure))
 			{
 				try

--- a/dotnet/src/extensions/Azure/Handlers/TimerHandler/TimerTriggerHandler.cs
+++ b/dotnet/src/extensions/Azure/Handlers/TimerHandler/TimerTriggerHandler.cs
@@ -9,12 +9,19 @@ using GeneXus.Utils;
 using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
 using System.Collections;
 using GeneXus.Metadata;
+using System.Linq;
 
 namespace GeneXus.Deploy.AzureFunctions.TimerHandler
 {
-    public static class TimerTriggerHandler
+    public class TimerTriggerHandler
     {
-		public static void Run(MyInfo TimerInfo, FunctionContext context) 
+		private ICallMappings _callmappings;
+
+		public TimerTriggerHandler(ICallMappings callMappings)
+		{
+			_callmappings = callMappings;
+		}
+		public void Run(MyInfo TimerInfo, FunctionContext context) 
 		{
 			var logger = context.GetLogger("TimerTriggerHandler");
 			string functionName = context.FunctionDefinition.Name;
@@ -31,10 +38,14 @@ namespace GeneXus.Deploy.AzureFunctions.TimerHandler
 				throw ex;
 			}
 		}
-		private static void ProcessMessage(FunctionContext context, ILogger log, MyInfo TimerInfo, string messageId)
+		private void ProcessMessage(FunctionContext context, ILogger log, MyInfo TimerInfo, string messageId)
 		{
-			string gxProcedure = FunctionReferences.GetFunctionEntryPoint(context, log, messageId);
+			CallMappings callmap = (CallMappings)_callmappings;
+
+			GxAzMappings map = callmap.mappings is object ? callmap.mappings.First(m => m.FunctionName == context.FunctionDefinition.Name) : null;
+			string gxProcedure = map is object ? map.GXEntrypoint : string.Empty;
 			string exMessage;
+
 			if (!string.IsNullOrEmpty(gxProcedure))
 			{
 				try
@@ -164,7 +175,7 @@ namespace GeneXus.Deploy.AzureFunctions.TimerHandler
 				throw new Exception(exMessage);
 			}
 		}
-		private static GxUserType CreateCustomPayloadItem(Type customPayloadItemType, string propertyId, object propertyValue, GxContext gxContext)
+		private GxUserType CreateCustomPayloadItem(Type customPayloadItemType, string propertyId, object propertyValue, GxContext gxContext)
 		{
 			GxUserType CustomPayloadItem = (GxUserType)Activator.CreateInstance(customPayloadItemType, new object[] { gxContext });
 			ClassLoader.SetPropValue(CustomPayloadItem, "gxTpr_Propertyid", propertyId);

--- a/dotnet/src/extensions/Azure/Handlers/TimerHandler/TimerTriggerHandler.cs
+++ b/dotnet/src/extensions/Azure/Handlers/TimerHandler/TimerTriggerHandler.cs
@@ -35,7 +35,7 @@ namespace GeneXus.Deploy.AzureFunctions.TimerHandler
 			catch (Exception ex) //Catch System exception and retry
 			{
 				logger.LogError(ex.ToString());
-				throw ex;
+				throw;
 			}
 		}
 		private void ProcessMessage(FunctionContext context, ILogger log, MyInfo TimerInfo, string messageId)
@@ -150,10 +150,10 @@ namespace GeneXus.Deploy.AzureFunctions.TimerHandler
 									log.LogInformation("(GX function handler) Function finished execution.");
 								}
 							}
-							catch (Exception ex)
+							catch (Exception)
 							{
 								log.LogError("{0} Error invoking the GX procedure for Message Id {1}.", FunctionExceptionType.SysRuntimeError, messageId);
-								throw ex; //Throw the exception so the runtime can Retry the operation.
+								throw; //Throw the exception so the runtime can Retry the operation.
 							}
 						}
 					}
@@ -163,10 +163,10 @@ namespace GeneXus.Deploy.AzureFunctions.TimerHandler
 						throw new Exception(exMessage);
 					}
 				}
-				catch (Exception ex)
+				catch (Exception)
 				{
 					log.LogError("{0} Error processing Message Id {1}.", FunctionExceptionType.SysRuntimeError, messageId);
-					throw ex; //Throw the exception so the runtime can Retry the operation.
+					throw; //Throw the exception so the runtime can Retry the operation.
 				}
 			}
 			else

--- a/dotnet/src/extensions/Azure/test/AzureFunctionsTest/AzureFunctionsTest.csproj
+++ b/dotnet/src/extensions/Azure/test/AzureFunctionsTest/AzureFunctionsTest.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Handlers\GeneXus.Deploy.AzureFunctions.Handlers.csproj" />
+    <ProjectReference Include="..\amyprocedurehandler\amyprochandler.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="gxazmappings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/extensions/Azure/test/AzureFunctionsTest/ListLogger.cs
+++ b/dotnet/src/extensions/Azure/test/AzureFunctionsTest/ListLogger.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Functions.Tests
+{
+	public class ListLogger : ILogger
+	{
+		public IList<string> Logs;
+
+		public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+		public bool IsEnabled(LogLevel logLevel) => false;
+
+		public ListLogger()
+		{
+			this.Logs = new List<string>();
+		}
+
+		public void Log<TState>(LogLevel logLevel,
+								EventId eventId,
+								TState state,
+								Exception exception,
+								Func<TState, Exception, string> formatter)
+		{
+			string message = formatter(state, exception);
+			this.Logs.Add(message);
+		}
+	}
+}

--- a/dotnet/src/extensions/Azure/test/AzureFunctionsTest/NullScope.cs
+++ b/dotnet/src/extensions/Azure/test/AzureFunctionsTest/NullScope.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Functions.Tests
+{
+	public class NullScope : IDisposable
+	{
+		public static NullScope Instance { get; } = new NullScope();
+
+		private NullScope() { }
+
+		public void Dispose() { }
+	}
+}

--- a/dotnet/src/extensions/Azure/test/AzureFunctionsTest/QueueTriggerTest.cs
+++ b/dotnet/src/extensions/Azure/test/AzureFunctionsTest/QueueTriggerTest.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
+using GeneXus.Deploy.AzureFunctions.QueueHandler;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Extensions.AzureFunctions.Test
+{
+	public class QueueTriggerTest
+	{
+
+		[Fact]
+		public void QueueTest()
+		{			
+			try
+			{
+				var serviceCollection = new ServiceCollection();
+				serviceCollection.AddScoped<ILoggerFactory, LoggerFactory>();
+				var serviceProvider = serviceCollection.BuildServiceProvider();
+
+				var context = new Mock<FunctionContext>();
+				context.SetupProperty(c => c.InstanceServices, serviceProvider);
+
+				context.SetupGet(c => c.FunctionId).Returns("6202c88748614a51851a40fa6a4366e6");
+				context.SetupGet(c => c.FunctionDefinition.Name).Returns("queueTest");
+				context.SetupGet(c => c.InvocationId).Returns("6a871dbc3cb74a9fa95f05ae63505c2c");
+
+				ICallMappings callMappings = new CallMappings(".");
+
+			
+				IReadOnlyDictionary<string, object> bindingData = new Dictionary<string, object>()
+				{ 
+					{
+						"Id", new PropertyId { Id = "b50d8f85-3d42-4904-bfdf-dd006ac5ec6a"}
+					},
+				};
+
+				string message = "This is a sample message";
+				context.SetupGet(c => c.BindingContext.BindingData).Returns(bindingData);
+				var ex = Record.Exception(() => new QueueTriggerHandler(callMappings).Run(message, context.Object));
+				Assert.Null(ex);
+				
+			} catch(Exception ex)
+			{
+				throw new Exception("Exception should not be thrown.", ex);
+			}
+				
+		}
+	}
+
+	public class PropertyId
+	{
+		public string Id;
+	}
+
+}

--- a/dotnet/src/extensions/Azure/test/AzureFunctionsTest/TestFactory.cs
+++ b/dotnet/src/extensions/Azure/test/AzureFunctionsTest/TestFactory.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Functions.Tests
+{
+	public enum LoggerTypes
+	{
+		Null,
+		List
+	}
+
+	public class TestFactory
+	{
+			
+		public static ILogger CreateLogger(LoggerTypes type = LoggerTypes.Null)
+		{
+			ILogger logger;
+
+			if (type == LoggerTypes.List)
+			{
+				logger = new ListLogger();
+			}
+			else
+			{
+				logger = NullLoggerFactory.Instance.CreateLogger("Null Logger");
+			}
+
+			return logger;
+		}
+
+	}
+}

--- a/dotnet/src/extensions/Azure/test/AzureFunctionsTest/TimerTriggerTest.cs
+++ b/dotnet/src/extensions/Azure/test/AzureFunctionsTest/TimerTriggerTest.cs
@@ -1,0 +1,49 @@
+using System;
+using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
+using GeneXus.Deploy.AzureFunctions.TimerHandler;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Extensions.AzureFunctions.Test
+{
+	public class TimerTriggerTest
+	{
+		[Fact]
+		public void TimerTest()
+		{			
+			try
+			{
+				var serviceCollection = new ServiceCollection();
+				serviceCollection.AddScoped<ILoggerFactory, LoggerFactory>();
+				var serviceProvider = serviceCollection.BuildServiceProvider();
+
+				var context = new Mock<FunctionContext>();
+				context.SetupProperty(c => c.InstanceServices, serviceProvider);
+
+				context.SetupGet(c => c.FunctionId).Returns("6202c88748614a51851a40fa6a4366e6");
+				context.SetupGet(c => c.FunctionDefinition.Name).Returns("timerTest");
+				context.SetupGet(c => c.InvocationId).Returns("6a871dbc3cb74a9fa95f05ae63505c2c");
+
+				ICallMappings callMappings = new CallMappings(".");
+
+				MyScheduleStatus scheduleStatus = new MyScheduleStatus();
+				scheduleStatus.Next = DateTime.Now.AddMinutes(10);
+				MyInfo myinfo = new();
+				myinfo.IsPastDue = false;
+				myinfo.ScheduleStatus = scheduleStatus;
+				
+				var exception = Record.Exception(() => new TimerTriggerHandler(callMappings).Run(myinfo,context.Object));
+				Assert.Null(exception);
+				
+			} catch(Exception ex)
+			{
+				throw new Exception("Exception should not be thrown.", ex);
+			}
+				
+		}
+	}
+
+}

--- a/dotnet/src/extensions/Azure/test/AzureFunctionsTest/gxazmappings.json
+++ b/dotnet/src/extensions/Azure/test/AzureFunctionsTest/gxazmappings.json
@@ -1,0 +1,1 @@
+[{"FunctionName":"timerTest","GXEntrypoint":"amyprochandler"},{"FunctionName":"queueTest","GXEntrypoint":"amyprochandler"}]

--- a/dotnet/src/extensions/Azure/test/amyprocedurehandler/amyprochandler.cs
+++ b/dotnet/src/extensions/Azure/test/amyprocedurehandler/amyprochandler.cs
@@ -1,0 +1,35 @@
+using GeneXus.Application;
+using GeneXus.Procedure;
+
+namespace GeneXus.Programs
+{
+	public class amyprochandler : GXProcedure
+	{
+		public amyprochandler()
+		{
+			context = new GxContext();
+			IsMain = true;
+		}
+
+		public override void cleanup()
+		{
+			if (IsMain)
+			{
+				context.CloseConnections();
+			}
+			ExitApp();
+		}
+
+		public void execute(genexusserverlessapi.SdtEventMessages aP0_EventMessages,
+						   out genexusserverlessapi.SdtEventMessageResponse aP1_ExternalEventMessageResponse)
+		{
+			aP1_ExternalEventMessageResponse = new GeneXus.Programs.genexusserverlessapi.SdtEventMessageResponse(context);
+			aP1_ExternalEventMessageResponse.gxTpr_Handled = true;
+		}
+
+		public override void initialize()
+		{
+			context.Gx_err = 0;
+		}
+	}
+}

--- a/dotnet/src/extensions/Azure/test/amyprocedurehandler/amyprochandler.csproj
+++ b/dotnet/src/extensions/Azure/test/amyprocedurehandler/amyprochandler.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyName>amyprochandler</AssemblyName>
+		<IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\dotnetcore\GxClasses\GxClasses.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/extensions/Azure/test/amyprocedurehandler/type_SdtEventCustomPayload_CustomPayloadItem.cs
+++ b/dotnet/src/extensions/Azure/test/amyprocedurehandler/type_SdtEventCustomPayload_CustomPayloadItem.cs
@@ -1,0 +1,130 @@
+/*
+				   File: type_SdtEventCustomPayload_CustomPayloadItem
+			Description: EventCustomPayload
+				 Author: Nemo 🐠 for C# (.NET Core) version 17.0.4.150138
+		   Program type: Callable routine
+			  Main DBMS: 
+*/
+using System;
+using System.Collections;
+using GeneXus.Utils;
+using GeneXus.Application;
+using System.Xml.Serialization;
+namespace GeneXus.Programs.genexusserverlessapi
+{
+	[XmlRoot(ElementName="CustomPayloadItem")]
+	[XmlType(TypeName="CustomPayloadItem" , Namespace="ServerlessAPI" )]
+	[Serializable]
+	public class SdtEventCustomPayload_CustomPayloadItem : GxUserType
+	{
+		public SdtEventCustomPayload_CustomPayloadItem( )
+		{
+			/* Constructor for serialization */
+			gxTv_SdtEventCustomPayload_CustomPayloadItem_Propertyid = "";
+
+			gxTv_SdtEventCustomPayload_CustomPayloadItem_Propertyvalue = "";
+
+		}
+
+		public SdtEventCustomPayload_CustomPayloadItem(IGxContext context)
+		{
+			this.context = context;	
+			initialize();
+		}
+
+		#region Json
+		private static Hashtable mapper;
+		public override string JsonMap(string value)
+		{
+			if (mapper == null)
+			{
+				mapper = new Hashtable();
+			}
+			return (string)mapper[value]; ;
+		}
+
+		public override void ToJSON()
+		{
+			ToJSON(true) ;
+			return;
+		}
+
+		public override void ToJSON(bool includeState)
+		{
+			AddObjectProperty("PropertyId", gxTpr_Propertyid, false);
+
+
+			AddObjectProperty("PropertyValue", gxTpr_Propertyvalue, false);
+
+			return;
+		}
+		#endregion
+
+		#region Properties
+
+		[SoapElement(ElementName="PropertyId")]
+		[XmlElement(ElementName="PropertyId")]
+		public string gxTpr_Propertyid
+		{
+			get { 
+				return gxTv_SdtEventCustomPayload_CustomPayloadItem_Propertyid; 
+			}
+			set { 
+				gxTv_SdtEventCustomPayload_CustomPayloadItem_Propertyid = value;
+				SetDirty("Propertyid");
+			}
+		}
+
+
+
+
+		[SoapElement(ElementName="PropertyValue")]
+		[XmlElement(ElementName="PropertyValue")]
+		public string gxTpr_Propertyvalue
+		{
+			get { 
+				return gxTv_SdtEventCustomPayload_CustomPayloadItem_Propertyvalue; 
+			}
+			set { 
+				gxTv_SdtEventCustomPayload_CustomPayloadItem_Propertyvalue = value;
+				SetDirty("Propertyvalue");
+			}
+		}
+
+
+
+
+		public override bool ShouldSerializeSdtJson()
+		{
+		 
+		  return true; 
+		}
+
+		#endregion
+
+		#region Initialization
+
+		public void initialize( )
+		{
+			gxTv_SdtEventCustomPayload_CustomPayloadItem_Propertyid = "";
+			gxTv_SdtEventCustomPayload_CustomPayloadItem_Propertyvalue = "";
+			return  ;
+		}
+
+
+
+		#endregion
+
+		#region Declaration
+
+		protected string gxTv_SdtEventCustomPayload_CustomPayloadItem_Propertyid;
+		 
+
+		protected string gxTv_SdtEventCustomPayload_CustomPayloadItem_Propertyvalue;
+		 
+
+
+		#endregion
+	}
+
+}

--- a/dotnet/src/extensions/Azure/test/amyprocedurehandler/type_SdtEventMessage.cs
+++ b/dotnet/src/extensions/Azure/test/amyprocedurehandler/type_SdtEventMessage.cs
@@ -1,0 +1,318 @@
+/*
+				   File: type_SdtEventMessage
+			Description: EventMessage
+				 Author: Nemo 🐠 for C# (.NET Core) version 17.0.4.150138
+		   Program type: Callable routine
+			  Main DBMS: 
+*/
+using System;
+using System.Collections;
+using GeneXus.Utils;
+using GeneXus.Application;
+using System.Xml.Serialization;
+using System.Runtime.Serialization;
+namespace GeneXus.Programs.genexusserverlessapi
+{
+	[XmlRoot(ElementName="EventMessage")]
+	[XmlType(TypeName="EventMessage" , Namespace="ServerlessAPI" )]
+	[Serializable]
+	public class SdtEventMessage : GxUserType
+	{
+		public SdtEventMessage( )
+		{
+			/* Constructor for serialization */
+			gxTv_SdtEventMessage_Eventmessageid = "";
+
+			gxTv_SdtEventMessage_Eventmessagedate = (DateTime)(DateTime.MinValue);
+
+			gxTv_SdtEventMessage_Eventmessagesourcetype = "";
+
+			gxTv_SdtEventMessage_Eventmessagedata = "";
+
+			gxTv_SdtEventMessage_Eventmessageversion = "";
+
+		}
+
+		public SdtEventMessage(IGxContext context)
+		{
+			this.context = context;	
+			initialize();
+		}
+
+		#region Json
+		private static Hashtable mapper;
+		public override string JsonMap(string value)
+		{
+			if (mapper == null)
+			{
+				mapper = new Hashtable();
+			}
+			return (string)mapper[value]; ;
+		}
+
+		public override void ToJSON()
+		{
+			ToJSON(true) ;
+			return;
+		}
+
+		public override void ToJSON(bool includeState)
+		{
+			AddObjectProperty("EventMessageId", gxTpr_Eventmessageid, false);
+
+
+			datetime_STZ = gxTpr_Eventmessagedate;
+			sDateCnv = "";
+			sNumToPad = StringUtil.Trim(StringUtil.Str((decimal)(DateTimeUtil.Year(datetime_STZ)), 10, 0));
+			sDateCnv = sDateCnv + StringUtil.Substring("0000", 1, 4-StringUtil.Len( sNumToPad)) + sNumToPad;
+			sDateCnv = sDateCnv + "-";
+			sNumToPad = StringUtil.Trim( StringUtil.Str((decimal)(DateTimeUtil.Month(datetime_STZ)), 10, 0));
+			sDateCnv = sDateCnv + StringUtil.Substring("00", 1, 2-StringUtil.Len(sNumToPad)) + sNumToPad;
+			sDateCnv = sDateCnv + "-";
+			sNumToPad = StringUtil.Trim(StringUtil.Str((decimal)(DateTimeUtil.Day(datetime_STZ)), 10, 0));
+			sDateCnv = sDateCnv + StringUtil.Substring("00", 1, 2-StringUtil.Len(sNumToPad)) + sNumToPad;
+			sDateCnv = sDateCnv + "T";
+			sNumToPad = StringUtil.Trim(StringUtil.Str((decimal)(DateTimeUtil.Hour(datetime_STZ)), 10, 0));
+			sDateCnv = sDateCnv + StringUtil.Substring("00", 1, 2-StringUtil.Len(sNumToPad)) + sNumToPad;
+			sDateCnv = sDateCnv + ":";
+			sNumToPad = StringUtil.Trim(StringUtil.Str((decimal)(DateTimeUtil.Minute(datetime_STZ)), 10, 0));
+			sDateCnv = sDateCnv + StringUtil.Substring("00", 1, 2-StringUtil.Len(sNumToPad)) + sNumToPad;
+			sDateCnv = sDateCnv + ":";
+			sNumToPad = StringUtil.Trim(StringUtil.Str((decimal)(DateTimeUtil.Second(datetime_STZ)), 10, 0));
+			sDateCnv = sDateCnv + StringUtil.Substring("00", 1, 2-StringUtil.Len(sNumToPad)) + sNumToPad;
+			AddObjectProperty("EventMessageDate", sDateCnv, false);
+
+
+			AddObjectProperty("EventMessageSourceType", gxTpr_Eventmessagesourcetype, false);
+
+
+			AddObjectProperty("EventMessageData", gxTpr_Eventmessagedata, false);
+
+
+			AddObjectProperty("EventMessageVersion", gxTpr_Eventmessageversion, false);
+
+			if (gxTv_SdtEventMessage_Eventmessagecustompayload != null)
+			{
+				AddObjectProperty("EventMessageCustomPayload", gxTv_SdtEventMessage_Eventmessagecustompayload, false);  
+			}
+			return;
+		}
+		#endregion
+
+		#region Properties
+
+		[SoapElement(ElementName="EventMessageId")]
+		[XmlElement(ElementName="EventMessageId")]
+		public string gxTpr_Eventmessageid
+		{
+			get { 
+				return gxTv_SdtEventMessage_Eventmessageid; 
+			}
+			set { 
+				gxTv_SdtEventMessage_Eventmessageid = value;
+				SetDirty("Eventmessageid");
+			}
+		}
+
+
+
+		[SoapElement(ElementName="EventMessageDate")]
+		[XmlElement(ElementName="EventMessageDate" , IsNullable=true)]
+		public string gxTpr_Eventmessagedate_Nullable
+		{
+			get {
+				if ( gxTv_SdtEventMessage_Eventmessagedate == DateTime.MinValue)
+					return null;
+				return new GxDatetimeString(gxTv_SdtEventMessage_Eventmessagedate).value ;
+			}
+			set {
+				gxTv_SdtEventMessage_Eventmessagedate = DateTimeUtil.CToD2(value);
+			}
+		}
+
+		[XmlIgnore]
+		public DateTime gxTpr_Eventmessagedate
+		{
+			get { 
+				return gxTv_SdtEventMessage_Eventmessagedate; 
+			}
+			set { 
+				gxTv_SdtEventMessage_Eventmessagedate = value;
+				SetDirty("Eventmessagedate");
+			}
+		}
+
+
+
+		[SoapElement(ElementName="EventMessageSourceType")]
+		[XmlElement(ElementName="EventMessageSourceType")]
+		public string gxTpr_Eventmessagesourcetype
+		{
+			get { 
+				return gxTv_SdtEventMessage_Eventmessagesourcetype; 
+			}
+			set { 
+				gxTv_SdtEventMessage_Eventmessagesourcetype = value;
+				SetDirty("Eventmessagesourcetype");
+			}
+		}
+
+
+
+
+		[SoapElement(ElementName="EventMessageData")]
+		[XmlElement(ElementName="EventMessageData")]
+		public string gxTpr_Eventmessagedata
+		{
+			get { 
+				return gxTv_SdtEventMessage_Eventmessagedata; 
+			}
+			set { 
+				gxTv_SdtEventMessage_Eventmessagedata = value;
+				SetDirty("Eventmessagedata");
+			}
+		}
+
+
+
+
+		[SoapElement(ElementName="EventMessageVersion")]
+		[XmlElement(ElementName="EventMessageVersion")]
+		public string gxTpr_Eventmessageversion
+		{
+			get { 
+				return gxTv_SdtEventMessage_Eventmessageversion; 
+			}
+			set { 
+				gxTv_SdtEventMessage_Eventmessageversion = value;
+				SetDirty("Eventmessageversion");
+			}
+		}
+
+
+
+
+		[SoapElement(ElementName="EventMessageCustomPayload" )]
+		[XmlArray(ElementName="EventMessageCustomPayload"  )]
+		[XmlArrayItemAttribute(ElementName="CustomPayloadItem" , IsNullable=false )]
+		public GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventCustomPayload_CustomPayloadItem> gxTpr_Eventmessagecustompayload_GXBaseCollection
+		{
+			get {
+				if ( gxTv_SdtEventMessage_Eventmessagecustompayload == null )
+				{
+					gxTv_SdtEventMessage_Eventmessagecustompayload = new GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventCustomPayload_CustomPayloadItem>( context, "EventCustomPayload", "");
+				}
+				return gxTv_SdtEventMessage_Eventmessagecustompayload;
+			}
+			set {
+				if ( gxTv_SdtEventMessage_Eventmessagecustompayload == null )
+				{
+					gxTv_SdtEventMessage_Eventmessagecustompayload = new GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventCustomPayload_CustomPayloadItem>( context, "EventCustomPayload", "");
+				}
+				gxTv_SdtEventMessage_Eventmessagecustompayload_N = 0;
+
+				gxTv_SdtEventMessage_Eventmessagecustompayload = value;
+			}
+		}
+
+		[XmlIgnore]
+		public GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventCustomPayload_CustomPayloadItem> gxTpr_Eventmessagecustompayload
+		{
+			get {
+				if ( gxTv_SdtEventMessage_Eventmessagecustompayload == null )
+				{
+					gxTv_SdtEventMessage_Eventmessagecustompayload = new GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventCustomPayload_CustomPayloadItem>( context, "EventCustomPayload", "");
+				}
+				gxTv_SdtEventMessage_Eventmessagecustompayload_N = 0;
+
+				return gxTv_SdtEventMessage_Eventmessagecustompayload ;
+			}
+			set {
+				gxTv_SdtEventMessage_Eventmessagecustompayload_N = 0;
+
+				gxTv_SdtEventMessage_Eventmessagecustompayload = value;
+				SetDirty("Eventmessagecustompayload");
+			}
+		}
+
+		public void gxTv_SdtEventMessage_Eventmessagecustompayload_SetNull()
+		{
+			gxTv_SdtEventMessage_Eventmessagecustompayload_N = 1;
+
+			gxTv_SdtEventMessage_Eventmessagecustompayload = null;
+			return  ;
+		}
+
+		public bool gxTv_SdtEventMessage_Eventmessagecustompayload_IsNull()
+		{
+			if (gxTv_SdtEventMessage_Eventmessagecustompayload == null)
+			{
+				return true ;
+			}
+			return false ;
+		}
+
+		public bool ShouldSerializegxTpr_Eventmessagecustompayload_GXBaseCollection_Json()
+		{
+				return gxTv_SdtEventMessage_Eventmessagecustompayload != null && gxTv_SdtEventMessage_Eventmessagecustompayload.Count > 0;
+
+		}
+
+
+		public override bool ShouldSerializeSdtJson()
+		{
+		 
+		  return true; 
+		}
+
+		#endregion
+
+		#region Initialization
+
+		public void initialize( )
+		{
+			gxTv_SdtEventMessage_Eventmessageid = "";
+			gxTv_SdtEventMessage_Eventmessagedate = (DateTime)(DateTime.MinValue);
+			gxTv_SdtEventMessage_Eventmessagesourcetype = "";
+			gxTv_SdtEventMessage_Eventmessagedata = "";
+			gxTv_SdtEventMessage_Eventmessageversion = "";
+
+			gxTv_SdtEventMessage_Eventmessagecustompayload_N = 1;
+
+			datetime_STZ = (DateTime)(DateTime.MinValue);
+			sDateCnv = "";
+			sNumToPad = "";
+			return  ;
+		}
+
+
+
+		#endregion
+
+		#region Declaration
+
+		protected string sDateCnv ;
+		protected string sNumToPad ;
+		protected DateTime datetime_STZ ;
+
+		protected string gxTv_SdtEventMessage_Eventmessageid;
+		 
+
+		protected DateTime gxTv_SdtEventMessage_Eventmessagedate;
+		 
+
+		protected string gxTv_SdtEventMessage_Eventmessagesourcetype;
+		 
+
+		protected string gxTv_SdtEventMessage_Eventmessagedata;
+		 
+
+		protected string gxTv_SdtEventMessage_Eventmessageversion;
+		 
+		protected short gxTv_SdtEventMessage_Eventmessagecustompayload_N;
+		protected GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventCustomPayload_CustomPayloadItem> gxTv_SdtEventMessage_Eventmessagecustompayload = null;  
+
+
+		#endregion
+	}
+}

--- a/dotnet/src/extensions/Azure/test/amyprocedurehandler/type_SdtEventMessageResponse.cs
+++ b/dotnet/src/extensions/Azure/test/amyprocedurehandler/type_SdtEventMessageResponse.cs
@@ -1,0 +1,127 @@
+/*
+				   File: type_SdtEventMessageResponse
+			Description: EventMessageResponse
+				 Author: Nemo 🐠 for C# (.NET Core) version 17.0.4.150138
+		   Program type: Callable routine
+			  Main DBMS: 
+*/
+using System;
+using System.Collections;
+using GeneXus.Utils;
+using GeneXus.Application;
+using System.Xml.Serialization;
+namespace GeneXus.Programs.genexusserverlessapi
+{
+	[XmlRoot(ElementName="EventMessageResponse")]
+	[XmlType(TypeName="EventMessageResponse" , Namespace="ServerlessAPI" )]
+	[Serializable]
+	public class SdtEventMessageResponse : GxUserType
+	{
+		public SdtEventMessageResponse( )
+		{
+			/* Constructor for serialization */
+			gxTv_SdtEventMessageResponse_Errormessage = "";
+
+		}
+
+		public SdtEventMessageResponse(IGxContext context)
+		{
+			this.context = context;	
+			initialize();
+		}
+
+		#region Json
+		private static Hashtable mapper;
+		public override string JsonMap(string value)
+		{
+			if (mapper == null)
+			{
+				mapper = new Hashtable();
+			}
+			return (string)mapper[value]; ;
+		}
+
+		public override void ToJSON()
+		{
+			ToJSON(true) ;
+			return;
+		}
+
+		public override void ToJSON(bool includeState)
+		{
+			AddObjectProperty("Handled", gxTpr_Handled, false);
+
+
+			AddObjectProperty("ErrorMessage", gxTpr_Errormessage, false);
+
+			return;
+		}
+		#endregion
+
+		#region Properties
+
+		[SoapElement(ElementName="Handled")]
+		[XmlElement(ElementName="Handled")]
+		public bool gxTpr_Handled
+		{
+			get { 
+				return gxTv_SdtEventMessageResponse_Handled; 
+			}
+			set { 
+				gxTv_SdtEventMessageResponse_Handled = value;
+				SetDirty("Handled");
+			}
+		}
+
+
+
+
+		[SoapElement(ElementName="ErrorMessage")]
+		[XmlElement(ElementName="ErrorMessage")]
+		public string gxTpr_Errormessage
+		{
+			get { 
+				return gxTv_SdtEventMessageResponse_Errormessage; 
+			}
+			set { 
+				gxTv_SdtEventMessageResponse_Errormessage = value;
+				SetDirty("Errormessage");
+			}
+		}
+
+
+
+
+		public override bool ShouldSerializeSdtJson()
+		{
+		 
+		  return true; 
+		}
+
+		#endregion
+
+		#region Initialization
+
+		public void initialize( )
+		{
+			gxTv_SdtEventMessageResponse_Errormessage = "";
+			return  ;
+		}
+
+
+
+		#endregion
+
+		#region Declaration
+
+		protected bool gxTv_SdtEventMessageResponse_Handled;
+		 
+
+		protected string gxTv_SdtEventMessageResponse_Errormessage;
+		 
+
+
+		#endregion
+	}
+
+}

--- a/dotnet/src/extensions/Azure/test/amyprocedurehandler/type_SdtEventMessages.cs
+++ b/dotnet/src/extensions/Azure/test/amyprocedurehandler/type_SdtEventMessages.cs
@@ -1,0 +1,158 @@
+/*
+				   File: type_SdtEventMessages
+			Description: EventMessages
+				 Author: Nemo 🐠 for C# (.NET Core) version 17.0.4.150138
+		   Program type: Callable routine
+			  Main DBMS: 
+*/
+using System;
+using System.Collections;
+using GeneXus.Utils;
+using GeneXus.Application;
+using System.Xml.Serialization;
+namespace GeneXus.Programs.genexusserverlessapi
+{
+	[XmlRoot(ElementName="EventMessages")]
+	[XmlType(TypeName="EventMessages" , Namespace="ServerlessAPI" )]
+	[Serializable]
+	public class SdtEventMessages : GxUserType
+	{
+		public SdtEventMessages( )
+		{
+			/* Constructor for serialization */
+		}
+
+		public SdtEventMessages(IGxContext context)
+		{
+			this.context = context;	
+			initialize();
+		}
+
+		#region Json
+		private static Hashtable mapper;
+		public override string JsonMap(string value)
+		{
+			if (mapper == null)
+			{
+				mapper = new Hashtable();
+			}
+			return (string)mapper[value]; ;
+		}
+
+		public override void ToJSON()
+		{
+			ToJSON(true) ;
+			return;
+		}
+
+		public override void ToJSON(bool includeState)
+		{
+			if (gxTv_SdtEventMessages_Eventmessage != null)
+			{
+				AddObjectProperty("EventMessage", gxTv_SdtEventMessages_Eventmessage, false);  
+			}
+			return;
+		}
+		#endregion
+
+		#region Properties
+
+		[SoapElement(ElementName="EventMessage" )]
+		[XmlArray(ElementName="EventMessage"  )]
+		[XmlArrayItemAttribute(ElementName="EventMessage" , IsNullable=false )]
+		public GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventMessage> gxTpr_Eventmessage_GXBaseCollection
+		{
+			get {
+				if ( gxTv_SdtEventMessages_Eventmessage == null )
+				{
+					gxTv_SdtEventMessages_Eventmessage = new GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventMessage>( context, "EventMessage", "");
+				}
+				return gxTv_SdtEventMessages_Eventmessage;
+			}
+			set {
+				if ( gxTv_SdtEventMessages_Eventmessage == null )
+				{
+					gxTv_SdtEventMessages_Eventmessage = new GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventMessage>( context, "EventMessage", "");
+				}
+				gxTv_SdtEventMessages_Eventmessage_N = 0;
+
+				gxTv_SdtEventMessages_Eventmessage = value;
+			}
+		}
+
+		[XmlIgnore]
+		public GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventMessage> gxTpr_Eventmessage
+		{
+			get {
+				if ( gxTv_SdtEventMessages_Eventmessage == null )
+				{
+					gxTv_SdtEventMessages_Eventmessage = new GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventMessage>( context, "EventMessage", "");
+				}
+				gxTv_SdtEventMessages_Eventmessage_N = 0;
+
+				return gxTv_SdtEventMessages_Eventmessage ;
+			}
+			set {
+				gxTv_SdtEventMessages_Eventmessage_N = 0;
+
+				gxTv_SdtEventMessages_Eventmessage = value;
+				SetDirty("Eventmessage");
+			}
+		}
+
+		public void gxTv_SdtEventMessages_Eventmessage_SetNull()
+		{
+			gxTv_SdtEventMessages_Eventmessage_N = 1;
+
+			gxTv_SdtEventMessages_Eventmessage = null;
+			return  ;
+		}
+
+		public bool gxTv_SdtEventMessages_Eventmessage_IsNull()
+		{
+			if (gxTv_SdtEventMessages_Eventmessage == null)
+			{
+				return true ;
+			}
+			return false ;
+		}
+
+		public bool ShouldSerializegxTpr_Eventmessage_GXBaseCollection_Json()
+		{
+				return gxTv_SdtEventMessages_Eventmessage != null && gxTv_SdtEventMessages_Eventmessage.Count > 0;
+
+		}
+
+
+		public override bool ShouldSerializeSdtJson()
+		{
+		  return ( 
+		   ShouldSerializegxTpr_Eventmessage_GXBaseCollection_Json()||  
+		  false  );
+		}
+
+		#endregion
+
+		#region Initialization
+
+		public void initialize( )
+		{
+			gxTv_SdtEventMessages_Eventmessage_N = 1;
+
+			return  ;
+		}
+
+
+
+		#endregion
+
+		#region Declaration
+
+		protected short gxTv_SdtEventMessages_Eventmessage_N;
+		protected GXBaseCollection<GeneXus.Programs.genexusserverlessapi.SdtEventMessage> gxTv_SdtEventMessages_Eventmessage = null;  
+
+
+		#endregion
+	}
+
+}


### PR DESCRIPTION
This change is for loading only once - in memory - the information of the file that has the mappings <function, proc to be called>
Also added unit tests for timer and queue.