### PR TITLE
Avoid loading multiple versions of the same assembly 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataHana.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataHana.cs
@@ -35,7 +35,7 @@ namespace GeneXus.Data
 						string assemblyPath = Path.Combine(FileUtil.GetStartupDirectory(), $"{_hanaAssemblyName}.dll");
 						GXLogging.Debug(log, $"Loading {_hanaAssemblyName} from:" + assemblyPath);
 						var asl = new AssemblyLoader(FileUtil.GetStartupDirectory());
-						_hanaAssembly = asl.LoadFromAssemblyPath(assemblyPath);
+						_hanaAssembly = asl.LoadFromAssemblyName(new AssemblyName(_hanaAssemblyName));
 #else
 						GXLogging.Debug(log, "Loading Sap.Data.Hana.v3.5 from GAC");
             _hanaAssembly = Assembly.LoadWithPartialName("Sap.Data.Hana.v3.5");

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataOracle.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataOracle.cs
@@ -550,6 +550,7 @@ namespace GeneXus.Data
 		static readonly ILog log = log4net.LogManager.GetLogger(typeof(GxODPManagedOracle));
 		static Assembly _odpAssembly;
 		const string OracleDbTypeEnum = "Oracle.ManagedDataAccess.Client.OracleDbType";
+		const string OracleAssemblyName = "Oracle.ManagedDataAccess";
 
 		public static Assembly OdpAssembly
 		{
@@ -559,11 +560,11 @@ namespace GeneXus.Data
 				{
 					if (_odpAssembly == null)
 					{
-						string assemblyPath = Path.Combine(FileUtil.GetStartupDirectory(), "Oracle.ManagedDataAccess.dll");
+						string assemblyPath = Path.Combine(FileUtil.GetStartupDirectory(), $"{OracleAssemblyName}.dll");
 						GXLogging.Debug(log, "Loading Oracle.ManagedDataAccess from:" + assemblyPath);
 #if NETCORE
 						var asl = new AssemblyLoader(FileUtil.GetStartupDirectory());
-						_odpAssembly = asl.LoadFromAssemblyPath(assemblyPath);
+						_odpAssembly = asl.LoadFromAssemblyName(new AssemblyName(OracleAssemblyName));
 #else
 						if (File.Exists(assemblyPath))
 						{

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
@@ -25,7 +25,7 @@ namespace GeneXus.Data
 		static Assembly _npgsqlAssembly;
 		private bool _byteaOutputEscape;
 		const string NpgsqlDbTypeEnum = "NpgsqlTypes.NpgsqlDbType";
-
+		const string NpgsqlAssemblyName = "Npgsql";
 		public static Assembly NpgsqlAssembly
 		{
 			get
@@ -34,11 +34,11 @@ namespace GeneXus.Data
 				{
 					if (_npgsqlAssembly == null)
 					{
-						string assemblyPath = Path.Combine(FileUtil.GetStartupDirectory(), "Npgsql.dll");
+						string assemblyPath = Path.Combine(FileUtil.GetStartupDirectory(), $"{NpgsqlAssemblyName}.dll");
 						GXLogging.Debug(log, "Loading Npgsql.dll from:" + assemblyPath);
 #if NETCORE
 						var asl = new AssemblyLoader(FileUtil.GetStartupDirectory());
-						_npgsqlAssembly = asl.LoadFromAssemblyPath(assemblyPath);
+						_npgsqlAssembly = asl.LoadFromAssemblyName(new AssemblyName(NpgsqlAssemblyName));
 #else
 						_npgsqlAssembly = Assembly.LoadFrom(assemblyPath);
 #endif

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/GXMetadata.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/GXMetadata.cs
@@ -30,7 +30,7 @@ namespace GeneXus.Metadata
 
 #if NETCORE
 				var asl = new AssemblyLoader(FileUtil.GetStartupDirectory());
-				Assembly assem = asl.LoadFromAssemblyPath(Path.Combine(FileUtil.GetStartupDirectory(), assemblyName + ".dll"));
+				Assembly assem = asl.LoadFromAssemblyName(new AssemblyName(assemblyName));
 				Type classType = assem.GetType(fullClassName, true, true);
 #else
 				Assembly assem = Assembly.Load(new AssemblyName(assemblyName));

--- a/dotnet/src/dotnetframework/GxClasses/Services/Search/GXSearch.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/Search/GXSearch.cs
@@ -17,7 +17,7 @@ namespace GeneXus.Search
 	public class GxSearchUtils
 	{
 #if NETCORE
-		public static Assembly m_GxSearchAssembly = new AssemblyLoader(FileUtil.GetStartupDirectory()).LoadFromAssemblyPath(Path.Combine(FileUtil.GetStartupDirectory(), "GxSearch.dll"));
+		public static Assembly m_GxSearchAssembly = new AssemblyLoader(FileUtil.GetStartupDirectory()).LoadFromAssemblyName(new AssemblyName("GxSearch"));
 #else
 		public static Assembly m_GxSearchAssembly = Assembly.Load(new AssemblyName("GxSearch"));
 #endif


### PR DESCRIPTION
Replace LoadFromAssemblyName with LoadFromAssemblyName which is overridden at AssemblyLoader to avoid re-loading multiple versions of the same assembly.