### PR TITLE
Fix set-output function deprecation in build workflow

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -99,10 +99,10 @@ jobs:
         echo "COMMIT_NUMBER=$COMMIT_NUMBER" >> $env:GITHUB_ENV
         echo "IsPrerelease=$IsPrerelease" >> $env:GITHUB_ENV
 
-        echo "NUGET_PACKAGE_VERSION=$NUGET_PACKAGE_VERSION" >> $GITHUB_OUTPUT
-        echo "SHOULD_DEPLOY=$SHOULD_DEPLOY" >> $GITHUB_OUTPUT
-        echo "LAST_COMMITTER=$LAST_COMMITTER" >> $GITHUB_OUTPUT
-        echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
+        echo "NUGET_PACKAGE_VERSION=$NUGET_PACKAGE_VERSION" >> $env:GITHUB_OUTPUT
+        echo "SHOULD_DEPLOY=$SHOULD_DEPLOY" >> $env:GITHUB_OUTPUT
+        echo "LAST_COMMITTER=$LAST_COMMITTER" >> $env:GITHUB_OUTPUT
+        echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> $env:GITHUB_OUTPUT
 
     - name: Write SNK
       if: github.repository_owner == 'GeneXusLabs' && steps.buildVariables.outputs.SHOULD_DEPLOY == 'true'

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -99,10 +99,10 @@ jobs:
         echo "COMMIT_NUMBER=$COMMIT_NUMBER" >> $env:GITHUB_ENV
         echo "IsPrerelease=$IsPrerelease" >> $env:GITHUB_ENV
 
-        echo "::set-output name=NUGET_PACKAGE_VERSION::$NUGET_PACKAGE_VERSION"
-        echo "::set-output name=SHOULD_DEPLOY::$SHOULD_DEPLOY"
-        echo "::set-output name=LAST_COMMITTER::$LAST_COMMITTER"
-        echo "::set-output name=COMMIT_MESSAGE::$COMMIT_MESSAGE"
+        echo "NUGET_PACKAGE_VERSION=$NUGET_PACKAGE_VERSION" >> $GITHUB_OUTPUT
+        echo "SHOULD_DEPLOY=$SHOULD_DEPLOY" >> $GITHUB_OUTPUT
+        echo "LAST_COMMITTER=$LAST_COMMITTER" >> $GITHUB_OUTPUT
+        echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
 
     - name: Write SNK
       if: github.repository_owner == 'GeneXusLabs' && steps.buildVariables.outputs.SHOULD_DEPLOY == 'true'


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/