### PR TITLE
Cannot create JWT using private keys on Linux 

### DIFF
--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/SecurityAPICommons/Keys/PrivateKeyManager.cs
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/SecurityAPICommons/Keys/PrivateKeyManager.cs
@@ -530,9 +530,14 @@ namespace SecurityAPICommons.Keys
 
 					byte[] serializedPrivateBytes = this.privateKeyInfo.ToAsn1Object().GetDerEncoded();
 					string serializedPrivate = Convert.ToBase64String(serializedPrivateBytes);
+					
 					RsaPrivateCrtKeyParameters privateKey = (RsaPrivateCrtKeyParameters)PrivateKeyFactory.CreateKey(Convert.FromBase64String(serializedPrivate));
 #if NETCORE
-					alg = DotNetUtilities.ToRSA(privateKey);
+					RSACryptoServiceProvider rsa = new RSACryptoServiceProvider();
+					alg = rsa;
+					byte[] serializedPrivateBytes1 = this.privateKeyInfo.ToAsn1Object().GetEncoded();
+					int bytesread = 0;
+					alg.ImportPkcs8PrivateKey(serializedPrivateBytes,out bytesread);
 #else
 
 


### PR DESCRIPTION
Issue:102621
Fix error 'CspParameters' requires Windows Cryptographic API (CAPI), which is not available on this platform wich happens loading private keys on Linux.