### PR TITLE
Catch any Exception when handling execute method at legacy HttpClient

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -756,6 +756,7 @@ namespace GeneXus.Http.Client
 		{
 			if (UseOldHttpClient(name))
 			{
+				GXLogging.Debug(log, "Using legacy GxHttpClient");
 				WebExecute(method, name);
 			}
 			else
@@ -1188,6 +1189,13 @@ namespace GeneXus.Http.Client
 				}
 			}
 #endif
+			catch (Exception e)
+			{
+				GXLogging.Warn(log, "Error Execute", e);
+				_errCode = 1;
+				_errDescription = e.Message;
+			}
+
 
 			_receiveData = Array.Empty<byte>();
 			if (resp != null)

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -744,10 +744,17 @@ namespace GeneXus.Http.Client
 				return true;
 
 #if !NETCORE
-			string requestUrl = GetRequestURL(name);
-			Uri uri = new Uri(requestUrl);
-			if (!uri.IsDefaultPort)
-				return true;
+			try
+			{
+				string requestUrl = GetRequestURL(name);
+				Uri uri = new Uri(requestUrl);
+				if (!uri.IsDefaultPort)
+					return true;
+			}
+			catch (Exception e)
+			{
+				GXLogging.Warn(log, "UseOldHttpClient", e);
+			}
 #endif
 			return false;
 		}

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -356,12 +356,25 @@ namespace GeneXus.Http.Client
 					sHost = sHost.Substring(0, sHost.Length - 1);
 			}
 			sBaseUrl = _baseUrl;
-			if (!string.IsNullOrEmpty(sBaseUrl) && sBaseUrl.StartsWith("/"))
-				sBaseUrl = sBaseUrl.Substring(1, sBaseUrl.Length - 1);
-			_url = _scheme + sHost + sPort + "/" + sBaseUrl;
+			if (IsAbsolute(sBaseUrl))
+			{
+				_url = sBaseUrl;
+			}
+			else
+			{
+				if (!string.IsNullOrEmpty(sBaseUrl) && sBaseUrl.StartsWith("/"))
+					sBaseUrl = sBaseUrl.Substring(1, sBaseUrl.Length - 1);
+
+				_url = _scheme + sHost + sPort + "/" + sBaseUrl;
+			}
 			if (_url.EndsWith("/"))
 				_url = _url.Substring(0, _url.Length - 1);
 		}
+		bool IsAbsolute(string url)
+		{
+			return Uri.IsWellFormedUriString(url, UriKind.Absolute);
+		}
+
 		public void ClearHeaders()
 		{
 			_headers.Clear();
@@ -1027,10 +1040,17 @@ namespace GeneXus.Http.Client
 				return name;
 			else
 			{
-				if (!string.IsNullOrEmpty(name) && name.IndexOf('/') == 0)
-					return _url + name;
+				if (IsAbsolute(name))
+				{
+					return name;
+				}
 				else
-					return _url + "/" + name;
+				{
+					if (!string.IsNullOrEmpty(name) && name.IndexOf('/') == 0)
+						return _url + name;
+					else
+						return _url + "/" + name;
+				}
 			}
 		}
 #if !NETCORE

--- a/dotnet/test/DotNetCoreUnitTest/HttpClient/StreamHandling.cs
+++ b/dotnet/test/DotNetCoreUnitTest/HttpClient/StreamHandling.cs
@@ -31,8 +31,50 @@ namespace DotNetCoreUnitTest.HttpClientTest
 
 				Assert.True(client.ToString().Length > 0);
 			}
+		}
+		[Fact]
+		public void HttpClientAbsoluteURLOnExecute()
+		{
+			using (GxHttpClient client = new GxHttpClient())
+			{
+				string url = "https://www.google.com/";
+				client.Port = 80;
+				client.Execute("GET", url);
+				string requestUrl = client.GetRequestURL(url);
+				Assert.Equal(client.StatusCode, (short)System.Net.HttpStatusCode.OK);
+				Assert.True(Uri.IsWellFormedUriString(requestUrl, UriKind.Absolute), "GetRequestURL is an invalid url which will cause Invalid URI at execute");
 
+			}
+		}
+		[Fact]
+		public void HttpClientRelativeURLOnExecute_1()
+		{
+			using (GxHttpClient client = new GxHttpClient())
+			{
+				string url = "imghp";
+				client.Port = 80;
+				client.BaseURL = "https://www.google.com/";
+				client.Execute("GET", url);
+				string requestUrl = client.GetRequestURL(url);
+				Assert.Equal(client.StatusCode, (short)System.Net.HttpStatusCode.OK);
+				Assert.True(Uri.IsWellFormedUriString(requestUrl, UriKind.Absolute), "GetRequestURL is an invalid url which will cause Invalid URI at execute");
 
+			}
+		}
+		[Fact]
+		public void HttpClientRelativeURLOnExecute_2()
+		{
+			using (GxHttpClient client = new GxHttpClient())
+			{
+				string url = "/imghp";
+				client.Port = 80;
+				client.BaseURL = "https://www.google.com";
+				client.Execute("GET", url);
+				string requestUrl = client.GetRequestURL(url);
+				Assert.Equal(client.StatusCode, (short)System.Net.HttpStatusCode.OK);
+				Assert.True(Uri.IsWellFormedUriString(requestUrl, UriKind.Absolute), "GetRequestURL is an invalid url which will cause Invalid URI at execute");
+
+			}
 		}
 	}
 }


### PR DESCRIPTION
In particular UriFormatException at WebRequest.Create.
Issue:HttpClient - Fiddler - System.UriFormatException