### PR TITLE
Upgrade log4net from 2.0.11 to 2.0.15 in .NET projects

### DIFF
--- a/dotnet/src/dotnetcore/DynService/OData/DynServiceOData.csproj
+++ b/dotnet/src/dotnetcore/DynService/OData/DynServiceOData.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="GeneXus.Odata.Client" Version="5.2.3.8" />
-		<PackageReference Include="log4net" Version="2.0.11" />
+		<PackageReference Include="log4net" Version="2.0.15" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\GxClasses\GxClasses.csproj" />

--- a/dotnet/src/dotnetcore/GxClasses.Web/GxClasses.Web.csproj
+++ b/dotnet/src/dotnetcore/GxClasses.Web/GxClasses.Web.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="log4net" Version="2.0.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/dotnetcore/GxClasses/GxClasses.csproj
+++ b/dotnet/src/dotnetcore/GxClasses/GxClasses.csproj
@@ -148,7 +148,7 @@
   </ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Experimental.System.Messaging.Signed" Version="1.0.0" />
-		<PackageReference Include="log4net" Version="2.0.11" />
+		<PackageReference Include="log4net" Version="2.0.15" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.4" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="3.0.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">

--- a/dotnet/src/dotnetcore/GxExcel/GxExcel.csproj
+++ b/dotnet/src/dotnetcore/GxExcel/GxExcel.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="4.5.3.2" />
-    <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.0" />
   </ItemGroup>
 

--- a/dotnet/src/dotnetcore/GxMail/GxMail.csproj
+++ b/dotnet/src/dotnetcore/GxMail/GxMail.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="MailKit" Version="3.1.1" />
     <PackageReference Include="Microsoft.Exchange.WebServices" Version="2.2.0" />
     <PackageReference Include="MimeKit" Version="3.1.1" />

--- a/dotnet/src/dotnetcore/GxPdfReportsCS.Itext4/GxPdfReportsCS.Itext4.csproj
+++ b/dotnet/src/dotnetcore/GxPdfReportsCS.Itext4/GxPdfReportsCS.Itext4.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dotnet/src/dotnetcore/GxPdfReportsCS/GxPdfReportsCS.csproj
+++ b/dotnet/src/dotnetcore/GxPdfReportsCS/GxPdfReportsCS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0</TargetFrameworks>
 		<NoWarn>1701;1702;NU1701</NoWarn>
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="iTextSharp-LGPL" Version="4.1.6" />
-		<PackageReference Include="log4net" Version="2.0.11" />
+		<PackageReference Include="log4net" Version="2.0.15" />
 		<PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dotnet/src/dotnetcore/GxSearch/GxSearch.csproj
+++ b/dotnet/src/dotnetcore/GxSearch/GxSearch.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Lucene.Net" Version="3.0.3" />
     <PackageReference Include="Lucene.Net.Contrib" Version="3.0.3" />
     <PackageReference Include="NUglify" Version="1.16.4" />

--- a/dotnet/src/dotnetcore/Providers/Cache/GxMemcached/GxMemcached.csproj
+++ b/dotnet/src/dotnetcore/Providers/Cache/GxMemcached/GxMemcached.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="EnyimMemcachedCore" Version="2.5.3" />
-    <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
   </ItemGroup>
 

--- a/dotnet/src/dotnetcore/Providers/Cache/GxRedis/GxRedis.csproj
+++ b/dotnet/src/dotnetcore/Providers/Cache/GxRedis/GxRedis.csproj
@@ -18,7 +18,7 @@
     <Compile Include="..\..\..\..\dotnetframework\Providers\Cache\GxRedis\GxRedis.cs" Link="GxRedis.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.593" />
   </ItemGroup>
 

--- a/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
@@ -415,7 +415,7 @@ namespace GeneXus.Configuration
 #if NETCORE
 		public static IConfiguration ConfigRoot { get; set; }
 		const string Log4NetShortName = "log4net";
-		static Version Log4NetVersion = new Version(2, 0, 11);
+		static Version Log4NetVersion = new Version(2, 0, 15);
 
 		const string ConfigurationManagerBak = "System.Configuration.ConfigurationManager, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51";
 		const string ConfigurationManagerFileName = "System.Configuration.ConfigurationManager.dll";

--- a/dotnet/src/dotnetframework/GxClasses/Diagnostics/Log.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Diagnostics/Log.cs
@@ -29,7 +29,6 @@ namespace GeneXus.Diagnostics
 
 		private static ILog GetLogger(string topic)
 		{
-			GXLogging.EnsureThreadIdPropertyExistsInContext();
 			if (!String.IsNullOrEmpty(topic))
 			{
 				string loggerName = topic.StartsWith("$") ? topic.Substring(1) : string.Format("{0}.{1}", defaultUserLogNamespace, topic.Trim());

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/GXLogging.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/GXLogging.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Reflection;
 using System.Text;
-using System.Threading;
 using log4net;
 using log4net.Core;
 
@@ -10,17 +9,10 @@ namespace GeneXus
 
 	public static class GXLogging
 	{
-		internal static void EnsureThreadIdPropertyExistsInContext()
-		{
-#if NETCORE
-			log4net.ThreadContext.Properties["threadid"] ??= Thread.CurrentThread.ManagedThreadId;
-#endif
-		}
 		public static void Trace(this ILog log, params string[] list)
 		{
 			if (log.Logger.IsEnabledFor(Level.Trace))
 			{
-				EnsureThreadIdPropertyExistsInContext();
 				log.Logger.Log(MethodBase.GetCurrentMethod().DeclaringType, Level.Trace, String.Join(" ", list), null);
 			}
 		}
@@ -28,7 +20,6 @@ namespace GeneXus
 		{
 			if (log.IsErrorEnabled)
 			{
-				EnsureThreadIdPropertyExistsInContext();
 				log.Error(msg, ex);
 			}
 		}
@@ -37,7 +28,6 @@ namespace GeneXus
 		{
 			if (log.IsErrorEnabled)
 			{
-				EnsureThreadIdPropertyExistsInContext();
 				log.Error(Utils.StringUtil.Sanitize(msg, Utils.StringUtil.LogUserEntryWhiteList), ex);
 			}
 		}
@@ -49,7 +39,6 @@ namespace GeneXus
         public static void Error(ILog log, Exception ex, params string[] list)
 		{
 			if (log.IsErrorEnabled){
-				EnsureThreadIdPropertyExistsInContext();
 				foreach (string parm in list){
 					log.Error(parm);
 				}
@@ -64,7 +53,6 @@ namespace GeneXus
 		{
 			if (log.IsWarnEnabled)
 			{
-				EnsureThreadIdPropertyExistsInContext();
 				StringBuilder msg = new StringBuilder();
 				foreach (string parm in list)
 				{
@@ -84,7 +72,6 @@ namespace GeneXus
 		{
 			if (log.IsWarnEnabled)
 			{
-				EnsureThreadIdPropertyExistsInContext();
 				log.Warn(msg, ex);
 			}
 		}
@@ -92,7 +79,6 @@ namespace GeneXus
 		{
 			if (log.IsDebugEnabled)
 			{
-				EnsureThreadIdPropertyExistsInContext();
 				StringBuilder msg = new StringBuilder();
 				foreach (string parm in list)
 				{
@@ -109,7 +95,6 @@ namespace GeneXus
 		{
 			if (log.IsDebugEnabled)
 			{
-				EnsureThreadIdPropertyExistsInContext();
 				StringBuilder msg = new StringBuilder();
 				foreach (string parm in list)
 				{
@@ -138,7 +123,6 @@ namespace GeneXus
 		{
 			if (log.IsDebugEnabled)
 			{
-				EnsureThreadIdPropertyExistsInContext();
 				string msg = buildMsg();
 				log.Debug(startMsg + msg);
 			}
@@ -151,7 +135,6 @@ namespace GeneXus
 		{
 			if (log.IsDebugEnabled)
 			{
-				EnsureThreadIdPropertyExistsInContext();
 				log.Debug(msg, ex);
 			}
 		}
@@ -159,7 +142,6 @@ namespace GeneXus
 		{
 			if (log.IsInfoEnabled)
 			{
-				EnsureThreadIdPropertyExistsInContext();
 				StringBuilder msg = new StringBuilder();
 				foreach (string parm in list)
 				{

--- a/dotnet/src/extensions/Azure/Handlers/GeneXus.Deploy.AzureFunctions.Handlers.csproj
+++ b/dotnet/src/extensions/Azure/Handlers/GeneXus.Deploy.AzureFunctions.Handlers.csproj
@@ -14,7 +14,7 @@
 	  <DebugType>none</DebugType>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="log4net" Version="2.0.11" />
+		<PackageReference Include="log4net" Version="2.0.15" />
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="4.2.1" />
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="5.0.0" />


### PR DESCRIPTION
Version 2.0.15 includes fixes for issues:
LOG4NET-680 (print thread id for .net worker pool threads) and
[LOG4NET-652] and [LOG4NET-653] related to an error on linux when having a custom property in a layout pattern.
https://logging.apache.org/log4net/release/release-notes.html
EnsureThreadIdPropertyExistsInContext method is not needed anymore because of the fix LOG4NET-680.
Issue:101981