### PR TITLE
Fix Empty date json serialization on rest services

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -2297,6 +2297,20 @@ namespace GeneXus.Utils
 			}
 			return emptyDT.ToString();
 		}
+		static string FormatEmptyJsonDate(string pic)
+		{
+			StringBuilder emptyDT = new StringBuilder(pic);
+			emptyDT.Replace('d', '0');
+			emptyDT.Replace('M', '0');
+			emptyDT.Replace('y', '0');
+
+			emptyDT.Replace('m', '0');
+			emptyDT.Replace('s', '0');
+			emptyDT.Replace('f', '0');
+			emptyDT.Replace('h', '0');
+			emptyDT.Replace('H', '0');
+			return emptyDT.ToString();
+		}
 		string TimeFormatFromSDT(String S, String TSep, bool allowsOneDigitTime)
 		{
 			int pos1, pos2, pos3, tSize, ampmFmt;
@@ -2550,6 +2564,13 @@ namespace GeneXus.Utils
 				return ("0000-00-00");
 			else
 				return dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+		}
+		internal static string DToC2(DateTime dt, string format)
+		{
+			if (dt == nullDate)
+				return FormatEmptyJsonDate(format);
+			else
+				return dt.ToString(format, CultureInfo.InvariantCulture);
 		}
 		public static DateTime CToD2(string value)
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -745,13 +745,7 @@ namespace GeneXus.Application
 				object strVal = null;
 				if (parameters[key].GetType() == typeof(DateTime))
 				{
-					DateTime udt = ((DateTime)parameters[key]).ToUniversalTime();
-					if (fmtParameters.ContainsKey(key) && !String.IsNullOrEmpty(fmtParameters[key]))
-					{
-						strVal = udt.ToString(fmtParameters[key], CultureInfo.InvariantCulture);
-					}
-					else
-						strVal = udt;
+					strVal = SerializeDateTime((DateTime)parameters[key], key, fmtParameters);
 				}				
 				else
 					strVal = parameters[key];
@@ -775,14 +769,8 @@ namespace GeneXus.Application
 					}
 					if (kv.Value.GetType() == typeof(DateTime))
 					{
-						DateTime udt = ((DateTime)kv.Value).ToUniversalTime();
-						if (fmtParameters.ContainsKey(kv.Key) && !String.IsNullOrEmpty(fmtParameters[kv.Key]))
-						{
-							object strVal = udt.ToString(fmtParameters[kv.Key], CultureInfo.InvariantCulture);
-							serializablePars.Add(strKey, strVal);
-						}
-						else
-							serializablePars.Add(strKey, udt);
+						object strVal = SerializeDateTime((DateTime)kv.Value, kv.Key, fmtParameters);
+						serializablePars.Add(strKey, strVal);
 					}
 					else
 						serializablePars.Add(strKey, kv.Value);
@@ -792,6 +780,18 @@ namespace GeneXus.Application
 			_httpContext.Response.Write(json); //Use intermediate StringWriter in order to avoid chunked response
 			return Task.CompletedTask;
 		}
+
+		private object SerializeDateTime(DateTime dt, string key, Dictionary<string, string> fmtParameters)
+		{
+			DateTime udt = (dt==DateTimeUtil.NullDate()) ? dt: dt.ToUniversalTime();
+			
+			if (fmtParameters.ContainsKey(key) && !String.IsNullOrEmpty(fmtParameters[key]))
+			{
+				return DateTimeUtil.DToC2(udt, fmtParameters[key]);
+			}
+			return udt;
+		}
+
 		private bool PrimitiveType(Type type)
 		{
 			return type.IsPrimitive || type == typeof(string) || type.IsValueType;


### PR DESCRIPTION
Empty dates were serialized as 0001-01-01 instead of 0000-00-00 on .NET (core) rest services.
Issue:90500