### PR TITLE
Remove revision number from version for HotFixes

### DIFF
--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -4,13 +4,9 @@
 		<MajorFileVersion>1</MajorFileVersion>
 		<MajorFileVersion Condition="$(GIT_REF.EndsWith('beta'))">$([MSBuild]::Add($(MajorFileVersion), 100))</MajorFileVersion>
 		<MinorFileVersion>23</MinorFileVersion>
-		<RevisionFileVersion Condition="'$(COMMIT_NUMBER)'!=''">$(COMMIT_NUMBER)</RevisionFileVersion>
-		<RevisionFileVersion Condition="'$(COMMIT_NUMBER)'==''">0</RevisionFileVersion>
-		<FileVersionWithoutRevision>$(MajorFileVersion).$(MinorFileVersion).$(RevisionFileVersion)</FileVersionWithoutRevision>
-		<BetaOrMaster Condition="$(GIT_REF.EndsWith('beta')) Or $(GIT_REF.EndsWith('master'))">true</BetaOrMaster>
-		<FileVersionWithoutRevision Condition="'$(BetaOrMaster)'=='true'">$(MajorFileVersion).$(MinorFileVersion).0</FileVersionWithoutRevision>
-		<FileVersion>$(FileVersionWithoutRevision)</FileVersion>
-		<FileVersion Condition="'$(BetaOrMaster)'=='true'">$(FileVersionWithoutRevision).$(RevisionFileVersion)</FileVersion>
+		<PatchFileVersion Condition="'$(COMMIT_NUMBER)'!=''">$(COMMIT_NUMBER)</PatchFileVersion>
+		<PatchFileVersion Condition="'$(COMMIT_NUMBER)'==''">0</PatchFileVersion>
+		<FileVersion>$(MajorFileVersion).$(MinorFileVersion).$(PatchFileVersion)</FileVersion>
 		<InformationalVersion>$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss")).$(GIT_SHA)</InformationalVersion>
 		<Company>GeneXus</Company>
 		<AssemblyCulture></AssemblyCulture>

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -7,8 +7,10 @@
 		<RevisionFileVersion Condition="'$(COMMIT_NUMBER)'!=''">$(COMMIT_NUMBER)</RevisionFileVersion>
 		<RevisionFileVersion Condition="'$(COMMIT_NUMBER)'==''">0</RevisionFileVersion>
 		<FileVersionWithoutRevision>$(MajorFileVersion).$(MinorFileVersion).$(RevisionFileVersion)</FileVersionWithoutRevision>
-		<FileVersionWithoutRevision Condition="$(GIT_REF.EndsWith('beta')) Or $(GIT_REF.EndsWith('master'))">$(MajorFileVersion).$(MinorFileVersion).0</FileVersionWithoutRevision>
-		<FileVersion>$(FileVersionWithoutRevision).$(RevisionFileVersion)</FileVersion>
+		<BetaOrMaster Condition="$(GIT_REF.EndsWith('beta')) Or $(GIT_REF.EndsWith('master'))">true</BetaOrMaster>
+		<FileVersionWithoutRevision Condition="'$(BetaOrMaster)'=='true'">$(MajorFileVersion).$(MinorFileVersion).0</FileVersionWithoutRevision>
+		<FileVersion>$(FileVersionWithoutRevision)</FileVersion>
+		<FileVersion Condition="'$(BetaOrMaster)'=='true'">$(FileVersionWithoutRevision).$(RevisionFileVersion)</FileVersion>
 		<InformationalVersion>$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss")).$(GIT_SHA)</InformationalVersion>
 		<Company>GeneXus</Company>
 		<AssemblyCulture></AssemblyCulture>

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -32,6 +32,6 @@
 	</PropertyGroup>
 
 	<Target Name="GetFileVersionForPackage">
-		<Message Importance="high" Text="FileVersion:$(FileVersionWithoutRevision)"></Message>
+		<Message Importance="high" Text="FileVersion:$(FileVersion)"></Message>
 	</Target>
 </Project>


### PR DESCRIPTION
It is optional and was getting the same number as the build number.