### PR TITLE
Upgrade version of Swashbuckle.AspNetCore.SwaggerUI from 6.2.3 to 6.5.0

### DIFF
--- a/dotnet/src/dotnetcore/GxNetCoreStartup/GxNetCoreStartup.csproj
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/GxNetCoreStartup.csproj
@@ -15,7 +15,7 @@
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.4" />
 		<PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="3.1.3" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="3.1.7" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.2.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
 	</ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GxClasses.Web\GxClasses.Web.csproj" />


### PR DESCRIPTION
Due to known vulnerabilities.
Issue:100940