### PR TITLE
Manage a MethodPatternName for sdsvc services

### DIFF
--- a/dotnet/src/dotnetcore/GxClasses.Web/Middleware/GXRouting.cs
+++ b/dotnet/src/dotnetcore/GxClasses.Web/Middleware/GXRouting.cs
@@ -37,7 +37,6 @@ namespace GxClasses.Web.Middleware
 		public bool AzureRuntime;
 		public static string AzureFunctionName;
 
-		const string SDSVC_METHO_SUFFIX = "DL";
 		static Regex SDSVC_PATTERN = new Regex("([^/]+/)*(sdsvc_[^/]+/[^/]+)(\\?.*)*");
 
 		const string PRIVATE_DIR = "private";
@@ -80,11 +79,6 @@ namespace GxClasses.Web.Middleware
 						{
 							if (sMapData[basePath].TryGetValue(Tuple.Create(path.ToLower(), verb), out string value))
 							{
-								//string httpverb = "";
-								//if (sVerb.ContainsKey(basePath))
-								//	sVerb[basePath].TryGetValue(path.ToLower(), out httpverb);
-								//else
-								//	httpverb = "";
 								string mth = sMap[basePath][value].ServiceMethod;
 								Dictionary<string, string> vMap = sMap[basePath][value].VariableAlias;
 								if (questionMarkIdx > 0 && path.Length > questionMarkIdx + 1)
@@ -95,7 +89,7 @@ namespace GxClasses.Web.Middleware
 							else
 							{
 								// Method not allowed
-								result.Add(new ControllerInfo() { Name = apiPaths[basePath], Parameters = "", MethodName = "", Verb = "" });
+								result.Add(new ControllerInfo() { Name = apiPaths[basePath], Parameters = string.Empty, MethodName = string.Empty, Verb = string.Empty });
 								GXLogging.Debug(log, $"Controller found (Method not allowed) Name:{apiPaths[basePath]}");
 								return result;
 							}
@@ -120,8 +114,8 @@ namespace GxClasses.Web.Middleware
 							if (idx > 0 && idx < controllerWithMth.Length - 1)
 							{
 								controller = controllerWithMth.Substring(0, idx);
-								method = $"{controllerWithMth.Substring(idx + 1)}{SDSVC_METHO_SUFFIX}";
-								result.Add(new ControllerInfo() { Name = controller, Parameters = parms, MethodName = method });
+								method = $"{controllerWithMth.Substring(idx + 1)}";
+								result.Add(new ControllerInfo() { Name = controller, Parameters = parms, MethodPattern = method });
 							}
 						}
 						else if (questionMarkIdx >= 0)
@@ -170,10 +164,10 @@ namespace GxClasses.Web.Middleware
 			try
 			{
 				string path = context.Request.Path.ToString();
-				string actualPath = "";
+				string actualPath = string.Empty;
 				if (path.Contains($"/{restBaseURL}") | ServiceInPath(path, out actualPath))
 				{
-					string controllerWithParms = "";
+					string controllerWithParms = string.Empty;
 					if (!AzureRuntime)
 						controllerWithParms = context.GetRouteValue(UrlTemplateControllerWithParms) as string;
 					else
@@ -184,7 +178,7 @@ namespace GxClasses.Web.Middleware
 					
 					List<ControllerInfo> controllers = GetRouteController(servicesPathUrl, servicesValidPath, servicesMap, servicesMapData, actualPath, context.Request.Method, controllerWithParms);
 					GxRestWrapper controller = null;
-					ControllerInfo controllerInfo = controllers.FirstOrDefault(c => (controller = GetController(context, c.Name, c.MethodName, c.VariableAlias)) != null);
+					ControllerInfo controllerInfo = controllers.FirstOrDefault(c => (controller = GetController(context, c)) != null);
 					
 
 					if (controller != null)
@@ -258,7 +252,6 @@ namespace GxClasses.Web.Middleware
 
 		internal string GetGxRouteValue(string path)
 		{
-			string controllerWithParms = "";
 			//Not API Objects
 			string basePath = restBaseURL;
 
@@ -274,14 +267,14 @@ namespace GxClasses.Web.Middleware
 				}			
 			}
 
-			controllerWithParms = path.Remove(0, basePath.Length + 1);
+			string controllerWithParms = path.Remove(0, basePath.Length + 1);
 			controllerWithParms = controllerWithParms.StartsWith("/") ? controllerWithParms.Remove(0, 1) : controllerWithParms;
 			return controllerWithParms;
 
 		}
 		public bool ServiceInPath(String path, out String actualPath)
 		{
-			actualPath = "";
+			actualPath = string.Empty;
 			foreach (String subPath in servicesPathUrl.Keys)
 			{
 				if (path.ToLower().Contains($"/{subPath.ToLower()}"))
@@ -296,17 +289,23 @@ namespace GxClasses.Web.Middleware
 		}
 		public GxRestWrapper GetController(HttpContext context, string controller, string methodName, Dictionary<string, string> variableAlias)
 		{
-			GXLogging.Debug(log, $"GetController:{controller} method:{methodName}");
+			return GetController(context, new ControllerInfo() { Name = controller, MethodName = methodName, VariableAlias = variableAlias });
+		}
+		public GxRestWrapper GetController(HttpContext context, ControllerInfo controllerInfo)
+		{
+			string controller = controllerInfo.Name;
+			string methodName = controllerInfo.MethodName;
+			string methodPattern = controllerInfo.MethodPattern;
+			Dictionary<string, string> variableAlias = controllerInfo.VariableAlias;
+			GXLogging.Debug(log, $"GetController:{controller} method:{methodName} methodPattern:{methodPattern}");
 			GxContext gxContext = GxContext.CreateDefaultInstance();
-			//	IHttpContextAccessor contextAccessor = context.RequestServices.GetService<IHttpContextAccessor>();
-			//	gxContext.HttpContext = new GxHttpContextAccesor(contextAccessor);
 			gxContext.HttpContext = context;
 			context.NewSessionCheck();
 			string nspace;
 			Config.GetValueOf("AppMainNamespace", out nspace);
 
 			String tmpController = controller;
-			String addNspace = "";
+			String addNspace = string.Empty;
 			String asssemblycontroller = tmpController;
 
 
@@ -349,11 +348,11 @@ namespace GxClasses.Web.Middleware
 					if (!string.IsNullOrEmpty(nspace) && controllerClassName.StartsWith(nspace))
 						controllerClassName = controllerClassName.Substring(nspace.Length + 1);
 					else
-						nspace = String.Empty;
+						nspace = string.Empty;
 					var controllerInstance = ClassLoader.FindInstance(controllerAssemblyName, nspace, controllerClassName, new Object[] { gxContext }, Assembly.GetEntryAssembly());
 					GXProcedure proc = controllerInstance as GXProcedure;
 					if (proc != null)
-						return new GxRestWrapper(proc, context, gxContext, methodName);
+						return new GxRestWrapper(proc, context, gxContext, methodName, methodPattern);
 					else
 						GXLogging.Warn(log, $"Controller not found controllerAssemblyName:{controllerAssemblyName} nspace:{nspace} controller:{controllerClassName}");
 				}
@@ -497,11 +496,11 @@ namespace GxClasses.Web.Middleware
 	[DataContract()]
 	public class SingleMap
 	{
-		String verb = "GET";
-		String name = "";
-		String path = "";
-		String implementation = "";
-		String methodName = "";
+		string verb = "GET";
+		string name = string.Empty;
+		string path = string.Empty;
+		string implementation = string.Empty;
+		string methodName = string.Empty;
 		Dictionary<string, string> variableAlias = new Dictionary<string, string>();
 
 		[DataMember()]

--- a/dotnet/src/dotnetcore/GxClasses.Web/Middleware/IGXRouting.cs
+++ b/dotnet/src/dotnetcore/GxClasses.Web/Middleware/IGXRouting.cs
@@ -10,6 +10,7 @@ namespace GxClasses.Web
 	{
 		public Task ProcessRestRequest(HttpContext context);
 		public bool ServiceInPath(String path, out String actualPath);
+		public GxRestWrapper GetController(HttpContext context, ControllerInfo controllerInfo);
 		public GxRestWrapper GetController(HttpContext context, string controller, string methodName, Dictionary<string, string> variableAlias);
 		public void ServicesGroupSetting();
 		public void ServicesFunctionsMetadata();

--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -51,19 +51,21 @@ namespace GeneXus.Application
 		protected IGxContext _gxContext;
 		private GXProcedure _procWorker;
 		private const string EXECUTE_METHOD = "execute";
-		public String ServiceMethod = "";
-		public Dictionary<String, String> VariableAlias = null;
+		private string _serviceMethod = string.Empty;
+		private Dictionary<string, string> _variableAlias = null;
+		private string _serviceMethodPattern;
 		public bool WrappedParameter = false;
 
-		public GxRestWrapper(GXProcedure worker, HttpContext context, IGxContext gxContext, String serviceMethod, Dictionary<string,string> variableAlias) : this(worker, context, gxContext)
+		public GxRestWrapper(GXProcedure worker, HttpContext context, IGxContext gxContext, string serviceMethod, Dictionary<string,string> variableAlias) : this(worker, context, gxContext)
 		{
-			ServiceMethod = serviceMethod;
-			VariableAlias = variableAlias;
+			_serviceMethod = serviceMethod;
+			_variableAlias = variableAlias;
 		}
 
-		public GxRestWrapper(GXProcedure worker, HttpContext context, IGxContext gxContext, String serviceMethod) : this(worker, context, gxContext)
+		public GxRestWrapper(GXProcedure worker, HttpContext context, IGxContext gxContext, string serviceMethod, string serviceMethodPattern) : this(worker, context, gxContext)
 		{
-			ServiceMethod = serviceMethod;
+			_serviceMethod = serviceMethod;
+			_serviceMethodPattern = serviceMethodPattern;
 		}
 
 		public GxRestWrapper(GXProcedure worker, HttpContext context, IGxContext gxContext):this(context, gxContext)
@@ -124,9 +126,9 @@ namespace GeneXus.Application
 					wrapped = false;
 				}				
 
-				if (!String.IsNullOrEmpty(this.ServiceMethod))
+				if (!String.IsNullOrEmpty(this._serviceMethod))
 				{
-					innerMethod = this.ServiceMethod;
+					innerMethod = this._serviceMethod;
 				}
 				Dictionary<string, object> outputParameters = ReflectionHelper.CallMethod(_procWorker, innerMethod, bodyParameters, _gxContext);
 				wrapped = GetWrappedStatus(_procWorker ,wrapped, outputParameters, outputParameters.Count);				
@@ -223,7 +225,7 @@ namespace GeneXus.Application
 		private string SynchronizerMethod()
 		{
 			string method = string.Empty;
-			var queryParameters = ReadQueryParameters(this.VariableAlias);
+			var queryParameters = ReadQueryParameters(this._variableAlias);
 			string gxevent = string.Empty;
 			if (queryParameters.ContainsKey(Synchronizer.SYNC_EVENT_PARAMETER))
 				gxevent = (string)queryParameters[Synchronizer.SYNC_EVENT_PARAMETER];
@@ -263,13 +265,24 @@ namespace GeneXus.Application
 				if (!ProcessHeaders(_procWorker.GetType().Name))
 					return Task.CompletedTask;
 				_procWorker.IsMain = true;
-				var queryParameters = ReadQueryParameters(this.VariableAlias);
-				String innerMethod = EXECUTE_METHOD;
-				if (!String.IsNullOrEmpty(this.ServiceMethod))
+				var queryParameters = ReadQueryParameters(this._variableAlias);
+				string innerMethod = EXECUTE_METHOD;
+				Dictionary<string, object> outputParameters;
+				if (!string.IsNullOrEmpty(_serviceMethodPattern))
 				{
-					innerMethod = this.ServiceMethod;
+					innerMethod = _serviceMethodPattern;
+					outputParameters = ReflectionHelper.CallMethodPattern(_procWorker, innerMethod, queryParameters);
 				}
-				Dictionary<string, object> outputParameters = ReflectionHelper.CallMethod(_procWorker, innerMethod, queryParameters);
+				else 
+				{
+					if (!string.IsNullOrEmpty(_serviceMethod))
+					{
+						innerMethod = _serviceMethod;
+					}
+
+					outputParameters = ReflectionHelper.CallMethod(_procWorker, innerMethod, queryParameters);
+				}
+				
 				int parCount = outputParameters.Count;
 				setWorkerStatus(_procWorker);
 				_procWorker.cleanup();
@@ -287,7 +300,6 @@ namespace GeneXus.Application
 				Cleanup();
 			}
 		}
-
 		bool GetWrappedStatus(GXProcedure worker, bool wrapped, Dictionary<string, object> outputParameters, int parCount)
 		{
 			if (worker.IsApiObject)
@@ -769,6 +781,7 @@ namespace GeneXus.Application
 		public string Name { get; set; }
 		public string Parameters { get; set; }
 		public string MethodName { get; set; }
+		public string MethodPattern { get; set; }
 		public string Verb { get; set; }
 		public Dictionary<string, string> VariableAlias { get; set; }
 	}

--- a/dotnet/test/DotNetCoreUnitTest/Routing.cs
+++ b/dotnet/test/DotNetCoreUnitTest/Routing.cs
@@ -27,7 +27,7 @@ namespace xUnitTesting
 			Assert.Single(cList);
 			Assert.Equal("sdsvc_ComputeTotalWeight_Level_Detail", cList[0].Name);
 			Assert.Equal("gxid=94692756", cList[0].Parameters);
-			Assert.Equal("Plate1DL", cList[0].MethodName);
+			Assert.Equal("Plate1", cList[0].MethodPattern);
 		}
 		[Fact]
 		public void TestSdsvcInModuleWithParms()
@@ -37,7 +37,7 @@ namespace xUnitTesting
 			Assert.Single(cList);
 			Assert.Equal("module1/sdsvc_ComputeTotalWeight_Level_Detail", cList[0].Name);
 			Assert.Equal("gxid=94692756", cList[0].Parameters);
-			Assert.Equal("Plate1DL", cList[0].MethodName);
+			Assert.Equal("Plate1", cList[0].MethodPattern);
 		}
 
 		[Fact]


### PR DESCRIPTION
Methods for sdsvc services has a suffix, then the Method specified in the URL maps to that name + a suffix: ['DL', 'DS', 'SG', 'HC'] depending on the attribute type: DynLoad, DataSource, Suggest or HideCode.