### PR TITLE
Runtime parameters were not properly handled.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataADO.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataADO.cs
@@ -1301,7 +1301,7 @@ namespace GeneXus.Data.ADO
 		public int ImgIdx { get; set; }
 		public bool Nullable { get; set; }
 		public bool ChkEmpty { get; set; }
-		public bool Return { get; set; }
+		public bool Return { get; set; }//Runtime parameters
 		public bool InDB { get; set; }
 		public bool AddAtt { get; set; }
 		public bool Preload { get; set; }

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTier.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTier.cs
@@ -184,80 +184,91 @@ namespace GeneXus.Data.NTier
 					parmsValues[idxParmCollection - 1] = parms[idx];
 					if (!valueIsNull)
 					{
-						switch (pdef.GxType)
+						if (pdef.Return)
 						{
-							case GXType.Char:
-							case GXType.NChar:
-							case GXType.VarChar:
-								if (pdef.AddAtt && !pdef.Preload)
-								{
-									if (!string.IsNullOrEmpty(pdef.Tbl) && !string.IsNullOrEmpty(pdef.Fld))
-										stmt.SetParameterMultimedia(idxParmCollection, (string)parms[idx], (string)parmsValues[pdef.ImgIdx], pdef.Tbl, pdef.Fld);
-									else
-										stmt.SetParameterMultimedia(idxParmCollection, (string)parms[idx], (string)parmsValues[pdef.ImgIdx]);
-								}
-								else
-								{
-									if (pdef.GxType == GXType.VarChar)
+							stmt.SetParameterRT(pdef.Name, (string)parms[idx]);
+						}
+						else
+						{
+							switch (pdef.GxType)
+							{
+								case GXType.Char:
+								case GXType.NChar:
+								case GXType.VarChar:
+									if (pdef.AddAtt && !pdef.Preload)
 									{
-										if (pdef.ChkEmpty)
-											stmt.SetParameterVChar(idxParmCollection, (string)parms[idx]);
+										if (!string.IsNullOrEmpty(pdef.Tbl) && !string.IsNullOrEmpty(pdef.Fld))
+											stmt.SetParameterMultimedia(idxParmCollection, (string)parms[idx], (string)parmsValues[pdef.ImgIdx], pdef.Tbl, pdef.Fld);
 										else
-											stmt.SetParameterObj(idxParmCollection, parms[idx]); 
+											stmt.SetParameterMultimedia(idxParmCollection, (string)parms[idx], (string)parmsValues[pdef.ImgIdx]);
 									}
 									else
 									{
-										if (pdef.ChkEmpty)
-											stmt.SetParameterChar(idxParmCollection, (string)parms[idx]);
+										if (pdef.GxType == GXType.VarChar)
+										{
+											if (pdef.ChkEmpty)
+												stmt.SetParameterVChar(idxParmCollection, (string)parms[idx]);
+											else
+												stmt.SetParameterObj(idxParmCollection, parms[idx]);
+										}
 										else
-											stmt.SetParameter(idxParmCollection, (string)parms[idx]);
+										{
+											if (pdef.ChkEmpty)
+												stmt.SetParameterChar(idxParmCollection, (string)parms[idx]);
+											else
+												stmt.SetParameter(idxParmCollection, (string)parms[idx]);
+										}
 									}
-								}
-								break;
-							case GXType.NVarChar:
-								if (pdef.ChkEmpty)
-									stmt.SetParameterVChar(idxParmCollection, (string)parms[idx]);
-								else
-									stmt.SetParameter(idxParmCollection, (string)parms[idx]);
-								break;
-							case GXType.NClob:
-							case GXType.Clob:
-							case GXType.LongVarChar:
-								if (pdef.ChkEmpty)
-									stmt.SetParameterLVChar(idxParmCollection, (string)parms[idx]);
-								else
-									stmt.SetParameter(idxParmCollection, (string)parms[idx]);
-								break;
-							case GXType.DateAsChar:
-							case GXType.Date:
-								stmt.SetParameter(idxParmCollection, (DateTime)parms[idx]);
-								break;
-							case GXType.DateTime:
-								stmt.SetParameterDatetime(idxParmCollection, (DateTime)parms[idx]);
-								break;
-							case GXType.DateTime2:
-								stmt.SetParameterDatetime(idxParmCollection, (DateTime)parms[idx], true);
-								break;
-							case GXType.Blob:
-								stmt.SetParameterBlob(idxParmCollection, (string)parms[idx], pdef.InDB);
-								break;
-							case GXType.UniqueIdentifier:
-								stmt.SetParameter(idxParmCollection, (Guid)parms[idx]);
-								break;
-							case GXType.Geography:
-							case GXType.Geopoint:
-							case GXType.Geoline:
-							case GXType.Geopolygon:
-								stmt.SetParameter(idxParmCollection, (Geospatial)parms[idx], pdef.GxType);
-								break;
-							default:
-								stmt.SetParameterObj(idxParmCollection, parms[idx]);
-								break;
+									break;
+								case GXType.NVarChar:
+									if (pdef.ChkEmpty)
+										stmt.SetParameterVChar(idxParmCollection, (string)parms[idx]);
+									else
+										stmt.SetParameter(idxParmCollection, (string)parms[idx]);
+									break;
+								case GXType.NClob:
+								case GXType.Clob:
+								case GXType.LongVarChar:
+									if (pdef.ChkEmpty)
+										stmt.SetParameterLVChar(idxParmCollection, (string)parms[idx]);
+									else
+										stmt.SetParameter(idxParmCollection, (string)parms[idx]);
+									break;
+								case GXType.DateAsChar:
+								case GXType.Date:
+									stmt.SetParameter(idxParmCollection, (DateTime)parms[idx]);
+									break;
+								case GXType.DateTime:
+									stmt.SetParameterDatetime(idxParmCollection, (DateTime)parms[idx]);
+									break;
+								case GXType.DateTime2:
+									stmt.SetParameterDatetime(idxParmCollection, (DateTime)parms[idx], true);
+									break;
+								case GXType.Blob:
+									stmt.SetParameterBlob(idxParmCollection, (string)parms[idx], pdef.InDB);
+									break;
+								case GXType.UniqueIdentifier:
+									stmt.SetParameter(idxParmCollection, (Guid)parms[idx]);
+									break;
+								case GXType.Geography:
+								case GXType.Geopoint:
+								case GXType.Geoline:
+								case GXType.Geopolygon:
+									stmt.SetParameter(idxParmCollection, (Geospatial)parms[idx], pdef.GxType);
+									break;
+								default:
+									stmt.SetParameterObj(idxParmCollection, parms[idx]);
+									break;
+							}
 						}
 					}
 				Increment:
 					idx += 1;
-					idxParmCollection += 1;
+					if (!pdef.Return)
+					{
+						idxParmCollection += 1;
+					}
+
 				}
 				catch (InvalidCastException ex)
 				{

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTierADO.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTierADO.cs
@@ -883,10 +883,10 @@ namespace GeneXus.Data.NTier.ADO
 					{
 						foreach (ParDef p in ptb)
 						{
+							_gxDbCommand.ParmDefinition.Add(p);
 							if (p.Return)
 								continue;
 							_gxDbCommand.AddParameter(p.Name, p.GxType, p.Size, p.Scale);
-							_gxDbCommand.ParmDefinition.Add(p);
 							pos++;
 						}
 					}
@@ -907,8 +907,6 @@ namespace GeneXus.Data.NTier.ADO
 					{
 						foreach (ParDef p in ptb)
 						{
-							if (p.Return)
-								continue;
 							_dynamicParameters.Add(p);
 							pos++;
 						}


### PR DESCRIPTION
Keep the name Return since renaming it implies a compatibility issue: Return property of parameters (PDef) should be renamed to "Runtime".
Issue:96892