### PR TITLE
Add characters to LogUserEntryWhiteList 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -509,7 +509,7 @@ namespace GeneXus.Utils
 		const char QMARK = '_';
 		static char[] numbersAndSep = new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9', '-' };
 		static char[] numbers = new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
-		internal static Dictionary<char, char> LogUserEntryWhiteList = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789+-_=/".ToDictionary(item => item, item => item);
+		internal static Dictionary<char, char> LogUserEntryWhiteList = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789+-_=/[]{}\":, ".ToDictionary(item => item, item => item);
 		internal static Dictionary<char, char> HostWhiteList = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789./".ToDictionary(item => item, item => item);
 
 		internal static string Sanitize(string input, Dictionary<char, char> WhiteList)


### PR DESCRIPTION
Add characters to LogUserEntryWhiteList to keep legible log entries when printing json data and white spaces.
Issue:100583