### PR TITLE
Add assembly redirect for Microsoft.SqlServer.Types 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
@@ -445,6 +445,7 @@ namespace GeneXus.Configuration
 			{ "System.Memory",new Version(4, 0, 1, 1) }
 		};
 
+		static string GeoTypesAssembly = "Microsoft.SqlServer.Types";
 		[SecurityCritical]
 		private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
 		{
@@ -453,6 +454,10 @@ namespace GeneXus.Configuration
 			{
 				requestedAssembly.Version = AssemblyRedirect[requestedAssembly.Name];
 				return Assembly.Load(requestedAssembly);
+			}
+			else if (requestedAssembly.Name == GeoTypesAssembly && requestedAssembly.Version!=null)
+			{
+				return SQLGeographyWrapper.GeoAssembly;
 			}
 			else return null;
 		}


### PR DESCRIPTION
So that dependency from System.Data.SqlClient.SqlDataReader.GetValue is loaded with the available version.

Fix error System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.SqlServer.Types, Version=10.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91' or one of its dependencies.
Issue:94876