### PR TITLE
DecryptParm is used to URLs encoded with UriEncrypt64

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -3970,7 +3970,7 @@ namespace GeneXus.Utils
 			string value = parm.ToString();
 			if (!String.IsNullOrEmpty(gxkey))
 			{
-				string strValue = Crypto.Decrypt64(value.ToString(), gxkey);
+				string strValue = Crypto.Decrypt64(value.ToString(), gxkey, true);
 				if ((String.CompareOrdinal(StringUtil.Right(strValue, 6).TrimEnd(' '),
 					Crypto.CheckSum(StringUtil.Left(strValue, (short)(StringUtil.Len(strValue) - 6)), 6).TrimEnd(' ')) == 0))
 				{


### PR DESCRIPTION
So it must pass true for safeEncoding parameter.
Issue:90776