### PR TITLE
Output string of dfrgtxt was being unassigned 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtils.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtils.cs
@@ -430,9 +430,10 @@ namespace GeneXus.Utils
 			}
 			string fld;
 			short err = getNextFld(length, out fld);
+			fld = stripDelimiters(fld);
+			s=fld;
 			if (err == GX_ASCDEL_SUCCESS)
 			{
-				fld = stripDelimiters(fld);
 				if (length != 0)
 				{
 					try
@@ -441,12 +442,9 @@ namespace GeneXus.Utils
 					}
 					catch
 					{
-						s = fld;
 						return GX_ASCDEL_OVERFLOW;
 					}
 				}
-				else
-					s = fld;
 			}
 			return err;
 		}

--- a/dotnet/test/DotNetUnitTest/FileIO/DfrgFunctions.cs
+++ b/dotnet/test/DotNetUnitTest/FileIO/DfrgFunctions.cs
@@ -57,6 +57,7 @@ namespace UnitTesting
 			if (context.FileIOInstance.dfrnext() == 0)
 			{
 				code = context.FileIOInstance.dfrgtxt(out line, 10);
+				Assert.Equal(MS923_CONTENT.Substring(0, 10), line);
 				Assert.Equal(-6, code);
 			}
 			code = context.FileIOInstance.dfrclose();
@@ -68,6 +69,7 @@ namespace UnitTesting
 			if (context.FileIOInstance.dfrnext() == 0)
 			{
 				code = context.FileIOInstance.dfrgtxt(out line, 10);
+				Assert.Equal(MS923_CONTENT.Substring(0,10), line);
 				Assert.Equal(-6, code);
 			}
 			code = context.FileIOInstance.dfrclose();


### PR DESCRIPTION
when overflow happened (error code= GX_ASCDEL_OVERFLOW -6).
Issue:94412