### PR TITLE
Take into account server variable HTTP_HOST when getting ServerName.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -314,6 +314,7 @@ namespace GeneXus.Application
 		internal static string GX_SPA_REDIRECT_URL = "X-SPA-REDIRECT-URL";
 		internal const string GXLanguage = "GXLanguage";
 		internal const string GXTheme = "GXTheme";
+		internal const string SERVER_VAR_HTTP_HOST = "HTTP_HOST";
 		[NonSerialized]
 		HttpContext _HttpContext;
 		[NonSerialized]
@@ -2756,7 +2757,9 @@ namespace GeneXus.Application
 				if (Config.GetValueOf("SERVER_NAME", out serverName))
 					return serverName;
 #if !NETCORE
-				serverName = _HttpContext.Request.ServerVariables["http_host"];
+				serverName = _HttpContext.Request.ServerVariables[SERVER_VAR_HTTP_HOST];
+#else
+				serverName = _HttpContext.GetServerVariable(SERVER_VAR_HTTP_HOST);
 #endif
 				if (String.IsNullOrEmpty(serverName))
 				{
@@ -2768,9 +2771,8 @@ namespace GeneXus.Application
 				return serverName;
 			}
 			catch
-
 			{
-				return "";
+				return string.Empty;
 			}
 		}
 		private static bool DynamicPortRequest(HttpRequest request)


### PR DESCRIPTION
It fixes the case of getting the wrong ServerName when running kestrel with hostingModel=InProcess in IIS.
In .NET Framework the casing of Server Variable must be uppercase (although it was also found as http_host).
Issue:92954