### PR TITLE
Always encode subjects with UTF-8 in new mail implementation (using System.Net.Mail)

### DIFF
--- a/dotnet/src/dotnetframework/GxMail/SMTPMailClient.cs
+++ b/dotnet/src/dotnetframework/GxMail/SMTPMailClient.cs
@@ -162,12 +162,6 @@ namespace GeneXus.Mail
 
         private Encoding GetEncoding()
         {
-            
-            string cult;
-            if (GeneXus.Configuration.Config.GetValueOf("Culture", out cult) && cult == "ja-JP")
-            {
-                return Encoding.GetEncoding("ISO-2022-JP");
-            }
             return Encoding.UTF8;
         }
 


### PR DESCRIPTION
Issue:91654
The special case for Japanese was inherited from previous implementation SMTPSession, but it doesn't seem to be necessary on the new one and it breaks some Japanese characters when consumed by Becky reader tool.

