### PR TITLE
Session recovery after an application encryption key renewal was not working in .NET.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -1537,17 +1537,24 @@ namespace GeneXus.Http
 			SendResponseStatus((int)statusCode, string.Empty);
 		}
 
+
+#if !NETCORE
 		protected void SendResponseStatus(int statusCode, string statusDescription)
 		{
 			context.HttpContext.Response.StatusCode = statusCode;
-#if !NETCORE
 			if (!string.IsNullOrEmpty(statusDescription))
 				context.HttpContext.Response.StatusDescription = statusDescription;
-#endif
 			this.setAjaxCallMode();
 			this.disableOutput();
 		}
-
+#else
+		protected override void SendResponseStatus(int statusCode, string statusDescription)
+		{
+			context.HttpContext.Response.StatusCode = statusCode;
+			this.setAjaxCallMode();
+			this.disableOutput();
+		}
+#endif
 		private void SendReferer()
 		{
 			context.httpAjaxContext.ajax_rsp_assign_hidden("sCallerURL", context.GetReferer());

--- a/dotnet/src/dotnetframework/GxClasses/Model/GXBaseObject.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/GXBaseObject.cs
@@ -142,10 +142,17 @@ namespace GeneXus.Application
 			}
 			catch (InvalidKeyException)
 			{
+				context.SetCookie("GX_SESSION_ID", string.Empty, string.Empty, DateTime.MinValue, string.Empty, context.GetHttpSecure());
 				GXLogging.Error(log, "440 Invalid encryption key");
+				SendResponseStatus(440, "Session timeout");
 			}
 			return sRet;
 		}
+		protected virtual void SendResponseStatus(int statusCode, string statusDescription)
+		{
+			context.HttpContext.Response.StatusCode = statusCode;
+		}
+
 		protected string UriEncrypt64(string value, string key)
 		{
 			return Encrypt64(value, key, true);
@@ -164,7 +171,9 @@ namespace GeneXus.Application
 			}
 			catch (InvalidKeyException)
 			{
+				context.SetCookie("GX_SESSION_ID", string.Empty, string.Empty, DateTime.MinValue, string.Empty, context.GetHttpSecure());
 				GXLogging.Error(log, "440 Invalid encryption key");
+				SendResponseStatus(440, "Session timeout");
 			}
 			return sRet;
 		}

--- a/dotnet/src/dotnetframework/GxClasses/Model/GXBaseObject.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/GXBaseObject.cs
@@ -1,4 +1,3 @@
-using GeneXus.Diagnostics;
 using GeneXus.Encryption;
 using GeneXus.Http;
 using GeneXus.Utils;


### PR DESCRIPTION
Fix the 403 forbidden error that happens after a deployment that changes the application encryption key.
Issue:99531