### PR TITLE
Move SmartCacheProvider property from IGxDataStore to IDataStoreProvider

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataADO.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataADO.cs
@@ -2431,6 +2431,7 @@ namespace GeneXus.Data.ADO
 				return context.GetOlsonTimeZone();
 			}		
 		}
+		[Obsolete("GxDataStore.SmartCacheProvider is deprecated, use DataStoreProvider.SmartCacheProvider instead", false)]
         public GxSmartCacheProvider SmartCacheProvider
         {
             get

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
@@ -171,6 +171,7 @@ namespace GeneXus.Data
         string UserId {get;}
 		short ErrCode {get;}
 		string ErrDescription {get;}      
+		[Obsolete("IGxDataStore.SmartCacheProvider is deprecated, use IDataStoreProvider.SmartCacheProvider instead", false)]
         GxSmartCacheProvider SmartCacheProvider {get;}
 		OlsonTimeZone ClientTimeZone { get; }
         void CloseConnections();

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTier.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTier.cs
@@ -37,6 +37,7 @@ namespace GeneXus.Data.NTier
         DateTime serverNow();
 		DateTime serverNowMs();
 		string userId();
+		GxSmartCacheProvider SmartCacheProvider { get; }
     }
 
 	public interface IRemoteDataStoreProvider
@@ -380,7 +381,13 @@ namespace GeneXus.Data.NTier
 			dataStoreRequestCount++;
 
 		}
-
+		public GxSmartCacheProvider SmartCacheProvider
+		{
+			get
+			{
+				return _ds.SmartCacheProvider;
+			}
+		}
 		ICursor getCursor( int cursor)
 		{
 			return _cursor[cursor];


### PR DESCRIPTION
IDataStoreProvider encapsulates the IGxDataStore instance which can change when datastore name changes.
Issue:93010