### PR TITLE
Fix error: Can't write CLR type System.Guid with handler type TextHandler

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
@@ -313,7 +313,14 @@ namespace GeneXus.Data
 				return count;
 			}
 		}
-		//ByteArrayToByteaTextEscaped
+		public override void SetParameter(IDbDataParameter parameter, object value)
+		{
+			if (value is Guid)
+			{
+				value = value.ToString();
+			}
+			base.SetParameter(parameter, value);
+		}
 		public override void SetBinary(IDbDataParameter parameter, byte[] byteArray)
 		{
 			if (_byteaOutputEscape)


### PR DESCRIPTION
The error was thrown when executing a query with a Guid parameter and using npgsql 5.0.7.
Issue:101887