### PR TITLE
Avoid Error: System.Collections.Generic.KeyNotFoundException

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -721,12 +721,14 @@ namespace GeneXus.Application
 				{
 					outputParameters.Remove(k);
 				}
-				object o = MakeRestType(outputParameters[k]);
-				if (o == null)
-					outputParameters.Remove(k);
 				else
-					outputParameters[k] = o;
-
+				{
+					object o = MakeRestType(outputParameters[k]);
+					if (o == null)
+						outputParameters.Remove(k);
+					else
+						outputParameters[k] = o;
+				}
 			}			
 		}
 		


### PR DESCRIPTION
Issue:90985
The given key was not present in the dictionary for properties that Should not be Serialized.
