### PR TITLE
Waiting for submitted threads to end is limited now to command line context

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -5821,9 +5821,20 @@ namespace GeneXus.Utils
 				ThreadPool.QueueUserWorkItem(
 					arg =>
 					{
-						callbak(state);
-						resetEvent.Set();
-						events.TryRemove(eventGuid, out ManualResetEvent _);
+						try
+						{
+							callbak(state);
+						}
+						catch (Exception ex)
+						{
+							GXLogging.Error(log, "Error on submit of " + state.GetType(), ex);
+							throw;
+						}
+						finally
+						{
+							resetEvent.Set();
+							events.TryRemove(eventGuid, out ManualResetEvent _);
+						}
 
 					});
 				events[eventGuid]= resetEvent;

--- a/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
@@ -91,7 +91,7 @@ namespace GeneXus.Procedure
 		}
 		private void exitApplication(bool flushBatchCursor)
 		{
-			if (IsMain && !(context as GxContext).IsSubmited)
+			if (!(GxContext.IsHttpContext || GxContext.IsRestService) && IsMain && !(context as GxContext).IsSubmited)
 				ThreadUtil.WaitForEnd();
 
 			if (flushBatchCursor)


### PR DESCRIPTION
Exclude ThreadUtil.WaitForEnd() -it waits for all submitted threads to end- from the web context where it can lead to a deadlock when a web object calls another hosted service (p.e. Rest service) in the same working process, using an intermediate submit call.
Issue:99024