### PR TITLE
Avoid header manipultaion on "Access-Control-Allow-Headers" and "Access-Control-Allow-Methods"

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -511,6 +511,7 @@ namespace GeneXus.Utils
 		static char[] numbers = new char[] { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 		internal static Dictionary<char, char> LogUserEntryWhiteList = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789+-_=/[]{}\":, ".ToDictionary(item => item, item => item);
 		internal static Dictionary<char, char> HostWhiteList = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789./".ToDictionary(item => item, item => item);
+		internal static Dictionary<char, char> HttpHeaderWhiteList = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789-@".ToDictionary(item => item, item => item);
 
 		internal static string Sanitize(string input, Dictionary<char, char> WhiteList)
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
@@ -132,10 +132,10 @@ namespace GeneXus.Http
 			httpResponse.Headers[HeaderNames.AccessControlAllowCredentials] = true.ToString();
 
 			if (!string.IsNullOrEmpty(requestHeaders))
-				httpResponse.Headers[HeaderNames.AccessControlAllowHeaders] = requestHeaders;
+				httpResponse.Headers[HeaderNames.AccessControlAllowHeaders] = StringUtil.Sanitize(requestHeaders, StringUtil.HttpHeaderWhiteList);
 
 			if (!string.IsNullOrEmpty(requestMethods))
-				httpResponse.Headers[HeaderNames.AccessControlAllowMethods] = requestMethods;
+				httpResponse.Headers[HeaderNames.AccessControlAllowMethods] = StringUtil.Sanitize(requestMethods, StringUtil.HttpHeaderWhiteList);
 
 			httpResponse.Headers[HeaderNames.AccessControlMaxAge] = CORS_MAX_AGE_SECONDS;
 
@@ -150,10 +150,10 @@ namespace GeneXus.Http
 			httpResponse.Headers[HeaderNames.AccessControlAllowCredentials] = true.ToString();
 
 			if (!string.IsNullOrEmpty(requestHeaders))
-				httpResponse.Headers[HeaderNames.AccessControlAllowHeaders] = requestHeaders;
+				httpResponse.Headers[HeaderNames.AccessControlAllowHeaders] = StringUtil.Sanitize(requestHeaders, StringUtil.HttpHeaderWhiteList);
 
 			if (!string.IsNullOrEmpty(requestMethods))
-				httpResponse.Headers[HeaderNames.AccessControlAllowMethods] = requestMethods;
+				httpResponse.Headers[HeaderNames.AccessControlAllowMethods] = StringUtil.Sanitize(requestMethods, StringUtil.HttpHeaderWhiteList);
 
 			httpResponse.Headers[HeaderNames.AccessControlMaxAge] = CORS_MAX_AGE_SECONDS;
 		}
@@ -170,10 +170,10 @@ namespace GeneXus.Http
 			httpResponse.AppendHeader(HeaderNames.AccessControlAllowCredentials, true.ToString());
 
 			if (!string.IsNullOrEmpty(requestHeaders))
-				httpResponse.AppendHeader(HeaderNames.AccessControlAllowHeaders, requestHeaders);
+				httpResponse.AppendHeader(HeaderNames.AccessControlAllowHeaders, StringUtil.Sanitize(requestHeaders, StringUtil.HttpHeaderWhiteList));
 
 			if (!string.IsNullOrEmpty(requestMethods))
-				httpResponse.AppendHeader(HeaderNames.AccessControlAllowMethods, requestMethods);
+				httpResponse.AppendHeader(HeaderNames.AccessControlAllowMethods, StringUtil.Sanitize(requestMethods, StringUtil.HttpHeaderWhiteList));
 
 			httpResponse.AppendHeader(HeaderNames.AccessControlMaxAge, CORS_MAX_AGE_SECONDS);
 		}


### PR DESCRIPTION
Validate the vales of those headers against a list of safe characters that can appear in HTTP request headers: alphanumeric characters, "-" and "@".
Issue:101991