### PR TITLE
Avoid http error: 429 "Too many request" executing external URL in unittest.

### DIFF
--- a/dotnet/test/DotNetCoreUnitTest/HttpClient/StreamHandling.cs
+++ b/dotnet/test/DotNetCoreUnitTest/HttpClient/StreamHandling.cs
@@ -39,9 +39,7 @@ namespace DotNetCoreUnitTest.HttpClientTest
 			{
 				string url = "https://www.google.com/";
 				client.Port = 80;
-				client.Execute("GET", url);
 				string requestUrl = client.GetRequestURL(url);
-				Assert.Equal(client.StatusCode, (short)System.Net.HttpStatusCode.OK);
 				Assert.True(Uri.IsWellFormedUriString(requestUrl, UriKind.Absolute), "GetRequestURL is an invalid url which will cause Invalid URI at execute");
 
 			}
@@ -54,9 +52,7 @@ namespace DotNetCoreUnitTest.HttpClientTest
 				string url = "imghp";
 				client.Port = 80;
 				client.BaseURL = "https://www.google.com/";
-				client.Execute("GET", url);
 				string requestUrl = client.GetRequestURL(url);
-				Assert.Equal(client.StatusCode, (short)System.Net.HttpStatusCode.OK);
 				Assert.True(Uri.IsWellFormedUriString(requestUrl, UriKind.Absolute), "GetRequestURL is an invalid url which will cause Invalid URI at execute");
 
 			}
@@ -69,9 +65,7 @@ namespace DotNetCoreUnitTest.HttpClientTest
 				string url = "/imghp";
 				client.Port = 80;
 				client.BaseURL = "https://www.google.com";
-				client.Execute("GET", url);
 				string requestUrl = client.GetRequestURL(url);
-				Assert.Equal(client.StatusCode, (short)System.Net.HttpStatusCode.OK);
 				Assert.True(Uri.IsWellFormedUriString(requestUrl, UriKind.Absolute), "GetRequestURL is an invalid url which will cause Invalid URI at execute");
 
 			}


### PR DESCRIPTION
For testing purposes it is not necessary to execute the URL. The GetRequestURL function is the tested one.
Issue:[Issue:101490](https://issues.genexus.com/viewissue.aspx?101490)