### PR TITLE
DateAsChar is not used anymore for as400

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataDb2400.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataDb2400.cs
@@ -318,7 +318,11 @@ namespace GeneXus.Data
 				case GXType.UniqueIdentifier:
 				case GXType.DateAsChar:
 				case GXType.Char: return ClassLoader.GetEnumValue(iAssembly, iDB2DbTypeEnum, "iDB2Char");
-				case GXType.Date: return ClassLoader.GetEnumValue(iAssembly, iDB2DbTypeEnum, "iDB2Date");
+				case GXType.Date:
+					if(m_UseCharInDate)
+						return ClassLoader.GetEnumValue(iAssembly, iDB2DbTypeEnum, "iDB2Char");
+					else
+						return ClassLoader.GetEnumValue(iAssembly, iDB2DbTypeEnum, "iDB2Date");
 				case GXType.Clob: return ClassLoader.GetEnumValue(iAssembly, iDB2DbTypeEnum, "Clob");
 				case GXType.VarChar: return ClassLoader.GetEnumValue(iAssembly, iDB2DbTypeEnum, "iDB2VarChar");
 				case GXType.Blob: return ClassLoader.GetEnumValue(iAssembly, iDB2DbTypeEnum, "iDB2Blob");
@@ -949,7 +953,11 @@ namespace GeneXus.Data
 				case GXType.Number: return MsDb2Type.Double;
 				case GXType.DateTime2:
 				case GXType.DateTime: return MsDb2Type.Timestamp;
-				case GXType.Date: return MsDb2Type.Date;
+				case GXType.Date:
+					if(m_UseCharInDate)
+						return MsDb2Type.Char;
+					else
+						return MsDb2Type.Date;
 				case GXType.UniqueIdentifier:
 				case GXType.DateAsChar:
 				case GXType.Char: return MsDb2Type.Char;

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTier.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTier.cs
@@ -228,10 +228,10 @@ namespace GeneXus.Data.NTier
 								else
 									stmt.SetParameter(idxParmCollection, (string)parms[idx]);
 								break;
+							case GXType.DateAsChar:
 							case GXType.Date:
 								stmt.SetParameter(idxParmCollection, (DateTime)parms[idx]);
 								break;
-							case GXType.DateAsChar:
 							case GXType.DateTime:
 								stmt.SetParameterDatetime(idxParmCollection, (DateTime)parms[idx]);
 								break;


### PR DESCRIPTION
 Instead, DateAsChar is inferred at runtime reading the UseCharInDate property of the corresponding DataStore. 
That's because UseCharInDate must be considered by datastore.
Issue:94625