### PR TITLE
Keep compatibility on AuthenticationType enum constants

### DIFF
--- a/dotnet/src/dotnetframework/GxMail/Exchange/ExchangeSession.cs
+++ b/dotnet/src/dotnetframework/GxMail/Exchange/ExchangeSession.cs
@@ -737,9 +737,9 @@ namespace GeneXus.Mail.Exchange
 	public enum AuthenticationType
 	{
 		Basic,
-		OAuthUsernamePassword,
 		OAuthDelegated,
 		OAuthDelegatedInteractive,
-		OAuthApplication
+		OAuthApplication,
+		OAuthUsernamePassword
 	}
 }


### PR DESCRIPTION
Move new enum value OAuthUsernamePassword added at #565 to the last place to keep compatibility.