### PR TITLE
GetCompleteURL was not working for urls starting with any scheme

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -2199,7 +2199,7 @@ namespace GeneXus.Application
 		{
 			String fout = file.Trim();
 
-			if (PathUtil.IsAbsoluteUrl(file) || file.StartsWith("//") || (file.Length > 2 && file[1] == ':'))
+			if (PathUtil.IsAbsoluteUrlOrAnyScheme(file))
 			{
 				return fout;
 			}

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -2199,7 +2199,7 @@ namespace GeneXus.Application
 		{
 			String fout = file.Trim();
 
-			if (PathUtil.IsAbsoluteUrlOrAnyScheme(file))
+			if (PathUtil.IsAbsoluteUrlOrAnyScheme(file) || file.StartsWith("//"))
 			{
 				return fout;
 			}

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -3530,7 +3530,7 @@ namespace GeneXus.Utils
 		}
 		public static bool IsAbsoluteUrlOrAnyScheme(string url)
 		{
-			return (!String.IsNullOrEmpty(url)) && (IsAbsoluteUrl(url) || url.StartsWith("/") || scheme.IsMatch(url));
+			return (!String.IsNullOrEmpty(url)) && (IsAbsoluteUrl(url) || scheme.IsMatch(url));
 		}
 
 		public static bool HasUrlQueryString(string url)

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -3520,10 +3520,17 @@ namespace GeneXus.Utils
 	}
 	public class PathUtil
 	{
+		const string schemeRegEx = @"^([a-z][a-z0-9+\-.]*):";
+		static Regex scheme = new Regex(schemeRegEx, RegexOptions.IgnoreCase);
+
 		public static bool IsAbsoluteUrl(string url)
 		{
 			Uri result;
 			return Uri.TryCreate(url, UriKind.Absolute, out result) && (result.Scheme == GXUri.UriSchemeHttp || result.Scheme == GXUri.UriSchemeHttps || result.Scheme == GXUri.UriSchemeFtp);
+		}
+		public static bool IsAbsoluteUrlOrAnyScheme(string url)
+		{
+			return (!String.IsNullOrEmpty(url)) && (IsAbsoluteUrl(url) || url.StartsWith("/") || scheme.IsMatch(url));
 		}
 
 		public static bool HasUrlQueryString(string url)

--- a/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
@@ -15,12 +15,10 @@ namespace GeneXus.Application
 
 		static ConcurrentDictionary<string, string> routerList;
 		const string RESOURCE_PATTERN = "*.rewrite";
-		const string schemeRegEx = @"^([a-z][a-z0-9+\-.]*):";
-		static Regex scheme = new Regex(schemeRegEx, RegexOptions.IgnoreCase);
 		internal static string GetURLRoute(string key, object[] objectParms, string[] parmsName, string scriptPath)
 		{
 			string[] parms = objectParms.Select(p => StringizeParm(p)).ToArray() ;
-			if (PathUtil.IsAbsoluteUrl(key) || key.StartsWith("/") || scheme.IsMatch(key))
+			if (PathUtil.IsAbsoluteUrlOrAnyScheme(key))
 			{
 				if (parms.Length > 0)
 				{

--- a/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
@@ -18,7 +18,7 @@ namespace GeneXus.Application
 		internal static string GetURLRoute(string key, object[] objectParms, string[] parmsName, string scriptPath)
 		{
 			string[] parms = objectParms.Select(p => StringizeParm(p)).ToArray() ;
-			if (PathUtil.IsAbsoluteUrlOrAnyScheme(key))
+			if (PathUtil.IsAbsoluteUrlOrAnyScheme(key) || key.StartsWith("/"))
 			{
 				if (parms.Length > 0)
 				{

--- a/dotnet/test/DotNetCoreUnitTest/DotNetCoreUnitTest.csproj
+++ b/dotnet/test/DotNetCoreUnitTest/DotNetCoreUnitTest.csproj
@@ -47,10 +47,6 @@
     </EmbeddedResource>
   </ItemGroup>
 
-	<ItemGroup>
-		<Folder Include="FileIO\" />
-	</ItemGroup>
-
 
 	<ItemGroup>
 		<None Update="FullTextSearch\Ugly.html">

--- a/dotnet/test/DotNetCoreUnitTest/FileIO/ImageIO.cs
+++ b/dotnet/test/DotNetCoreUnitTest/FileIO/ImageIO.cs
@@ -1,0 +1,21 @@
+using System;
+using GeneXus.Application;
+using GeneXus.Configuration;
+using Xunit;
+
+namespace UnitTesting
+{
+	public class ImageIO
+	{
+		[Fact]
+		public void GetCompleteURL()
+		{
+			GxContext context = new GxContext();
+			string imageUrl = "data:image/png;base64";
+			context.StaticContentBase = "StaticResources/";
+			string url = context.GetCompleteURL(imageUrl);
+			Assert.Equal(imageUrl, url);
+
+		}
+	}
+}

--- a/dotnet/test/DotNetCoreUnitTest/FileIO/ImageIO.cs
+++ b/dotnet/test/DotNetCoreUnitTest/FileIO/ImageIO.cs
@@ -1,6 +1,7 @@
 using System;
 using GeneXus.Application;
 using GeneXus.Configuration;
+using Microsoft.AspNetCore.Http;
 using Xunit;
 
 namespace UnitTesting
@@ -16,6 +17,15 @@ namespace UnitTesting
 			string url = context.GetCompleteURL(imageUrl);
 			Assert.Equal(imageUrl, url);
 
+			var httpctx = new DefaultHttpContext();
+			context.HttpContext = httpctx;
+			httpctx.Request.PathBase = new PathString("/VirtualDirectoryName");
+			httpctx.Request.Host = new HostString("localhost");
+			httpctx.Request.Scheme = Uri.UriSchemeHttp;
+			imageUrl = "/hostrelative/image.png";
+			context.StaticContentBase = string.Empty;
+			url = context.GetCompleteURL(imageUrl);
+			Assert.StartsWith(context.GetContextPath(), url);
 		}
 	}
 }


### PR DESCRIPTION
GetCompleteURL was not working for URLs starting with any scheme such as data:image/png;base64, it was adding the base URL in that case, which is already a kind of absolute URL.
Issue:90535