### PR TITLE
Store submitted threads events at context level.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -447,6 +447,7 @@ namespace GeneXus.Application
 			_errorHandlerInfo = new GxErrorHandlerInfo();
 			setContext(this);
 			httpContextVars = new GxHttpContextVars();
+			_threadEvents = new ConcurrentDictionary<Guid, ManualResetEvent>();
 			GXLogging.Debug(log, "GxContext.Ctr Default handle:", () => _handle.ToString());
 		}
 		public GxContext(int handle, string location)
@@ -561,6 +562,10 @@ namespace GeneXus.Application
 			}
 			return new CookieContainer();
 		}
+		[NonSerialized]
+		ConcurrentDictionary<Guid, ManualResetEvent> _threadEvents;
+		internal ConcurrentDictionary<Guid, ManualResetEvent> Events { get { return _threadEvents; } set { _threadEvents = value; } }
+
 
 		[NonSerialized]
 		static GxContext _currentGxContext;
@@ -3852,7 +3857,7 @@ namespace GeneXus.Application
 
 		public GXSOAPContext SoapContext { get; set; }
 
-#endregion
+		#endregion
 	}
 	public class GxXmlContext
 	{

--- a/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
@@ -194,7 +194,7 @@ namespace GeneXus.Procedure
 		}
 		protected void Submit(Action<object> executeMethod, object state)
 		{
-			ThreadUtil.Submit(PropagateCulture(new WaitCallback(executeMethod)), state);
+			ThreadUtil.Submit(PropagateCulture(new WaitCallback(executeMethod)), state, context);
 		}
 
 	}

--- a/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
@@ -67,7 +67,8 @@ namespace GeneXus.Procedure
 		}
 		protected void Submit(Action<object> executeMethod, object state)
 		{
-			ThreadUtil.Submit(PropagateCulture(new WaitCallback(executeMethod)), state);
+
+			ThreadUtil.Submit(PropagateCulture(new WaitCallback(executeMethod)), state, context);
 		}
 		public static WaitCallback PropagateCulture(WaitCallback action)
 		{
@@ -92,7 +93,7 @@ namespace GeneXus.Procedure
 		private void exitApplication(bool flushBatchCursor)
 		{
 			if (!(GxContext.IsHttpContext || GxContext.IsRestService) && IsMain && !(context as GxContext).IsSubmited)
-				ThreadUtil.WaitForEnd();
+				ThreadUtil.WaitForEnd(context);
 
 			if (flushBatchCursor)
 			{

--- a/dotnet/test/DotNetCoreUnitTest/Submit/SubmitTest.cs
+++ b/dotnet/test/DotNetCoreUnitTest/Submit/SubmitTest.cs
@@ -40,7 +40,7 @@ namespace UnitTesting
 				proc.executeSubmit();
 			}
 			cleanup();
-			ThreadUtil.WaitForEnd();//Force WaitForEnd since tests run in web context when running in parallel with Middleware tests
+			ThreadUtil.WaitForEnd(context);//Force WaitForEnd since tests run in web context when running in parallel with Middleware tests
 			Assert.Equal(THREAD_NUMBER, SubmitTest.numbers.Count);
 		}
 		public override void cleanup()


### PR DESCRIPTION
It fixes the infinite waiting when a webpanel calls via submit to a proc that executes a new procedure main X in a new context. So when X finishes, it tries to wait for pending threads, because the condition: if (!(GxContext.IsHttpContext || GxContext.IsRestService) && IsMain && !(context as GxContext).IsSubmited) is true for X.
And the pending thread is the same that started X, so it never ends. With Events stored at context level, when a proc finishes, it waits for the threads started at its context only.
Issue:99515