### PR TITLE
Unify version used of Google.Apis package.

### DIFF
--- a/dotnet/src/dotnetcore/Projects/StoreManager/StoreManager.csproj
+++ b/dotnet/src/dotnetcore/Projects/StoreManager/StoreManager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 		<TargetFrameworks>net6.0</TargetFrameworks>
@@ -26,12 +26,12 @@
     <Folder Include="Store\Platforms\" />
   </ItemGroup>
 
-  <ItemGroup>
-	<PackageReference Include="Google.Apis" Version="1.42.0" />
-    <PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.42.0.1766"/>
-    <PackageReference Include="Google.Apis.Auth" Version="1.42.0" />
-    <PackageReference Include="Google.Apis.Core" Version="1.42.0" />    
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Google.Apis" Version="1.57.0" />
+		<PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.57.0.2741" />
+		<PackageReference Include="Google.Apis.Auth" Version="1.57.0" />
+		<PackageReference Include="Google.Apis.Core" Version="1.57.0" />
+	</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\GxClasses\GxClasses.csproj" />

--- a/dotnet/src/dotnetcore/Providers/Storage/GXGoogleCloudNetCore/GXGoogleCloudNetCore.csproj
+++ b/dotnet/src/dotnetcore/Providers/Storage/GXGoogleCloudNetCore/GXGoogleCloudNetCore.csproj
@@ -14,8 +14,9 @@
 	</ItemGroup>
 
   <ItemGroup>
-		<PackageReference Include="Google.Apis.Storage.v1" Version="1.42.0.1744" />
-		<PackageReference Include="Google.Cloud.Storage.V1" Version="2.0.0" />
+		<PackageReference Include="Google.Apis" Version="1.57.0" />
+		<PackageReference Include="Google.Apis.Storage.v1" Version="1.57.0.2685" />
+		<PackageReference Include="Google.Cloud.Storage.V1" Version="4.0.0" />
 		
 	</ItemGroup>
 

--- a/dotnet/src/dotnetframework/Projects/StoreManager/StoreManager.csproj
+++ b/dotnet/src/dotnetframework/Projects/StoreManager/StoreManager.csproj
@@ -9,10 +9,10 @@
 		<PackageId>GeneXus.StoreManager</PackageId>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Google.Apis" Version="1.42.0" />
-		<PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.42.0.1766"/>
-		<PackageReference Include="Google.Apis.Auth" Version="1.42.0" />
-		<PackageReference Include="Google.Apis.Core" Version="1.42.0" />
+		<PackageReference Include="Google.Apis" Version="1.57.0" />
+		<PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.57.0.2741" />
+		<PackageReference Include="Google.Apis.Auth" Version="1.57.0" />
+		<PackageReference Include="Google.Apis.Core" Version="1.57.0" />
 		<PackageReference Include="log4net" Version="2.0.11" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="Zlib.Portable.Signed" Version="1.11.0" />

--- a/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/GXGoogleCloud.csproj
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/GXGoogleCloud.csproj
@@ -8,15 +8,12 @@
 	</PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="BouncyCastle" Version="1.7.0" />
-    <PackageReference Include="Google.Api.Gax" Version="2.0.0" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="2.0.0" />
-    <PackageReference Include="Google.Apis" Version="1.42.0" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.42.0" />
-    <PackageReference Include="Google.Apis.Core" Version="1.42.0" />
-    <PackageReference Include="Google.Apis.Storage.v1" Version="1.27.1.881" />
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="2.0.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Google.Api.Gax" Version="4.0.0" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="4.0.0" />
+    <PackageReference Include="Google.Apis" Version="1.57.0" />
+    <PackageReference Include="Google.Apis.Storage.v1" Version="1.57.0.2685" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Fix the error:
System.IO.FileLoadException: Could not load file or assembly 'Google.Apis, Version=1.27.1.0, Culture=neutral
when using Google.Cloud.Storage.V1 2.0.0.
Issue:97404