### PR TITLE
Add existance check for file provider on GXFile

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GXFileIO.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GXFileIO.cs
@@ -583,8 +583,8 @@ public class GxExternalFileInfo : IGxFileInfo
 
 	private string URL
 	{
-		get {			
-			return _provider.GetUrl(_name, _fileTypeAtt, 0);
+		get {
+			return _provider == null ? String.Empty : _provider.GetUrl(_name, _fileTypeAtt, 0);
 		}
 	}
 


### PR DESCRIPTION
There is a constructor for GXFile that didn't ask for a file provider on its arguments, that caused an error when the file was a blob.

Issue:94821