### PR TITLE
Server Certificate Validation Fix

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -130,17 +130,13 @@ namespace GeneXus.Http.Client
 #if NETCORE
 		private HttpClientHandler GetHandler()
 		{
-			HttpClientHandler handlerInstance = new HttpClientHandler();
-			handlerInstance.MaxConnectionsPerServer = _maxConnPerRoute;
-			return handlerInstance;
+			return new HttpClientHandler();
 		}
 #else
 		[SecuritySafeCritical]
 		private WinHttpHandler GetHandler()
 		{
-			WinHttpHandler handlerInstance = new WinHttpHandler();
-			handlerInstance.MaxConnectionsPerServer = _maxConnPerRoute;
-			return handlerInstance;
+			return new WinHttpHandler();
 		}
 #endif
 		public GxHttpClient(IGxContext context) : this()
@@ -611,18 +607,19 @@ namespace GeneXus.Http.Client
 #if NETCORE
 			HttpClientHandler handler = GetHandler();
 			handler.Credentials = getCredentialCache(request.RequestUri, _authCollection);
-			if (System.Net.ServicePointManager.ServerCertificateValidationCallback != null)
+			if (ServicePointManager.ServerCertificateValidationCallback != null)
 			{
 				handler.ServerCertificateCustomValidationCallback = ((sender, certificate, chain, sslPolicyErrors) => ServicePointManager.ServerCertificateValidationCallback(sender, certificate, chain, sslPolicyErrors));
 			}
 #else
 			WinHttpHandler handler = GetHandler();
 			handler.ServerCredentials = getCredentialCache(request.RequestUri, _authCollection);
-			if (System.Net.ServicePointManager.ServerCertificateValidationCallback != null)
+			if (ServicePointManager.ServerCertificateValidationCallback != null)
 			{
 				handler.ServerCertificateValidationCallback = ((sender, certificate, chain, sslPolicyErrors) => ServicePointManager.ServerCertificateValidationCallback(sender, certificate, chain, sslPolicyErrors));
 			}
 #endif
+			handler.MaxConnectionsPerServer = _maxConnPerRoute;
 			if (GXUtil.CompressResponse())
 			{
 				handler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -611,11 +611,18 @@ namespace GeneXus.Http.Client
 #if NETCORE
 			HttpClientHandler handler = GetHandler();
 			handler.Credentials = getCredentialCache(request.RequestUri, _authCollection);
+			if (System.Net.ServicePointManager.ServerCertificateValidationCallback != null)
+			{
+				handler.ServerCertificateCustomValidationCallback = ((sender, certificate, chain, sslPolicyErrors) => ServicePointManager.ServerCertificateValidationCallback(sender, certificate, chain, sslPolicyErrors));
+			}
 #else
 			WinHttpHandler handler = GetHandler();
 			handler.ServerCredentials = getCredentialCache(request.RequestUri, _authCollection);
+			if (System.Net.ServicePointManager.ServerCertificateValidationCallback != null)
+			{
+				handler.ServerCertificateValidationCallback = ((sender, certificate, chain, sslPolicyErrors) => ServicePointManager.ServerCertificateValidationCallback(sender, certificate, chain, sslPolicyErrors));
+			}
 #endif
-
 			if (GXUtil.CompressResponse())
 			{
 				handler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;


### PR DESCRIPTION
Server Certificate Validation Fix, if the user specifies so, it allows, as long as the user specifies so, to change the server certificate validation.