### PR TITLE
Override System.Security.Cryptography.Pkcs on GxExcel

### DIFF
--- a/dotnet/src/dotnetcore/GxExcel/GxExcel.csproj
+++ b/dotnet/src/dotnetcore/GxExcel/GxExcel.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="4.5.3.2" />
     <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
issue#96794
Override System.Security.Cryptography.Pkcs dependency of EPPlus to version 6.0.0 on GxExcel
