### PR TITLE
Use version 3.7 of Google APIs

### DIFF
--- a/dotnet/src/dotnetframework/Projects/StoreManager/StoreManager.csproj
+++ b/dotnet/src/dotnetframework/Projects/StoreManager/StoreManager.csproj
@@ -9,7 +9,7 @@
 		<PackageId>GeneXus.StoreManager</PackageId>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.57.0.2741" />
+		<PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.55.0.2582" />
 		<PackageReference Include="log4net" Version="2.0.11" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="Zlib.Portable.Signed" Version="1.11.0" />

--- a/dotnet/src/dotnetframework/Projects/StoreManager/StoreManager.csproj
+++ b/dotnet/src/dotnetframework/Projects/StoreManager/StoreManager.csproj
@@ -9,10 +9,7 @@
 		<PackageId>GeneXus.StoreManager</PackageId>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Google.Apis" Version="1.57.0" />
 		<PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.57.0.2741" />
-		<PackageReference Include="Google.Apis.Auth" Version="1.57.0" />
-		<PackageReference Include="Google.Apis.Core" Version="1.57.0" />
 		<PackageReference Include="log4net" Version="2.0.11" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="Zlib.Portable.Signed" Version="1.11.0" />

--- a/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/ExternalProviderGoogle.cs
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/ExternalProviderGoogle.cs
@@ -49,6 +49,19 @@ namespace GeneXus.Storage.GXGoogleCloud
 
 		public ExternalProviderGoogle(GXService providerService) : base(providerService)
 		{
+#if NETFRAMEWORK
+			AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+			{
+				if (args.Name.StartsWith(nameof(Google)))
+				{
+					int sep = args.Name.IndexOf(',');
+					if (sep != -1)
+						return System.Reflection.Assembly.Load(args.Name.Remove(sep));
+				}
+
+				return null;
+			};
+#endif
 			Initialize();
 		}
 

--- a/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/GXGoogleCloud.csproj
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/GXGoogleCloud.csproj
@@ -8,11 +8,10 @@
 	</PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax" Version="4.0.0" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="4.0.0" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="3.7.0" />
     <PackageReference Include="Google.Apis" Version="1.57.0" />
     <PackageReference Include="Google.Apis.Storage.v1" Version="1.57.0.2685" />
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.0.0" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="3.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/GXGoogleCloud.csproj
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/GXGoogleCloud.csproj
@@ -8,9 +8,6 @@
 	</PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax.Rest" Version="3.7.0" />
-    <PackageReference Include="Google.Apis" Version="1.57.0" />
-    <PackageReference Include="Google.Apis.Storage.v1" Version="1.57.0.2685" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="3.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/app.config
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/app.config
@@ -1,34 +1,30 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Storage.v1" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.27.1.888" newVersion="1.27.1.888" />
+        <bindingRedirect oldVersion="0.0.0.0-1.55.0.2526" newVersion="1.55.0.2526" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.28.0.0" newVersion="1.28.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.55.0.0" newVersion="1.55.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.28.0.0" newVersion="1.28.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.55.0.0" newVersion="1.55.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.PlatformServices" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.28.0.0" newVersion="1.28.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.55.0.0" newVersion="1.55.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Api.Gax" publicKeyToken="3ec5ea7f18953e47" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.6.0.0" newVersion="3.6.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Auth" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.28.0.0" newVersion="1.28.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.55.0.0" newVersion="1.55.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />


### PR DESCRIPTION
This is so that Microsoft.BCL.AsyncInterfaces is resolved to version 5.0.0 instead of 6.0.0, which conflicts with the rest of .NET Framework standard classes.

Issue:98027
Issue:97404