### PR TITLE
Google Storage Private Signer was encoding twice

### DIFF
--- a/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/ExternalProviderGoogle.cs
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/ExternalProviderGoogle.cs
@@ -282,7 +282,7 @@ namespace GeneXus.Storage.GXGoogleCloud
 		private string GetURL(string objectName, GxFileType fileType, int urlMinutes = 0)
 		{
 			if (IsPrivateResource(fileType))
-				return Signer.Sign(Bucket, StorageUtils.EncodeUrlPath(objectName), ResolveExpiration(urlMinutes), HttpMethod.Get);
+				return Signer.Sign(Bucket, objectName, ResolveExpiration(urlMinutes), HttpMethod.Get);
 			else
 			{
 				return StorageUri + StorageUtils.EncodeUrlPath(objectName);


### PR DESCRIPTION
When Serving Google Cloud Storage URLS, in Private mode we were Encoding Twice, as the Signer already encodes the URL. 