### PR TITLE
Remove PrivateAssets=All for Microsoft.Data.Sqlite.

### DIFF
--- a/dotnet/src/dotnetcore/GxClasses/GxClasses.csproj
+++ b/dotnet/src/dotnetcore/GxClasses/GxClasses.csproj
@@ -150,7 +150,7 @@
 		<PackageReference Include="Experimental.System.Messaging.Signed" Version="1.0.0" />
 		<PackageReference Include="log4net" Version="2.0.15" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.4" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="3.0.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="3.0.0" />
 		<PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Microsoft.Data.Sqlite.dll was not being copied to the output directory of generated projects referencing GxClasses package.
Issue:102677
