### PR TITLE
Add an explicit reference to Microsoft.Extensions.Configuration.Binder

### DIFF
--- a/dotnet/src/dotnetcore/Providers/Cache/GxMemcached/GxMemcached.csproj
+++ b/dotnet/src/dotnetcore/Providers/Cache/GxMemcached/GxMemcached.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="EnyimMemcachedCore" Version="2.5.3" />
     <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It is used by MemcachedClientConfiguration.
Issue:92113