### PR TITLE
Make GetHeader safe and avoid returning null for absent headers.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -973,7 +973,7 @@ namespace GeneXus.Http.Client
 
 		public string GetHeader(string name)
 		{
-			if (_respHeaders != null)
+			if (_respHeaders != null && _respHeaders.Get(name)!=null)
 				return _respHeaders.Get(name);
 			else
 				return string.Empty;


### PR DESCRIPTION
Issue:90014