### PR TITLE
Fix cast exception at GxSimpleColleciton<int16>.IndexOf(x) 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
@@ -372,6 +372,14 @@ namespace GeneXus.Utils
 		}
 		public void Add(Object o, int idx)
 		{
+			T TObject = ConvertToT(o);
+			if (idx == 0)
+				Add(TObject);
+			else
+				Insert(idx - 1, TObject);
+		}
+		private T ConvertToT(Object o)
+		{
 			T TObject;
 			if (typeof(T).IsAssignableFrom(o.GetType()))
 				TObject = (T)o;
@@ -400,12 +408,8 @@ namespace GeneXus.Utils
 				else
 					TObject = (T)Convert.ChangeType(o.ToString(), typeof(T));
 			}
-			if (idx == 0)
-				Add(TObject);
-			else
-				Insert(idx - 1, TObject);
+			return TObject;
 		}
-
 		public void RemoveItem(int idx)
 		{
 			if (idx <= 0 || idx > Count)
@@ -430,7 +434,8 @@ namespace GeneXus.Utils
 		}
 		public int IndexOf(object value)
 		{
-			return base.IndexOf((T)value) + 1;
+			T TObject = ConvertToT(value);
+			return base.IndexOf(TObject) + 1;
 		}
 
 		public virtual void writexml(GXXMLWriter oWriter, string sName)


### PR DESCRIPTION
when x is not a castable type to int16 (p.e. int32).
Do the same conversion used at Add method.
Issue:75539