### PR TITLE
Downgrade targetframework of GenexusSecurity modules

### DIFF
--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusCryptography/GeneXusCryptography.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusCryptography/GeneXusCryptography.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <RootNamespace>GeneXusCryptography</RootNamespace>
     <AssemblyName>GeneXusCryptographyImpl</AssemblyName>
     <NoWarn>CA1031, CA1801, CA1724</NoWarn>

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusFtps/GeneXusFtps.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusFtps/GeneXusFtps.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <RootNamespace>GeneXusFtps</RootNamespace>
     <AssemblyName>GeneXusFtpsImpl</AssemblyName>
 	  <NoWarn>CA1031</NoWarn>

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusJWT/GeneXusJWT.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusJWT/GeneXusJWT.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <RootNamespace>GeneXusJWT</RootNamespace>
     <AssemblyName>GeneXusJWTImpl</AssemblyName>
 	 <NoWarn>CA1031, CA1720, CA1812, CA1724</NoWarn>

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusSftp/GeneXusSftp.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusSftp/GeneXusSftp.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <RootNamespace>GeneXusSftp</RootNamespace>
     <AssemblyName>GeneXusSftpClientImpl</AssemblyName>
 	 <NoWarn>CA1031</NoWarn>

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusXmlSignature/GeneXusXmlSignature.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusXmlSignature/GeneXusXmlSignature.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
 	  <RootNamespace>GeneXusXmlSignature</RootNamespace>
     <AssemblyName>GeneXusXmlSignatureImpl</AssemblyName>
 	 <NoWarn>CA1031</NoWarn>

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/SecurityAPICommons/SecurityAPICommons.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/SecurityAPICommons/SecurityAPICommons.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net47</TargetFramework>
+		<TargetFramework>net462</TargetFramework>
 		<AssemblyName>GeneXusSecurityAPICommonsImpl</AssemblyName>
 		<NoWarn>CA1031, CA1801</NoWarn>
 		<PackageId>GeneXus.Security.Common</PackageId>

--- a/dotnet/src/extensions/SecurityAPI/test/dotnetframework/SecurityAPITest/SecurityAPITest.csproj
+++ b/dotnet/src/extensions/SecurityAPI/test/dotnetframework/SecurityAPITest/SecurityAPITest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net471</TargetFramework>
+		<TargetFramework>net462</TargetFramework>
 		<IsPublishable>false</IsPublishable>
 		<RootNamespace>SecurityAPITest</RootNamespace>
 		<AssemblyName>SecurityAPITest</AssemblyName>


### PR DESCRIPTION
Downgrade from net471 to net462 to keep the same requirements as standard classes.