### PR TITLE
Unify GXWebSocket endpoint across al Generators as '/gxwebsocket'

### DIFF
--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -337,7 +337,8 @@ namespace GeneXus.Application
 			app.UseWebSockets();
 			string basePath = string.IsNullOrEmpty(VirtualPath) ? string.Empty : $"/{VirtualPath}";
 			Config.ScriptPath = basePath;
-			app.MapWebSocketManager($"{basePath}/gxwebsocket.svc");
+			app.MapWebSocketManager($"{basePath}/gxwebsocket.svc"); //Compatibility reasons.
+			app.MapWebSocketManager($"{basePath}/gxwebsocket");
 
 			app.MapWhen(
 				context => IsAspx(context, basePath),

--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -81,10 +81,11 @@ namespace GeneXus.Application
 		{
 			return builder.UseMiddleware<HandlerFactory>(basePath);
 		}
-		public static IApplicationBuilder MapWebSocketManager(this IApplicationBuilder app,
-															  PathString path)
+		public static IApplicationBuilder MapWebSocketManager(this IApplicationBuilder app, string basePath)
 		{
-			return app.Map(path, (_app) => _app.UseMiddleware<Notifications.WebSocket.WebSocketManagerMiddleware>());
+			return app
+					.Map($"{basePath}/gxwebsocket"    , (_app) => _app.UseMiddleware<Notifications.WebSocket.WebSocketManagerMiddleware>())
+					.Map($"{basePath}/gxwebsocket.svc", (_app) => _app.UseMiddleware<Notifications.WebSocket.WebSocketManagerMiddleware>()); //Compatibility reasons. Remove in the future.
 		}
 	}
   
@@ -337,8 +338,7 @@ namespace GeneXus.Application
 			app.UseWebSockets();
 			string basePath = string.IsNullOrEmpty(VirtualPath) ? string.Empty : $"/{VirtualPath}";
 			Config.ScriptPath = basePath;
-			app.MapWebSocketManager($"{basePath}/gxwebsocket.svc"); //Compatibility reasons.
-			app.MapWebSocketManager($"{basePath}/gxwebsocket");
+			app.MapWebSocketManager(basePath);
 
 			app.MapWhen(
 				context => IsAspx(context, basePath),


### PR DESCRIPTION
Until now, the GX WebSocket Server URL Endpoint was different depending on the Generator:

- Java: /gxwebsocket
- DotNet: /gxwebsoket.svc

Now we use the same endpoint "gxwebsocket" for all generators.

> 'gxwebsoket.svc' still supported for compatibility reasons. We should remove it in the future

Issue: 97680
