### PR TITLE
[AzureStorage] File Upload get stucked and never finishes

### DIFF
--- a/dotnet/src/dotnetframework/Providers/Storage/GXAzureStorage/AzureStorageExternalProvider.cs
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXAzureStorage/AzureStorageExternalProvider.cs
@@ -188,8 +188,20 @@ namespace GeneXus.Storage.GXAzureStorage
 			{
 				blob.Properties.ContentType = mimeType;
 			}
-
-			blob.UploadFromStreamAsync(stream).GetAwaiter().GetResult();
+			
+			using (MemoryStream ms = new MemoryStream())
+			{
+				/*
+				 * WA for Issue Azure SDK: 
+					https://github.com/Azure/azure-sdk-for-net/issues/10814
+					https://github.com/Azure/azure-storage-net-data-movement/issues/148
+					https://github.com/Azure/azure-storage-net/issues/864
+				 * */
+				stream.Position = 0;
+				stream.CopyTo(ms);
+				ms.Position = 0;
+				blob.UploadFromStreamAsync(ms).GetAwaiter().GetResult();
+			}
 			return GetURL(blob, fileType);
 		}
 


### PR DESCRIPTION
When using File Upload Control.
If the User uploads multiple Files (> 5) at the same time, the WebServer freezes and the Upload never completes.

This seems to be a bug in Azure SDK that has been fixed:

https://github.com/Azure/azure-sdk-for-net/issues/10814
https://github.com/Azure/azure-storage-net-data-movement/issues/148
https://github.com/Azure/azure-storage-net/issues/864

A workaround has been made in order to fix this problem, but the ideal FIX would be to Update Azure Storage SDK. 
