### PR TITLE
Issue91042 generics

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
@@ -2684,10 +2684,12 @@ namespace GeneXus.Utils
 
 		static Type GetEnumerableType(Type type)
 		{
-#if !NETCORE
-			if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
-				return type.GetGenericArguments()[0];
-#endif
+			if (type.IsGenericType)
+			{
+				return type.GetInterfaces()
+					.FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+					?.GetGenericArguments()[0];
+			}
 			return null;
 		}
 


### PR DESCRIPTION
fix GetEnumerableType to work with Net6 and to support types implementing multiple interfaces (one one which should be IEnumerable)