### PR TITLE
Fix error System.IO.InvalidDataException: Multipart body length limit

### DIFF
--- a/dotnet/src/dotnetcore/GxClasses.Web/Middleware/HandlerFactory.cs
+++ b/dotnet/src/dotnetcore/GxClasses.Web/Middleware/HandlerFactory.cs
@@ -33,7 +33,6 @@ namespace GeneXus.HttpHandlerFactory
 	public class HandlerFactory
 	{
 		private static readonly ILog log = log4net.LogManager.GetLogger(typeof(GeneXus.HttpHandlerFactory.HandlerFactory));
-		private readonly AppSettings _appSettings;
 		private string _basePath;
 		static Dictionary<string, Type> _aspxObjects = new Dictionary<string, Type>(){
 												{"gxoauthlogout",typeof(GXOAuthLogout)},
@@ -64,14 +63,13 @@ namespace GeneXus.HttpHandlerFactory
 		public HandlerFactory()
 		{
 		}
-		public HandlerFactory(RequestDelegate next, IOptions<AppSettings> appSettings)
+		public HandlerFactory(RequestDelegate next)
 		{
-			_appSettings = appSettings.Value; 
+		
 		}
-		public HandlerFactory(RequestDelegate next, IOptions<AppSettings> appSettings, String basePath)
+		public HandlerFactory(RequestDelegate next, String basePath)
 		{
 			_basePath = basePath;
-			_appSettings = appSettings.Value;
 		}
 
 

--- a/dotnet/src/dotnetcore/GxClasses.Web/Middleware/HandlerFactory.cs
+++ b/dotnet/src/dotnetcore/GxClasses.Web/Middleware/HandlerFactory.cs
@@ -20,6 +20,7 @@ namespace GeneXus.HttpHandlerFactory
 		public BaseUrls BaseUrls { get; set; }
 		public bool AnalyticsEnabled { get; set; }
 		public int SessionTimeout { get; set; }
+		public int MaxFileUploadSize { get; set; }
 	}
 
 	public class BaseUrls

--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -94,7 +94,7 @@ namespace GeneXus.Application
 
 		static readonly ILog log = log4net.LogManager.GetLogger(typeof(Startup));
 		const int DEFAULT_SESSION_TIMEOUT_MINUTES = 20;
-		const int DEFAULT_MAX_FILE_UPLOAD_SIZE_BYTES = 500000000;
+		const int DEFAULT_MAX_FILE_UPLOAD_SIZE_BYTES = 528000000;
 		public static string VirtualPath = string.Empty;
 		public static string LocalPath = Directory.GetCurrentDirectory();
 

--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Net;
 using System.Threading.Tasks;
 using GeneXus.Configuration;
@@ -9,7 +8,6 @@ using GeneXus.Http;
 using GeneXus.HttpHandlerFactory;
 using GeneXus.Services;
 using GeneXus.Utils;
-using GxClasses.Helpers;
 using GxClasses.Web.Middleware;
 using log4net;
 using Microsoft.AspNetCore;
@@ -18,6 +16,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.AspNetCore.Routing;
@@ -95,6 +94,7 @@ namespace GeneXus.Application
 
 		static readonly ILog log = log4net.LogManager.GetLogger(typeof(Startup));
 		const int DEFAULT_SESSION_TIMEOUT_MINUTES = 20;
+		const int DEFAULT_MAX_FILE_UPLOAD_SIZE_BYTES = 500000000;
 		public static string VirtualPath = string.Empty;
 		public static string LocalPath = Directory.GetCurrentDirectory();
 
@@ -144,6 +144,10 @@ namespace GeneXus.Application
 			AppSettings settings = new AppSettings();
 			Config.ConfigRoot.GetSection("AppSettings").Bind(settings);
 
+			services.Configure<FormOptions>(options =>
+			{
+				options.MultipartBodyLengthLimit = settings.MaxFileUploadSize==0 ? DEFAULT_MAX_FILE_UPLOAD_SIZE_BYTES : settings.MaxFileUploadSize;
+			});
 			ISessionService sessionService = GXSessionServiceFactory.GetProvider();
 
 			if (sessionService != null)


### PR DESCRIPTION
Fix error: Multipart body length limit 134217728 exceeded making that limit configurable and with a default of 500MB instead of 128MB
Issue:94849