### PR TITLE
Support ExcelCell.BackColor for ExcelDocument

### DIFF
--- a/dotnet/src/dotnetframework/GxExcel/GxExcelEPPlus.cs
+++ b/dotnet/src/dotnetframework/GxExcel/GxExcelEPPlus.cs
@@ -831,7 +831,11 @@ namespace GeneXus.Office.ExcelGXEPPlus
 
                     System.Drawing.Color color = System.Drawing.Color.FromArgb(red, green, blue);
 
-                    pCells[i].Style.Fill.BackgroundColor.SetColor(color);
+					if (pCells[i].Style.Fill.PatternType == ExcelFillStyle.None)
+					{
+						pCells[i].Style.Fill.PatternType = ExcelFillStyle.Solid;
+					}
+					pCells[i].Style.Fill.BackgroundColor.SetColor(color);
                 }
                 
             }

--- a/dotnet/src/dotnetframework/GxExcel/GxExcelEPPlus.cs
+++ b/dotnet/src/dotnetframework/GxExcel/GxExcelEPPlus.cs
@@ -824,20 +824,12 @@ namespace GeneXus.Office.ExcelGXEPPlus
 
                 for (int i = 1; i <= cntCells; i++)
                 {
-                    int val = (int)value;
-                    int red = val >> 16 & 0xff;
-                    int green = val >> 8 & 0xff;
-                    int blue = val & 0xff;
-
-                    System.Drawing.Color color = System.Drawing.Color.FromArgb(red, green, blue);
-
 					if (pCells[i].Style.Fill.PatternType == ExcelFillStyle.None)
 					{
 						pCells[i].Style.Fill.PatternType = ExcelFillStyle.Solid;
 					}
-					pCells[i].Style.Fill.BackgroundColor.SetColor(color);
-                }
-                
+					pCells[i].Style.Fill.BackgroundColor.SetColor(GXExcelHelper.ResolveColor(value));
+                }                
             }
         }
 


### PR DESCRIPTION
New: Support for ExcelCell BackColor. 

```
&ExcelDocument.Cells(1,1, 3, 3).BackColor = RGB(25,4, 189)
```

