### PR TITLE
Restore intermediate XMLReader used when deserializing. 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Helpers/XMLHelper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/XMLHelper.cs
@@ -81,7 +81,10 @@ namespace GeneXus.Utils
 				{
 					using (StringReader sr = new StringReader(serialized))
 					{
-						deserialized = (T)(xmls.Deserialize(sr));
+						using (XmlReader xmlReader = XmlReader.Create(sr, new XmlReaderSettings { CheckCharacters = false }))
+						{
+							deserialized = (T)xmls.Deserialize(xmlReader);
+						}
 					}
 				}
 				catch (InvalidOperationException ex)


### PR DESCRIPTION
It was lost by mistake on #739
Issue:100898