### PR TITLE
#Fix: Azure Copy() was not taking into account TableName and Field Name properties

### DIFF
--- a/dotnet/src/dotnetframework/Providers/Storage/GXAzureStorage/AzureStorageExternalProvider.cs
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXAzureStorage/AzureStorageExternalProvider.cs
@@ -198,8 +198,9 @@ namespace GeneXus.Storage.GXAzureStorage
 			CloudBlockBlob sourceBlob = GetCloudBlockBlob(sourceUrl, GxFileType.Private);
 			if (sourceBlob.ExistsAsync().GetAwaiter().GetResult())
 			{
-				CloudBlockBlob targetBlob = GetCloudBlockBlob(newName, fileType);
 				newName = tableName + StorageUtils.DELIMITER + fieldName + StorageUtils.DELIMITER + newName;
+				CloudBlockBlob targetBlob = GetCloudBlockBlob(newName, fileType);
+				
 				targetBlob.Metadata["Table"] = tableName;
 				targetBlob.Metadata["Field"] = fieldName;
 				targetBlob.Metadata["KeyValue"] = StorageUtils.EncodeUrl(newName);


### PR DESCRIPTION
## When copying elements in Azure, TableName and FieldName information was not taken into account.

## **Expected behavior:** 
https://host/Contentsj/TestBinary/TestBinaryImage/audiodownload_d7da4c40-ca1f-4524-89a4-08e05ee68ca6.png

## **Obtained:**
https://host/Contentsj/audiodownload_d7da4c40-ca1f-4524-89a4-08e05ee68ca6.png

**Notice** 'TestBinary/TestBinaryImage' was missing in the URL.

Added WEBUnitTest ('EnsureImageCheckUploadedName') for automated testing of this Case. 

