### PR TITLE
Avoid XSS Security Issues due to SPA redirects

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -34,6 +34,7 @@ namespace GeneXus.Http
 	using GeneXus.Web.Security;
 	using System.Linq;
 	using System.Reflection.PortableExecutable;
+	using System.Web;
 #else
 	using System.Web;
 	using System.Web.UI;
@@ -1568,7 +1569,7 @@ namespace GeneXus.Http
 				context.httpAjaxContext.AddStylesHidden();
 				if (IsSpaRequest())
 				{
-					context.WriteHtmlTextNl("<script>gx.ajax.saveJsonResponse(" + context.getJSONResponse() + ");</script>");
+					context.WriteHtmlTextNl("<script>gx.ajax.saveJsonResponse('" + GXUtil.HtmlEncodeInputValue(HttpUtility.JavaScriptStringEncode(context.getJSONResponse())) + "');</script>");
 				}
 				else
 				{


### PR DESCRIPTION
Do not send raw json unencoded to client because some html special characters will break SinglePage Application parsing introducing possible XSS attacks. 

Issue: 99580