### PR TITLE
Avoid validation of options.password when using private key file on SFTP connection.

### DIFF
--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusSftp/Sftp/SftpClient.cs
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusSftp/Sftp/SftpClient.cs
@@ -51,27 +51,19 @@ namespace Sftp.GeneXusSftp
                 return false;
             }
             bool useKey = false;
-            if (SecurityUtils.compareStrings("", options.KeyPath) || SecurityUtils.compareStrings("", options.User) || SecurityUtils.compareStrings("", options.KeyPassword))
-            {
-                useKey = false;
-                if (SecurityUtils.compareStrings("", options.User)
-                        || SecurityUtils.compareStrings("", options.Password))
-                {
+            if (!SecurityUtils.compareStrings("", options.KeyPath) )
+				{
+					useKey = true;
+				}else
+				{
+					if (SecurityUtils.compareStrings("", options.User)
+							|| SecurityUtils.compareStrings("", options.Password))
+					{
 
-                    this.error.setError("SF001", "Authentication misconfiguration");
-                    return false;
-                }
-                else
-                {
-                    useKey = false;
-                }
-            }
-            else
-            {
-                useKey = true;
-            }
-
-
+						this.error.setError("SF001", "Authentication misconfiguration. Missing user or password");
+						return false;
+					}
+				}
 
             if (SecurityUtils.compareStrings("", options.Host))
             {
@@ -318,9 +310,6 @@ namespace Sftp.GeneXusSftp
 
                 PrivateKeyFile keyFile = new PrivateKeyFile(options.KeyPath, options.KeyPassword);
                 method.Add(new PrivateKeyAuthenticationMethod(options.User, keyFile));
-
-
-
             }
             else
             {

--- a/dotnet/src/extensions/SecurityAPI/test/dotnetcore/SecurityAPITestNetCore/SecurityAPITestNetCore.csproj
+++ b/dotnet/src/extensions/SecurityAPI/test/dotnetcore/SecurityAPITestNetCore/SecurityAPITestNetCore.csproj
@@ -49,6 +49,7 @@
     <Compile Include="..\..\dotnetframework\SecurityAPITest\SecurityAPICommons\keys\TestBase64PrivateKey.cs" Link="SecurityAPICommons\keys\TestBase64PrivateKey.cs" />
     <Compile Include="..\..\dotnetframework\SecurityAPITest\SecurityAPICommons\keys\TestBase64PublicKey.cs" Link="SecurityAPICommons\keys\TestBase64PublicKey.cs" />
     <Compile Include="..\..\dotnetframework\SecurityAPITest\Sftp\TestSftp.cs" Link="Sftp\TestSftp.cs" />
+	<Compile Include="..\..\dotnetframework\SecurityAPITest\Sftp\TestLoginWithKeyWithoutPassword.cs" Link="Sftp\TestLoginWithKeyWithoutPassword.cs" />
     <Compile Include="..\..\dotnetframework\SecurityAPITest\XmlSignature\DSig\TestBase64Certificate.cs" Link="XmlSignature\DSig\TestBase64Certificate.cs" />
     <Compile Include="..\..\dotnetframework\SecurityAPITest\XmlSignature\DSig\TestFindID.cs" Link="XmlSignature\DSig\TestFindID.cs" />
     <Compile Include="..\..\dotnetframework\SecurityAPITest\XmlSignature\DSig\TestRSASigning.cs" Link="XmlSignature\DSig\TestRSASigning.cs" />

--- a/dotnet/src/extensions/SecurityAPI/test/dotnetframework/SecurityAPITest/Sftp/TestLoginWithKeyWithoutPassword.cs
+++ b/dotnet/src/extensions/SecurityAPI/test/dotnetframework/SecurityAPITest/Sftp/TestLoginWithKeyWithoutPassword.cs
@@ -1,0 +1,74 @@
+using SecurityAPITest.SecurityAPICommons.commons;
+using NUnit.Framework;
+using Sftp.GeneXusSftp;
+using System.IO;
+using System;
+
+namespace SecurityAPITest.Sftp
+{
+	[TestFixture]
+	[RunIfRunSettingsConfigured]
+	public class TestLoginWithKeyWithoutPassword : SecurityAPITestObject
+	{
+		protected static string host;
+		protected static string user;
+		protected static string keyPath;
+		protected static string keyPassword;
+		protected static string localPath;
+		protected static string remoteDir;
+		protected static string remoteFilePath;
+		protected static string localDir;
+
+
+		[SetUp]
+		public virtual void SetUp()
+		{
+
+			host = TestContextParameter("gx_ftp_host");
+			user = TestContextParameter("gx_sftp_user");
+			string known_hosts_content_base64 = TestContextParameter("gx_ftp_known_hosts_content_base64");
+			keyPath = Path.Combine(BASE_PATH, "Temp", "sftptest", "key", "id_rsa");
+			string id_rsaConentBase64 = TestContextParameter("gx_ftp_id_rsa_content_base64");
+			File.WriteAllBytes(keyPath, Convert.FromBase64String(id_rsaConentBase64));
+			keyPassword = TestContextParameter("gx_sftp_key_password");
+			localPath = Path.Combine(BASE_PATH, "Temp", "sftptest", "sftptest1.txt");
+			remoteDir = "sftp";
+			remoteFilePath = "sftp/sftptest1.txt";
+			localDir = Path.Combine(BASE_PATH, "Temp", "sftptest", "back");
+		}
+
+		private SftpClient TestConnection(SftpOptions options)
+		{
+			SftpClient client = new SftpClient();
+			bool connected = client.Connect(options);
+			True(connected, client);
+			return client;
+		}
+
+		private void TestPut(SftpClient client)
+		{
+			bool put = client.Put(localPath, remoteDir);
+			True(put, client);
+		}
+
+		private void TestGet(SftpClient client)
+		{
+			bool get = client.Get(remoteFilePath, localDir);
+			True(get, client);
+		}
+
+		[Test]
+		public void TestWithKey()
+		{
+			SftpOptions options = new SftpOptions();
+			options.Host = host;
+			options.User = user;
+			options.AllowHostKeyChecking = false;
+			options.KeyPassword = keyPassword;
+			SftpClient client = TestConnection(options);
+			TestPut(client);
+			TestGet(client);
+			client.Disconnect();
+		}
+	}
+}


### PR DESCRIPTION
issue#98118
Avoid validation of options.password when using private key file.
#GXSEC