### PR TITLE
Change method to get extension of a file to avoid Fortify Path Manipulation issue

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -3528,8 +3528,7 @@ namespace GeneXus.Utils
 			}
 			catch
 			{
-				FileInfo fi = new FileInfo(FileName); //Local file that do not exist
-				extension = fi.Extension;
+				extension = Path.GetExtension(FileName); //Local file that do not exist
 			}
 			int extStart = extension.LastIndexOf('.');
 			if (extStart == -1)

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
@@ -344,11 +344,8 @@ namespace GeneXus.Http
 				var pf = GetFormFile(httpContext, varName);
 				if (pf != null)
 				{
-#pragma warning disable SCS0018 // Path traversal: injection possible in {1} argument passed to '{0}'
-					FileInfo fi = new FileInfo(pf.FileName);
-#pragma warning restore SCS0018 // Path traversal: injection possible in {1} argument passed to '{0}'
 					string tempDir = Preferences.getTMP_MEDIA_PATH();
-					string ext = fi.Extension;
+					string ext = Path.GetExtension(pf.FileName);
 					if (ext != null)
 						ext = ext.TrimStart('.');
 					filePath = FileUtil.getTempFileName(tempDir);


### PR DESCRIPTION
Issue:100622
Fix https://github.com/genexuslabs/DotNetClasses/security/code-scanning/284