### PR TITLE
Fix null reference exception at SendResponseStatus at GXProcedure

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Model/GXBaseObject.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/GXBaseObject.cs
@@ -150,7 +150,6 @@ namespace GeneXus.Application
 		}
 		protected virtual void SendResponseStatus(int statusCode, string statusDescription)
 		{
-			context.HttpContext.Response.StatusCode = statusCode;
 		}
 
 		protected string UriEncrypt64(string value, string key)


### PR DESCRIPTION
When Encrypt64 fails.
SendResponseStatus at GXBaseObject does not have an httpcontext when called from GXProcedures. When called from web objects, the overridden at GXHttpHandler is used.

Side effect of #707