### PR TITLE
Print thread number instead of thread name at log4net logs.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Diagnostics/Log.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Diagnostics/Log.cs
@@ -29,6 +29,7 @@ namespace GeneXus.Diagnostics
 
 		private static ILog GetLogger(string topic)
 		{
+			GXLogging.EnsureThreadIdPropertyExistsInContext();
 			if (!String.IsNullOrEmpty(topic))
 			{
 				string loggerName = topic.StartsWith("$") ? topic.Substring(1) : string.Format("{0}.{1}", defaultUserLogNamespace, topic.Trim());

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/GXLogging.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/GXLogging.cs
@@ -10,7 +10,7 @@ namespace GeneXus
 
 	public static class GXLogging
 	{
-		private static void EnsureThreadIdPropertyExistsInContext()
+		internal static void EnsureThreadIdPropertyExistsInContext()
 		{
 #if NETCORE
 			log4net.ThreadContext.Properties["threadid"] ??= Thread.CurrentThread.ManagedThreadId;

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/GXLogging.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/GXLogging.cs
@@ -1,22 +1,26 @@
-using log4net;
-using log4net.Core;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Text.RegularExpressions;
+using System.Threading;
+using log4net;
+using log4net.Core;
 
 namespace GeneXus
 {
 
 	public static class GXLogging
 	{
-
+		private static void EnsureThreadIdPropertyExistsInContext()
+		{
+#if NETCORE
+			log4net.ThreadContext.Properties["threadid"] ??= Thread.CurrentThread.ManagedThreadId;
+#endif
+		}
 		public static void Trace(this ILog log, params string[] list)
 		{
 			if (log.Logger.IsEnabledFor(Level.Trace))
 			{
+				EnsureThreadIdPropertyExistsInContext();
 				log.Logger.Log(MethodBase.GetCurrentMethod().DeclaringType, Level.Trace, String.Join(" ", list), null);
 			}
 		}
@@ -24,6 +28,7 @@ namespace GeneXus
 		{
 			if (log.IsErrorEnabled)
 			{
+				EnsureThreadIdPropertyExistsInContext();
 				log.Error(msg, ex);
 			}
 		}
@@ -32,6 +37,7 @@ namespace GeneXus
 		{
 			if (log.IsErrorEnabled)
 			{
+				EnsureThreadIdPropertyExistsInContext();
 				log.Error(Utils.StringUtil.Sanitize(msg, Utils.StringUtil.LogUserEntryWhiteList), ex);
 			}
 		}
@@ -43,6 +49,7 @@ namespace GeneXus
         public static void Error(ILog log, Exception ex, params string[] list)
 		{
 			if (log.IsErrorEnabled){
+				EnsureThreadIdPropertyExistsInContext();
 				foreach (string parm in list){
 					log.Error(parm);
 				}
@@ -57,6 +64,7 @@ namespace GeneXus
 		{
 			if (log.IsWarnEnabled)
 			{
+				EnsureThreadIdPropertyExistsInContext();
 				StringBuilder msg = new StringBuilder();
 				foreach (string parm in list)
 				{
@@ -76,6 +84,7 @@ namespace GeneXus
 		{
 			if (log.IsWarnEnabled)
 			{
+				EnsureThreadIdPropertyExistsInContext();
 				log.Warn(msg, ex);
 			}
 		}
@@ -83,6 +92,7 @@ namespace GeneXus
 		{
 			if (log.IsDebugEnabled)
 			{
+				EnsureThreadIdPropertyExistsInContext();
 				StringBuilder msg = new StringBuilder();
 				foreach (string parm in list)
 				{
@@ -99,6 +109,7 @@ namespace GeneXus
 		{
 			if (log.IsDebugEnabled)
 			{
+				EnsureThreadIdPropertyExistsInContext();
 				StringBuilder msg = new StringBuilder();
 				foreach (string parm in list)
 				{
@@ -127,6 +138,7 @@ namespace GeneXus
 		{
 			if (log.IsDebugEnabled)
 			{
+				EnsureThreadIdPropertyExistsInContext();
 				string msg = buildMsg();
 				log.Debug(startMsg + msg);
 			}
@@ -139,6 +151,7 @@ namespace GeneXus
 		{
 			if (log.IsDebugEnabled)
 			{
+				EnsureThreadIdPropertyExistsInContext();
 				log.Debug(msg, ex);
 			}
 		}
@@ -146,6 +159,7 @@ namespace GeneXus
 		{
 			if (log.IsInfoEnabled)
 			{
+				EnsureThreadIdPropertyExistsInContext();
 				StringBuilder msg = new StringBuilder();
 				foreach (string parm in list)
 				{


### PR DESCRIPTION
Log4net uses thread name for pattern %thread when available. It uses the thread number if no name is available. 
In .NET Framework and .NET until v5  threadpool threads are not named by default, therefore thread number is printed in logs by default, but in Net6 they are named. 
Given that the thread number is more useful that thread name, the property threadid is added to log4net context and can be used with the pattern [%property{threadid}] 
Issue:101981