### PR TITLE
Store the MainContext of command line executions. 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -307,6 +307,10 @@ namespace GeneXus.Application
 		}
 	}
 #endif
+	internal class GxApplication
+	{
+		internal static GxContext MainContext { get; set; }
+	}
 	[Serializable]
 	public class GxContext : IGxContext
 	{
@@ -448,6 +452,8 @@ namespace GeneXus.Application
 			setContext(this);
 			httpContextVars = new GxHttpContextVars();
 			GXLogging.Debug(log, "GxContext.Ctr Default handle:", () => _handle.ToString());
+			if (GxApplication.MainContext == null && !(IsHttpContext || GxContext.IsRestService))
+				GxApplication.MainContext = this;
 		}
 		public GxContext(int handle, string location)
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
@@ -46,7 +46,6 @@ namespace GeneXus.Procedure
 		private DateTime beginExecute;
 		private ProcedureInfo pInfo;
 #endif
-		
 		public GXProcedure()
 		{
 #if !NETCORE
@@ -56,10 +55,10 @@ namespace GeneXus.Procedure
 				beginExecute = DateTime.Now;
 				pInfo = ProceduresInfo.addProcedureInfo(name);
 				pInfo.incCount();
-				
 			}
 #endif
 		}
+
 		public bool DisconnectAtCleanup
 		{
 			get{ return disconnectUserAtCleanup;}
@@ -91,7 +90,7 @@ namespace GeneXus.Procedure
 		}
 		private void exitApplication(bool flushBatchCursor)
 		{
-			if (!(GxContext.IsHttpContext || GxContext.IsRestService) && IsMain && !(context as GxContext).IsSubmited)
+			if (!(GxContext.IsHttpContext || GxContext.IsRestService) && IsMain && GxApplication.MainContext==context)
 				ThreadUtil.WaitForEnd();
 
 			if (flushBatchCursor)


### PR DESCRIPTION
Only main context must wait for unfinished submit threads.
It solves the case of deadlock when a submitted thread executes an external object that is a generated proc that executes in the same way as if it were a Main procedure.
It will be improved soon making main procedures extend GXMainProcedure<T> to hold the RealMainProgram.
Issue:99515

