### PR TITLE
Remove password parameter from strings sent to log since it is unnecessary

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
@@ -949,7 +949,7 @@ namespace GeneXus.Data
 		}
 
 		public virtual int MaxNumberOfValuesInList => int.MaxValue;
-
+		protected const string NaV = "xxxxx";
 		public string ConnectionStringForLog()
 		{
 			string result="";
@@ -1584,7 +1584,7 @@ namespace GeneXus.Data
 					m_connectionString=BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
 			}
 
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", ()=> BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 			MssqlConnectionWrapper connection=new MssqlConnectionWrapper(m_connectionString,connectionCache, isolationLevel);
 
 			m_FailedConnections = 0;

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataDb2.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataDb2.cs
@@ -166,7 +166,7 @@ namespace GeneXus.Data
 		{
 			if (m_connectionString == null)
 				m_connectionString=BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", () => BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 
 			return new Db2ConnectionWrapper(m_connectionString,connectionCache, isolationLevel);
 		}

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataDb2400.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataDb2400.cs
@@ -223,7 +223,7 @@ namespace GeneXus.Data
 		{
 			if (m_connectionString == null)
 				m_connectionString=BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", () => BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 
 			return new Db2ISeriesConnectionWrapper(m_connectionString,connectionCache, isolationLevel);
 		}
@@ -854,7 +854,7 @@ namespace GeneXus.Data
 		{
 			if (m_connectionString == null)
 				m_connectionString = BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", ()=> BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 
 			return new Db2ISeriesHISConnectionWrapper(m_connectionString, connectionCache, isolationLevel);
 		}

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataHana.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataHana.cs
@@ -60,7 +60,7 @@ namespace GeneXus.Data
         {
             if (m_connectionString == null)
                 m_connectionString = BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", () => BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 
             return new HanaConnectionWrapper(m_connectionString, connectionCache, isolationLevel);
         }

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataInformix.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataInformix.cs
@@ -142,7 +142,7 @@ namespace GeneXus.Data
 		{
 			if (m_connectionString == null)
 				m_connectionString = BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", () => BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 
 			return new InformixConnectionWrapper(m_connectionString, connectionCache, isolationLevel);
 		}

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataMysqlConnector.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataMysqlConnector.cs
@@ -44,7 +44,7 @@ namespace GeneXus.Data
 		{
 			if (m_connectionString == null)
 				m_connectionString = BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", () => BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 			m_FailedConnections = 0;
 			return new MySqlConnectorConnectionWrapper(m_connectionString, connectionCache, isolationLevel);
 		}

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataMysqlDriverCS.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataMysqlDriverCS.cs
@@ -32,7 +32,7 @@ namespace GeneXus.Data
 		{
 			if (m_connectionString == null)
 				m_connectionString = BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", () => BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 			m_FailedConnections = 0;
 			return new MySqlDriverCSConnectionWrapper(m_connectionString, connectionCache, isolationLevel);
 		}

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTierService.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataNTierService.cs
@@ -116,7 +116,7 @@ namespace GeneXus.Data.NTier
 		{
 			if (string.IsNullOrEmpty(m_connectionString))
 				m_connectionString = BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", () => BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 
 			return new ServiceConnectionWrapper(m_ServiceType, m_connectionString, connectionCache, isolationLevel, DataSource);
 		}

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataOracle.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataOracle.cs
@@ -289,7 +289,7 @@ namespace GeneXus.Data
 				if (m_connectionString == null)
 					m_connectionString = BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
 			}
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", () => BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 			return new OracleConnectionWrapper(m_connectionString, connectionCache, isolationLevel);
 		}
 		protected override string BuildConnectionString(string datasourceName, string userId,
@@ -609,7 +609,7 @@ namespace GeneXus.Data
 				if (m_connectionString == null)
 					m_connectionString = BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
 			}
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", () => BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 			return new OracleManagedConnectionWrapper(m_connectionString, connectionCache, isolationLevel);
 		}
 
@@ -873,7 +873,7 @@ namespace GeneXus.Data
 				if (m_connectionString == null)
 					m_connectionString = BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
 			}
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", ()=> BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 			return new MSOracleConnectionWrapper(m_connectionString, connectionCache, isolationLevel);
 		}
 #else

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
@@ -73,7 +73,7 @@ namespace GeneXus.Data
 		{
 			if (m_connectionString == null)
 				m_connectionString = BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", () => BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 			return new PostgresqlConnectionWrapper(m_connectionString, connectionCache, isolationLevel);
 		}
 		string convertToSqlCall(string stmt, GxParameterCollection parameters)

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataSqlite.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataSqlite.cs
@@ -32,7 +32,7 @@ namespace GeneXus.Data
 		{
 			if (m_connectionString == null)
 				m_connectionString = BuildConnectionString(datasourceName, userId, userPassword, databaseName, port, schema, extra);
-			GXLogging.Debug(log, "Setting connectionString property ", ConnectionStringForLog);
+			GXLogging.Debug(log, "Setting connectionString property ", () => BuildConnectionString(datasourceName, userId, NaV, databaseName, port, schema, extra));
 			SQLiteConnectionWrapper connection = new SQLiteConnectionWrapper(m_connectionString, connectionCache, isolationLevel);
 			m_FailedConnections = 0;
 			return connection;


### PR DESCRIPTION
It fixes a Privacy Violation which is a false positive since password is not printed to trace.