### PR TITLE
Move handleException method to base class to make it visible from BCs in .NET

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -2723,11 +2723,12 @@ namespace GeneXus.Http
 		{
 			((GxContext)this.context).ClearJavascriptSources();
 		}
-
+#if !NETCORE
 		public virtual void handleException(String gxExceptionType, String gxExceptionDetails, String gxExceptionStack)
 		{
 
 		}
+#endif
 
 		private Diagnostics.GXDebugInfo dbgInfo;
 		protected void initialize(int objClass, int objId, int dbgLines, long hash)

--- a/dotnet/src/dotnetframework/GxClasses/Model/GXBaseObject.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/GXBaseObject.cs
@@ -53,6 +53,7 @@ namespace GeneXus.Application
 		protected virtual GAMSecurityLevel IntegratedSecurityLevel { get { return 0; } }
 		protected virtual bool IsSynchronizer { get { return false; } }
 		protected virtual string ExecutePermissionPrefix { get { return String.Empty; } }
+		public virtual void handleException(String gxExceptionType, String gxExceptionDetails, String gxExceptionStack) { }
 
 		public virtual void CallWebObject(string url)
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
@@ -317,10 +317,6 @@ namespace GeneXus.Procedure
 			context.wjLoc = url;
 		}
 
-		public virtual void handleException(String gxExceptionType, String gxExceptionDetails, String gxExceptionStack)
-		{
-		}
-
 		private Diagnostics.GXDebugInfo dbgInfo;
 		protected void initialize(int objClass, int objId, int dbgLines, long hash)
 		{


### PR DESCRIPTION
Issue:99922
It fixes error CS0115: 'xx_bc.handleException(string, string, string)': no suitable method found to override