### PR TITLE
Compatibility fix: Dot not validate headers on new HttpClient implementation

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -580,11 +580,7 @@ namespace GeneXus.Http.Client
 		}
 		void AddHeader(HttpRequestHeaders headers, string headerName, string headerValue)
 		{
-#if NETCORE
-			headers.Add(headerName, headerValue);
-#else
 			headers.TryAddWithoutValidation(headerName, headerValue);
-#endif
 		}
 		void InferContentType(string contentType, HttpRequestMessage req)
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -523,7 +523,7 @@ namespace GeneXus.Http.Client
 						contentHeaders.ContentType = MediaTypeHeaderValue.Parse(_headers[i].ToString());
 						break;
 					case "ACCEPT":
-						headers.Add("Accept", _headers[i]);
+						AddHeader(headers, "Accept", _headers[i]);
 						break;
 					case "EXPECT":
 						if (string.IsNullOrEmpty(_headers[i]))
@@ -535,7 +535,7 @@ namespace GeneXus.Http.Client
 						headers.Referrer = new Uri(_headers[i]);
 						break;
 					case "USER-AGENT":
-						headers.Add("User-Agent", _headers[i]);
+						AddHeader(headers, "User-Agent", _headers[i]);
 						break;
 					case "DATE":
 						DateTime value;
@@ -545,7 +545,7 @@ namespace GeneXus.Http.Client
 						}
 						else
 						{
-							headers.Add(currHeader, _headers[i]);
+							AddHeader(headers, currHeader, _headers[i]);
 						}
 						break;
 					case "COOKIE":
@@ -564,7 +564,7 @@ namespace GeneXus.Http.Client
 							request.Headers.IfModifiedSince = dt;
 						break;
 					default:
-						headers.Add(currHeader, _headers[i]);
+						AddHeader(headers, currHeader, _headers[i]);
 						break;
 				}
 			}
@@ -577,6 +577,14 @@ namespace GeneXus.Http.Client
 					headers.ConnectionClose = false;
 			}
 			InferContentType(contentType, request);
+		}
+		void AddHeader(HttpRequestHeaders headers, string headerName, string headerValue)
+		{
+#if NETCORE
+			headers.Add(headerName, headerValue);
+#else
+			headers.TryAddWithoutValidation(headerName, headerValue);
+#endif
 		}
 		void InferContentType(string contentType, HttpRequestMessage req)
 		{

--- a/dotnet/test/DotNetCoreUnitTest/DotNetCoreUnitTest.csproj
+++ b/dotnet/test/DotNetCoreUnitTest/DotNetCoreUnitTest.csproj
@@ -12,6 +12,7 @@
 	</PropertyGroup>
 	<ItemGroup>		
 	    <Compile Include="..\DotNetUnitTest\ConfigMappings\ConfigTest.cs" Link="ConfigMappings\ConfigTest.cs" />		
+	    <Compile Include="..\DotNetUnitTest\Domain\GxHttpClientTest.cs" Link="Domain\GxHttpClientTest.cs" />		
 	    <Compile Include="..\DotNetUnitTest\FileIO\DfrgFunctions.cs" Link="FileIO\DfrgFunctions.cs" />
 		<Compile Include="..\DotNetUnitTest\FileIO\FileSystemTest.cs" Link="FileIO\FileSystemTest.cs" />
 		<Compile Include="..\DotNetUnitTest\FileIO\Xslt.cs" Link="FileIO\Xslt.cs" />
@@ -153,6 +154,7 @@
 	<ItemGroup>
 	  <Folder Include="apps\" />
 	  <Folder Include="ConfigMappings\" />
+	  <Folder Include="Domain\" />
 	  <Folder Include="PDF\" />
 	  <Folder Include="resources\xml\" />
 	</ItemGroup>

--- a/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
@@ -8,7 +8,7 @@ namespace xUnitTesting
 	public class GxHttpClientTest
 	{
 		[Fact]
-		public void TestHttpClientAddHeaderWithSpecialCharactersDoesNotThrowException()
+		public void AddHeaderWithSpecialCharactersDoesNotThrowException()
 		{
 			GxHttpClient httpclient = new GxHttpClient();
 			string headerValue = "d3890093-289b-4f87-adad-f2ebea826e8f!8db3bc7ac3d38933c3b0c91a3bcdab60b9bbb3f607a1c9b312b24374e750243f3a31d7e90a4c55@SSORT!d3890093-289b-4f87-adad-f2ebea826e8f!8c7564ac08514ff988ba6c8c6ba3fc0c";

--- a/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
@@ -1,0 +1,25 @@
+using System.Net;
+using GeneXus.Http.Client;
+using Xunit;
+
+namespace xUnitTesting
+{
+
+	public class GxHttpClientTest
+	{
+		[Fact]
+		public void TestHttpClientAddHeaderWithSpecialCharactersDoesNotThrowException()
+		{
+			GxHttpClient httpclient = new GxHttpClient();
+			string headerValue = "d3890093-289b-4f87-adad-f2ebea826e8f!8db3bc7ac3d38933c3b0c91a3bcdab60b9bbb3f607a1c9b312b24374e750243f3a31d7e90a4c55@SSORT!d3890093-289b-4f87-adad-f2ebea826e8f!8c7564ac08514ff988ba6c8c6ba3fc0c";
+			string headerName = "Authorization";
+			httpclient.AddHeader(headerName, headerValue);
+			httpclient.Host="accountstest.genexus.com";
+			httpclient.Secure=1;
+			httpclient.BaseURL =@"oauth/gam/v2.0/dummy/requesttokenanduserinfo";
+			httpclient.Execute("GET", string.Empty);
+			Assert.NotEqual(((int)HttpStatusCode.InternalServerError), httpclient.StatusCode);
+
+		}
+	}
+}


### PR DESCRIPTION
Do not validate headers in the new HttpClient implementation for .NET Framework so that it behaves the same way as the old HTTP client implementation.