### PR TITLE
Use Signature V4 for AWS S3 & bump AWSSDK to latest version

### DIFF
--- a/dotnet/src/dotnetcore/Providers/Storage/GXAmazonS3/GXAmazonS3.csproj
+++ b/dotnet/src/dotnetcore/Providers/Storage/GXAmazonS3/GXAmazonS3.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.9.21" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/dotnetcore/Providers/Storage/GXAmazonS3/GXAmazonS3.csproj
+++ b/dotnet/src/dotnetcore/Providers/Storage/GXAmazonS3/GXAmazonS3.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.3.15" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/dotnetframework/Providers/Storage/GXAmazonS3/ExternalProviderS3.cs
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXAmazonS3/ExternalProviderS3.cs
@@ -96,6 +96,13 @@ namespace GeneXus.Storage.GXAmazonS3
 				config.ServiceURL = Endpoint;
 				customEndpoint = true;
 			}
+			else
+			{
+				if (region == Amazon.RegionEndpoint.USEast1)
+				{
+					Amazon.AWSConfigsS3.UseSignatureVersion4 = true;
+				}
+			}
 
 #if NETCORE
 			if (credentials != null)

--- a/dotnet/src/dotnetframework/Providers/Storage/GXAmazonS3/GXAmazonS3.csproj
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXAmazonS3/GXAmazonS3.csproj
@@ -7,7 +7,7 @@
 		<PackageId>GeneXus.Amazon</PackageId>
 	</PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.3.15" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.24" />
     <PackageReference Include="log4net" Version="2.0.11" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Bump AWSSDK.S3 to latest Version
- Set forced use of Signature V4 for AWS for us-east-1.  **

Only for Region 'us-east-1', the SDK does not use Signature V4, instead uses SigV2 (for compatibility reasons) that we don't need:

`Configures if the S3 client should use Signature Version 4 signing with requests. By default, this setting is set to true which will use Signature Version 4 for all requests except presigned URL requests when the region is set to us-east-1. When UseSignatureVersion4 is explicitly set to true by directly setting this property or directly setting this property through configuration, Signature Version 4 will be used for all requests when able to do so. When this setting is false, Signature Version 2 will be used. Note that when the setting is false, Signature Version 4 may still be used by default in some cases or with some regions.`

https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Amazon/TAWSConfigsS3.html
