### PR TITLE
Fix working directory of fully qualified shell files 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses.Win/Process/CommandLine.cs
+++ b/dotnet/src/dotnetframework/GxClasses.Win/Process/CommandLine.cs
@@ -129,11 +129,7 @@ namespace GeneXus.Utils
 					//If WorkingDirectory is an empty string, the current directory is understood to contain the executable.
 					try
 					{
-						if (Path.IsPathRooted(file))
-						{
-							p.StartInfo.WorkingDirectory = Path.GetDirectoryName(file);
-						}
-						else
+						if (!Path.IsPathRooted(file))
 						{
 							p.StartInfo.WorkingDirectory = GxContext.StaticPhysicalPath();
 						}

--- a/dotnet/test/DotNetUnitTest/Domain/ShellTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/ShellTest.cs
@@ -34,5 +34,23 @@ namespace xUnitTesting
 			int errorCode = GXUtil.Shell($"'{fileName}'  test", 1, 1);
 			Assert.Equal(0, errorCode);
 		}
+		[Fact]
+		public void WorkingDirForFullQualifiedBat()
+		{
+			string pathName = Directory.GetParent(Directory.GetCurrentDirectory()).FullName; //bat is in a different directory to the current dir
+			string fileName = Path.Combine(pathName, "TestCurrentDir.bat");
+			string outputFileName = Path.Combine(Directory.GetCurrentDirectory(), "output.txt"); //Current dir of the process must be the main current dir
+			File.WriteAllText(fileName, "cd > output.txt");
+			if (File.Exists(outputFileName))
+			{
+				File.Delete(outputFileName);
+			}
+			int errorCode = GXUtil.Shell($"{fileName}", 1, 0);
+			string outputTxt = File.ReadAllText(outputFileName);
+			Assert.Equal(Directory.GetCurrentDirectory(), outputTxt.Trim());
+			Assert.Equal(0, errorCode);
+		}
+
 	}
+	
 }


### PR DESCRIPTION
Issue:100626
It was changed by mistake at #709 
Before that change, the working directory of PathRooted files and no modal (i.e. UseShellExecute = true) worked like empty since it had double delimiters making an invalid value.