### PR TITLE
Downgrade itextasian.dll from 2.1.0 to 1.0.0 because the name space o…

### DIFF
--- a/dotnet/src/dotnetcore/GxPdfReportsCS/GxPdfReportsCS.csproj
+++ b/dotnet/src/dotnetcore/GxPdfReportsCS/GxPdfReportsCS.csproj
@@ -14,7 +14,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="iTextSharp-LGPL" Version="4.1.6" />
-		<PackageReference Include="Portable.iTextAsian" Version="2.1.0" />
 		<PackageReference Include="log4net" Version="2.0.11" />
 		<PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
 			<PrivateAssets>all</PrivateAssets>

--- a/dotnet/src/dotnetframework/GxPdfReportsCS/PDFReportItext.cs
+++ b/dotnet/src/dotnetframework/GxPdfReportsCS/PDFReportItext.cs
@@ -2772,9 +2772,9 @@ namespace com.genexus.reports
 			new string[]{"Script", "Helvetica"},
 			new string[]{"System", "Helvetica"},
 			new string[]{"Times New Roman", "Times"},
-			new string[]{"\uff2d\uff33 \u660e\u671d", "Japanese"},
-			new string[]{"\uff2d\uff33 \u30b4\u30b7\u30c3\u30af", "Japanese2"}};
-		
+			new string[]{"\uff2d\uff33 \u660e\u671d", "Japanese"},  //(MS Mincho)
+			new string[]{"\uff2d\uff33 \u30b4\u30b7\u30c3\u30af", "Japanese2"}};//(MS Gothic)
+
 
 		public static String REGISTRY_FONT_SUBSTITUTES_ENTRY = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\FontSubstitutes"; 
 		public static String REGISTRY_FONT_SUBSTITUTES_ENTRY_NT = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\FontSubstitutes"; 


### PR DESCRIPTION
Resources' name space is not compatible with itextsharp 4x.
Issue:95202