### PR TITLE
Fix Crash ExcelFile.Save() when bounded to not existent External File

### DIFF
--- a/dotnet/src/dotnetframework/GxExcel/GxExcelEPPlus.cs
+++ b/dotnet/src/dotnetframework/GxExcel/GxExcelEPPlus.cs
@@ -57,17 +57,16 @@ namespace GeneXus.Office.ExcelGXEPPlus
                         fileName += Constants.EXCEL2007Extension;
                     }
 					if (file.IsExternalFile)
-					{
+					{						
 						Stream stream = file.GetStream();
+
 						if (stream != null)
 						{
-							p = new ExcelPackage(file.GetStream());
+							p = new ExcelPackage(stream);
 						}
 						else
 						{
-							errCod = 4;
-							errDescription = "Invalid file.";
-							return errCod;
+							p = new ExcelPackage();
 						}
 					}
 					else


### PR DESCRIPTION
When an ExcelFile is bounded to a External Storage File, the External File may no exist as the Developer wants to create a new one. 

After PR 661, we were throwing an Invalid File error, instead of creating the file and saving it into the External Storage.


Issue: 99628

Side effect: https://github.com/genexuslabs/DotNetClasses/pull/661