### PR TITLE
Unify version of external packages so the same number is used across all the projects.

### DIFF
--- a/dotnet/DotNetStandardClasses.sln
+++ b/dotnet/DotNetStandardClasses.sln
@@ -202,6 +202,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeneXus.Programs.Common", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "apiattractions", "src\extensions\Azure\test\apiattractions\apiattractions.csproj", "{E85FDB0F-FA81-4CDD-8BF3-865269CE2DB3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectHealthTest", "test\ProjectHealthTest\ProjectHealthTest.csproj", "{65048104-212A-4819-AECF-89CA9C08C83F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -492,6 +494,10 @@ Global
 		{E85FDB0F-FA81-4CDD-8BF3-865269CE2DB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E85FDB0F-FA81-4CDD-8BF3-865269CE2DB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E85FDB0F-FA81-4CDD-8BF3-865269CE2DB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65048104-212A-4819-AECF-89CA9C08C83F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65048104-212A-4819-AECF-89CA9C08C83F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65048104-212A-4819-AECF-89CA9C08C83F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65048104-212A-4819-AECF-89CA9C08C83F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -589,6 +595,7 @@ Global
 		{B01A243D-C012-4BEB-BAA9-E1D9AC1468C8} = {C16BD5A9-4412-4B91-BB70-5C88B7AAE675}
 		{DCEC0B38-93B6-4003-81E6-9FBC2BB4F163} = {7BA5A2CE-7992-4F87-9D84-91AE4D046F5A}
 		{E85FDB0F-FA81-4CDD-8BF3-865269CE2DB3} = {7BA5A2CE-7992-4F87-9D84-91AE4D046F5A}
+		{65048104-212A-4819-AECF-89CA9C08C83F} = {1D6F1776-FF4B-46C2-9B3D-BC46CCF049DC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E18684C9-7D76-45CD-BF24-E3944B7F174C}

--- a/dotnet/src/dotnetcore/Projects/StoreManager/StoreManager.csproj
+++ b/dotnet/src/dotnetcore/Projects/StoreManager/StoreManager.csproj
@@ -28,9 +28,7 @@
 
   <ItemGroup>
 	<PackageReference Include="Google.Apis" Version="1.42.0" />
-    <PackageReference Include="Google.Apis.AndroidPublisher.v3">
-      <Version>1.42.0.1766</Version>
-    </PackageReference>
+    <PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.42.0.1766"/>
     <PackageReference Include="Google.Apis.Auth" Version="1.42.0" />
     <PackageReference Include="Google.Apis.Core" Version="1.42.0" />    
   </ItemGroup>

--- a/dotnet/src/dotnetcore/Providers/Storage/GXGoogleCloudNetCore/GXGoogleCloudNetCore.csproj
+++ b/dotnet/src/dotnetcore/Providers/Storage/GXGoogleCloudNetCore/GXGoogleCloudNetCore.csproj
@@ -14,7 +14,7 @@
 	</ItemGroup>
 
   <ItemGroup>
-		<PackageReference Include="Google.Apis.Storage.v1" Version="1.27.1.888" />
+		<PackageReference Include="Google.Apis.Storage.v1" Version="1.42.0.1744" />
 		<PackageReference Include="Google.Cloud.Storage.V1" Version="2.0.0" />
 		
 	</ItemGroup>

--- a/dotnet/src/dotnetframework/DynServiceFabric/DynService.Fabric.csproj
+++ b/dotnet/src/dotnetframework/DynServiceFabric/DynService.Fabric.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net462</TargetFramework>
 		<RootNamespace>GeneXus.Data.DynService.Fabric</RootNamespace>
@@ -12,7 +12,7 @@
 		<PackageReference Include="log4net" Version="2.0.11" />
 		<PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-		<PackageReference Include="System.Spatial" Version="5.8.3" />
+		<PackageReference Include="System.Spatial" Version="5.8.4" />
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="System.Web.Extensions" />

--- a/dotnet/src/dotnetframework/GxDataInitialization/GXDataInitialization.csproj
+++ b/dotnet/src/dotnetframework/GxDataInitialization/GXDataInitialization.csproj
@@ -9,8 +9,7 @@
 		<PackageId>GeneXus.DataInitialization</PackageId>
 	</PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net">
-      <Version>2.0.11</Version>
+    <PackageReference Include="log4net" Version="2.0.11">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/GXGoogleCloud.csproj
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/GXGoogleCloud.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net462</TargetFramework>
 		<RootNamespace>GXGoogleCloud</RootNamespace>
@@ -11,9 +11,9 @@
     <PackageReference Include="BouncyCastle" Version="1.7.0" />
     <PackageReference Include="Google.Api.Gax" Version="2.0.0" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="2.0.0" />
-    <PackageReference Include="Google.Apis" Version="1.27.1" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.27.1" />
-    <PackageReference Include="Google.Apis.Core" Version="1.27.1" />
+    <PackageReference Include="Google.Apis" Version="1.42.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.42.0" />
+    <PackageReference Include="Google.Apis.Core" Version="1.42.0" />
     <PackageReference Include="Google.Apis.Storage.v1" Version="1.27.1.881" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="2.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/GeneXusJWTNetCore/GeneXusJWTNetCore.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/GeneXusJWTNetCore/GeneXusJWTNetCore.csproj
@@ -32,12 +32,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="6.5.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.5.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="6.5.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.5.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/SecurityAPICommonsNetCore/SecurityAPICommonsNetCore.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/SecurityAPICommonsNetCore/SecurityAPICommonsNetCore.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/extensions/SecurityAPI/test/dotnetcore/SecurityAPITestNetCore/SecurityAPITestNetCore.csproj
+++ b/dotnet/src/extensions/SecurityAPI/test/dotnetcore/SecurityAPITestNetCore/SecurityAPITestNetCore.csproj
@@ -56,12 +56,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0" />
     <PackageReference Include="NUnit.Engine" Version="3.12.0" />
     <PackageReference Include="NUnit.Extension.NUnitProjectLoader" Version="3.6.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/extensions/mocking/test/TestMockDBAccess/TestMockDBAccess.csproj
+++ b/dotnet/src/extensions/mocking/test/TestMockDBAccess/TestMockDBAccess.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
 		<PackageReference Include="coverlet.collector" Version="3.1.0" />

--- a/dotnet/test/ProjectHealthTest/PackageVersionsConsistency.cs
+++ b/dotnet/test/ProjectHealthTest/PackageVersionsConsistency.cs
@@ -60,8 +60,8 @@ namespace ProjectHealthTest
 							}
 
 							XmlAttribute packageIdAtt = packageNode.Attributes[PACKAGE_NAME];
+							Assert.True(packageIdAtt!=null, $"{fileInfo.FullName} contains an invalid Package Id for a packageReference");
 							string packageId = packageIdAtt.Value;
-							Assert.True(packageId!=null, $"{fileInfo.FullName} contains an invalid Package Id for a packageReference");
 							XmlAttribute packageVersionAtt = packageNode.Attributes[PACKAGE_VERSION_ATTRIBUTE_NAME];
 							Assert.True(packageVersionAtt!=null, $"{fileInfo.FullName} contains an invalid Package Version for a packageReference");
 							string packageVersion = packageVersionAtt.Value;

--- a/dotnet/test/ProjectHealthTest/PackageVersionsConsistency.cs
+++ b/dotnet/test/ProjectHealthTest/PackageVersionsConsistency.cs
@@ -31,10 +31,15 @@ namespace ProjectHealthTest
 		/// - Fail this test if any referenced package has referenced to more than one version accross projects
 		/// - Output a message mentioning the different versions for each package 
 		/// </summary>
+		[Fact(Skip = "Transitive dependencies disabled while it does not success")]
+		public void TestPackageVersionConsistencyAcrossNETProjectsAndTransitives()
+		{
+			TestPackageVersionConsistencyAcrossProjects(NET6, true);
+		}
 		[Fact]
 		public void TestPackageVersionConsistencyAcrossNETProjects()
 		{
-			TestPackageVersionConsistencyAcrossProjects(NET6, true);
+			TestPackageVersionConsistencyAcrossProjects(NET6, false);
 		}
 		[Fact]
 		public void TestPackageVersionConsistencyAcrossNETFrameworkProjects()

--- a/dotnet/test/ProjectHealthTest/PackageVersionsConsistency.cs
+++ b/dotnet/test/ProjectHealthTest/PackageVersionsConsistency.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Xml;
+using System;
+using Xunit;
+using System.Linq;
+
+namespace ProjectHealthTest
+{
+	public class PackageVersionTest
+	{
+		private const string PROJECTS = "*.csproj";
+
+		private const string PACKAGES_NODE_NAME = "Project/ItemGroup/PackageReference";
+		private const string PACKAGE_NAME = "Include";
+		private const string SRC_DIR = @"..\..\..\..\..\src";
+		private const string PACKAGE_VERSION_ATTRIBUTE_NAME = "Version";
+		private const string TARGET_FRAMEWORK = "Project/PropertyGroup/TargetFramework";
+		private const string TARGET_FRAMEWORKS = "Project/PropertyGroup/TargetFrameworks";
+		private const string NET6 = "net6";
+		private const string NET_FRAMEWORK = "net462";
+
+		/// <summary>
+		/// Tests that all referenced packages have the same version by doing:
+		/// - Get all projects files contained in the backend with a given targetFramework
+		/// - Retrieve the id and version of all packages
+		/// - Fail this test if any referenced package has referenced to more than one version accross projects
+		/// - Output a message mentioning the different versions for each package 
+		/// </summary>
+		[Fact]
+		public void TestPackageVersionConsistencyAcrossNETProjects()
+		{
+			TestPackageVersionConsistencyAcrossProjects(NET6);
+		}
+		[Fact]
+		public void TestPackageVersionConsistencyAcrossNETFrameworkProjects()
+		{
+			TestPackageVersionConsistencyAcrossProjects(NET_FRAMEWORK);
+		}
+		private void TestPackageVersionConsistencyAcrossProjects(string targetFramework)
+		{
+			IDictionary<string, ICollection<PackageVersionItem>> packageVersionsById = new Dictionary<string, ICollection<PackageVersionItem>>();
+			foreach (string packagesConfigFilePath in GetAllProjects())
+			{
+				FileInfo fileInfo = new FileInfo(packagesConfigFilePath);
+				XmlDocument doc = new XmlDocument();
+				doc.Load(fileInfo.FullName);
+
+				if (IsTargetFramework(doc, targetFramework))
+				{
+					XmlNodeList packagesNodes = doc.SelectNodes(PACKAGES_NODE_NAME);
+					if (packagesNodes != null)
+					{
+						foreach (XmlNode packageNode in packagesNodes)
+						{
+							if (packageNode.Attributes == null)
+							{
+								continue;
+							}
+
+							XmlAttribute packageIdAtt = packageNode.Attributes[PACKAGE_NAME];
+							string packageId = packageIdAtt.Value;
+							Assert.True(packageId!=null, $"{fileInfo.FullName} contains an invalid Package Id for a packageReference");
+							XmlAttribute packageVersionAtt = packageNode.Attributes[PACKAGE_VERSION_ATTRIBUTE_NAME];
+							Assert.True(packageVersionAtt!=null, $"{fileInfo.FullName} contains an invalid Package Version for a packageReference");
+							string packageVersion = packageVersionAtt.Value;
+
+							if (!packageVersionsById.TryGetValue(packageId, out ICollection<PackageVersionItem> packageVersions))
+							{
+								packageVersions = new List<PackageVersionItem>();
+								packageVersionsById.Add(packageId, packageVersions);
+							}
+
+							if (!packageVersions.Any(o => o.Version.Equals(packageVersion, StringComparison.OrdinalIgnoreCase)))
+							{
+								packageVersions.Add(new PackageVersionItem()
+								{
+									SourceFile = fileInfo.FullName,
+									Version = packageVersion
+								});
+							}
+
+						}
+					}
+				}
+			}
+
+			List<KeyValuePair<string, ICollection<PackageVersionItem>>> packagesWithIncoherentVersions = packageVersionsById.Where(kv => kv.Value.Count > 1).ToList();
+
+			string errorMessage = string.Empty;
+			if (packagesWithIncoherentVersions.Any())
+			{
+				errorMessage = $"Some referenced packages have incoherent versions:{Environment.NewLine}";
+				foreach (KeyValuePair<string, ICollection<PackageVersionItem>> packagesWithIncoherentVersion in packagesWithIncoherentVersions)
+				{
+					string packageName = packagesWithIncoherentVersion.Key;
+					string packageVersions = string.Join("\n  ", packagesWithIncoherentVersion.Value);
+					errorMessage += $"{packageName}:\n  {packageVersions}\n\n";
+				}
+			}
+
+			Assert.True(packagesWithIncoherentVersions.Count == 0, errorMessage);
+		}
+
+		private bool IsTargetFramework(XmlDocument doc, string targetFramework)
+		{
+			XmlNode targetFrameworkNode = doc.SelectSingleNode(TARGET_FRAMEWORK);
+			if (targetFrameworkNode == null)
+			{
+				targetFrameworkNode = doc.SelectSingleNode(TARGET_FRAMEWORKS);
+			}
+			if (targetFrameworkNode != null)
+			{
+				return targetFrameworkNode.InnerText.Contains(targetFramework, StringComparison.OrdinalIgnoreCase);
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		private static IEnumerable<string> GetAllProjects()
+		{
+			return Directory.GetFiles(SRC_DIR, PROJECTS, SearchOption.AllDirectories);
+		}
+	}
+
+	public class PackageVersionItem
+	{
+		public string SourceFile { get; set; }
+		public string Version { get; set; }
+
+		public override string ToString()
+		{
+			return $"{Version} in {SourceFile}";
+		}
+	}
+}

--- a/dotnet/test/ProjectHealthTest/ProjectHealthTest.csproj
+++ b/dotnet/test/ProjectHealthTest/ProjectHealthTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Issue:96837
A unit test fails when different package versions are being found in any project of the same TargetFramework.
This is a temporary solution. Seems to be better using the [Central package management](https://devblogs.microsoft.com/nuget/introducing-central-package-management/) which requires VS 2012 17.2 and .NET 6.0.300.