### PR TITLE
Upload of multimedia through offlineeventreplicator was missing the extension

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
@@ -1611,7 +1611,7 @@ namespace GeneXus.Utils
 								}
 								else if (GxUploadHelper.IsUpload(uploadPath)) //File upload from SD
 								{
-									objProperty.SetValue(this, GxUploadHelper.UploadPath(uploadPath), null);
+									objProperty.SetValue(this, uploadPath, null);
 									PropertyInfo info_gxi = this.GetType().GetProperty(objProperty.Name + "_gxi");//gxi reset
 									if (info_gxi != null)
 										info_gxi.SetValue(this, string.Empty, null);


### PR DESCRIPTION
The original extension of the image or multimedia file was being missed and replaced by .tmp.
To fix that, the upload token is preserved at FromJsonString in BCs instead of replacing it for the full path.
