### PR TITLE
Fix System.ArgumentException : Source array was not long enough. 

### DIFF
--- a/dotnet/src/dotnetframework/GxPdfReportsCS/PDFReportItext.cs
+++ b/dotnet/src/dotnetframework/GxPdfReportsCS/PDFReportItext.cs
@@ -3139,7 +3139,8 @@ namespace com.genexus.reports
 		
 		public static void addPredefinedSearchPaths(String [] predefinedPaths)
 		{
-			predefinedSearchPath.InsertRange(0, predefinedPaths);
+			lock (predefinedSearchPath)
+				predefinedSearchPath.InsertRange(0, predefinedPaths);
 		}
 
 		public static String getPredefinedSearchPaths()

--- a/dotnet/test/DotNetUnitTest/PDF/PDFTests.cs
+++ b/dotnet/test/DotNetUnitTest/PDF/PDFTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
+using com.genexus.reports;
 using GeneXus.Programs;
 using GeneXus.Utils;
 using Xunit;
@@ -10,6 +12,21 @@ namespace UnitTesting
 {
 	public class PDFTests
 	{
+		[Fact]
+		public void ConcurrencyPDFSearchPaths()
+		{
+			Parallel.For(0, 50, i =>
+			{
+				apdfbasictest test = new apdfbasictest();
+				test.execute();
+			});
+			Parallel.For(0, 300, i =>
+			{
+				//System.ArgumentException : Source array was not long enough. Check srcIndex and length, and the array's lower bounds.
+				Utilities.addPredefinedSearchPaths(new String[] { "A", "B", "C" });
+			});
+
+		}
 		[Fact]
 		public void ExtractTextFromPDF()
 		{


### PR DESCRIPTION
When creating concurrent PDF proc instances.
Issue:95656