### PR TITLE
Add test project to check dependency version consistency.

### DIFF
--- a/dotnet/DotNetStandardClasses.sln
+++ b/dotnet/DotNetStandardClasses.sln
@@ -209,10 +209,14 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeneXus.Programs.Common", "src\extensions\Azure\test\GeneXus.Programs.Common\GeneXus.Programs.Common.csproj", "{DCEC0B38-93B6-4003-81E6-9FBC2BB4F163}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GXAmazonSQS", "src\dotnetcore\Providers\Messaging\GXAmazonSQS\GXAmazonSQS.csproj", "{F8BA0D65-267D-491F-BFAB-33F5E5B61AD7}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "apiattractions", "src\extensions\Azure\test\apiattractions\apiattractions.csproj", "{E85FDB0F-FA81-4CDD-8BF3-865269CE2DB3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectHealthTest", "test\ProjectHealthTest\ProjectHealthTest.csproj", "{65048104-212A-4819-AECF-89CA9C08C83F}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetRedisTest", "test\DotNetRedisTest\DotNetRedisTest.csproj", "{48430E50-043A-47A2-8278-B86A4420758A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VersionConsistencyTest", "test\VersionConsistencyTest\VersionConsistencyTest.csproj", "{7D5068C7-B5ED-4F1A-873C-E403600ECDAF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -520,6 +524,10 @@ Global
 		{48430E50-043A-47A2-8278-B86A4420758A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48430E50-043A-47A2-8278-B86A4420758A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48430E50-043A-47A2-8278-B86A4420758A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D5068C7-B5ED-4F1A-873C-E403600ECDAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D5068C7-B5ED-4F1A-873C-E403600ECDAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D5068C7-B5ED-4F1A-873C-E403600ECDAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D5068C7-B5ED-4F1A-873C-E403600ECDAF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -624,6 +632,7 @@ Global
 		{E85FDB0F-FA81-4CDD-8BF3-865269CE2DB3} = {7BA5A2CE-7992-4F87-9D84-91AE4D046F5A}
 		{65048104-212A-4819-AECF-89CA9C08C83F} = {1D6F1776-FF4B-46C2-9B3D-BC46CCF049DC}
 		{48430E50-043A-47A2-8278-B86A4420758A} = {1D6F1776-FF4B-46C2-9B3D-BC46CCF049DC}
+		{7D5068C7-B5ED-4F1A-873C-E403600ECDAF} = {1D6F1776-FF4B-46C2-9B3D-BC46CCF049DC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E18684C9-7D76-45CD-BF24-E3944B7F174C}

--- a/dotnet/src/dotnetcore/GxExcel/GxExcel.csproj
+++ b/dotnet/src/dotnetcore/GxExcel/GxExcel.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="4.5.3.2" />
     <PackageReference Include="log4net" Version="2.0.11" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/dotnetcore/GxExcel/GxExcel.csproj
+++ b/dotnet/src/dotnetcore/GxExcel/GxExcel.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="4.5.3.2" />
     <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/test/VersionConsistencyTest/Program.cs
+++ b/dotnet/test/VersionConsistencyTest/Program.cs
@@ -1,0 +1,18 @@
+using System;
+using GeneXus.Mail;
+using GeneXus.Office.ExcelGXEPPlus;
+
+public class TestVersionConsistency
+{
+	public static void Main(string[] args)
+	{
+		ExcelDocument eppPlusDocument = new ExcelDocument();
+		Console.WriteLine($"ExcelDocument default path:{eppPlusDocument.DefaultPath}");
+
+		GXPOP3Session mailkitSession = new GXPOP3Session();
+		mailkitSession.Host = "localhost";
+		mailkitSession.Logout();
+
+
+	}
+}

--- a/dotnet/test/VersionConsistencyTest/VersionConsistencyTest.csproj
+++ b/dotnet/test/VersionConsistencyTest/VersionConsistencyTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+	<!--ItemGroup>
+    <PackageReference Include="GeneXus.Classes.Web.Core" Version="1.19.5" />
+    <PackageReference Include="GeneXus.Excel.Core" Version="1.19.5" />
+    <PackageReference Include="GeneXus.Mail.Core" Version="1.19.5" />
+  </ItemGroup-->
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\dotnetcore\GxClasses.Web\GxClasses.Web.csproj" />
+    <ProjectReference Include="..\..\src\dotnetcore\GxExcel\GxExcel.csproj" />
+    <ProjectReference Include="..\..\src\dotnetcore\GxMail\GxMail.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
In particular the case of System.Security.Cryptography.Pkcs
GxExcel references the version 4.0.3.2 (through transitive dependency)
And GXMail references version 6.0.0 through MimeKit reference.