### PR TITLE
DisableImplicitNamespaceImports to fix building error on dotnetcommon projects

### DIFF
--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -30,6 +30,7 @@
 		<RepositoryCommit>$(GIT_SHA)</RepositoryCommit>
 		<NoWarn>NU5105;CS0618;CS8032;CS0618;SYSLIB0021;SYSLIB0023</NoWarn>
 		<IsPackable>true</IsPackable>
+		<DisableImplicitNamespaceImports>True</DisableImplicitNamespaceImports>
 	</PropertyGroup>
 	
 	<PropertyGroup Condition="!$(TargetFramework.StartsWith('net4'))">


### PR DESCRIPTION
Apparently, due to a bug of NET 6 preview7 new feature: https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces
when a project has multiple target frameworks (<TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>)