### PR TITLE
Keep order of items when deserializing GXProperties objects.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
@@ -2230,11 +2230,11 @@ namespace GeneXus.Utils
 			JObject jObj = JSONHelper.ReadJSON<JObject>(s, Messages);
 			if (jObj != null)
 			{
-				foreach (DictionaryEntry item in jObj)
+				foreach (string name in jObj.Names) //.Names keeps the original order
 				{
 					lock (syncObj)
 					{
-						this.Set(item.Key.ToString(), JSONHelper.WriteJSON<dynamic>(item.Value));
+						this.Set(name, JSONHelper.WriteJSON<dynamic>(jObj[name]));
 					}
 				}
 				return true;


### PR DESCRIPTION
Issue:91872
