### PR TITLE
Fix release package version calculation

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -78,9 +78,10 @@ jobs:
         }
 
         $COMMIT_NUMBER = @($(git rev-list --count origin/master..), $(git rev-list --count HEAD))[$IsPrerelease]
-        echo "COMMIT_NUMBER=$COMMIT_NUMBER" >> $env:GITHUB_ENV
+        $COMMIT_MESSAGE = $(git log -1 --pretty=%B)
+        $LAST_COMMITTER = $(git log -1 --pretty=format:%an)
 
-        $GetFileVersionOutput = dotnet msbuild dotnet/Directory.Build.props /t:GetFileVersionForPackage
+        $GetFileVersionOutput = dotnet msbuild dotnet/Directory.Build.props /t:GetFileVersionForPackage /p:COMMIT_NUMBER=$COMMIT_NUMBER
         "$GetFileVersionOutput" -match "(?<=FileVersion:)(.*)" > $null
         $GetFileVersionOutput = $Matches[0]
         
@@ -93,9 +94,6 @@ jobs:
         }
         
         Write-Output "Packge version to be used: $NUGET_PACKAGE_VERSION"
-
-        $COMMIT_MESSAGE = $(git log -1 --pretty=%B)
-        $LAST_COMMITTER = $(git log -1 --pretty=format:%an)
 
         echo "NUGET_PACKAGE_VERSION=$NUGET_PACKAGE_VERSION" >> $env:GITHUB_ENV
         echo "IsPrerelease=$IsPrerelease" >> $env:GITHUB_ENV

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -77,6 +77,9 @@ jobs:
           }
         }
 
+        $COMMIT_NUMBER = @($(git rev-list --count origin/master..), $(git rev-list --count HEAD))[$IsPrerelease]
+        echo "COMMIT_NUMBER=$COMMIT_NUMBER" >> $env:COMMIT_NUMBER
+
         $GetFileVersionOutput = dotnet msbuild dotnet/Directory.Build.props /t:GetFileVersionForPackage
         "$GetFileVersionOutput" -match "(?<=FileVersion:)(.*)" > $null
         $GetFileVersionOutput = $Matches[0]
@@ -91,7 +94,6 @@ jobs:
         
         Write-Output "Packge version to be used: $NUGET_PACKAGE_VERSION"
 
-        $COMMIT_NUMBER = @($(git rev-list --count origin/master..), $(git rev-list --count HEAD))[$IsPrerelease]
         $COMMIT_MESSAGE = $(git log -1 --pretty=%B)
         $LAST_COMMITTER = $(git log -1 --pretty=format:%an)
 

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -78,7 +78,7 @@ jobs:
         }
 
         $COMMIT_NUMBER = @($(git rev-list --count origin/master..), $(git rev-list --count HEAD))[$IsPrerelease]
-        echo "COMMIT_NUMBER=$COMMIT_NUMBER" >> $env:COMMIT_NUMBER
+        echo "COMMIT_NUMBER=$COMMIT_NUMBER" >> $env:GITHUB_ENV
 
         $GetFileVersionOutput = dotnet msbuild dotnet/Directory.Build.props /t:GetFileVersionForPackage
         "$GetFileVersionOutput" -match "(?<=FileVersion:)(.*)" > $null


### PR DESCRIPTION
The `COMMIT_NUMBER` property was not being correctly passed to the MSBuild task that needed it.

Issue:97727