### PR TITLE
Add new test cases for nodatime timezone conversions.

### DIFF
--- a/dotnet/test/DotNetUnitTest/Domain/TimeZoneTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/TimeZoneTest.cs
@@ -99,5 +99,171 @@ namespace xUnitTesting
 			#endregion
 
 		}
+		[Fact]
+		public void Year1753Conversion()
+		{
+			DateTime dt = new DateTime(1753, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+			DateTime expected = new DateTime(1752, 12, 31, 21, 0, 0, DateTimeKind.Unspecified);
+
+			#region T4ZNet
+#pragma warning disable CS0618 // Type or member is obsolete
+			OlsonTimeZone timezone = TimeZoneUtil.GetInstanceFromOlsonName(MONTEVIDEO_IANA_TIMEZONE_ID);
+			DateTime result = DateTimeUtil.DBserver2local(dt, timezone);
+#pragma warning restore CS0618 // Type or member is obsolete
+			Assert.Equal(expected, result); 
+			#endregion
+
+			#region NodaTime
+			result = DateTimeUtil.DBserver2local(dt, MONTEVIDEO_IANA_TIMEZONE_ID);
+			Assert.Equal(expected, result);
+			#endregion
+
+		}
+		[Fact]
+		public void Year1901MidDayConversion()
+		{
+			
+			DateTime dt = new DateTime(1901, 12, 13, 12, 0, 0, DateTimeKind.Utc);
+			DateTime expected = new DateTime(1901, 12, 13, 9, 0, 0, DateTimeKind.Unspecified);
+
+			#region T4ZNet
+#pragma warning disable CS0618 // Type or member is obsolete
+			OlsonTimeZone timezone = TimeZoneUtil.GetInstanceFromOlsonName(MONTEVIDEO_IANA_TIMEZONE_ID);
+			DateTime result = DateTimeUtil.DBserver2local(dt, timezone);
+#pragma warning restore CS0618 // Type or member is obsolete
+			Assert.Equal(expected, result);
+			#endregion
+
+			#region NodaTime
+			result = DateTimeUtil.DBserver2local(dt, MONTEVIDEO_IANA_TIMEZONE_ID);
+			Assert.Equal(expected, result);
+			#endregion
+
+		}
+		[Fact]
+		public void Year1901Conversion()
+		{
+
+			DateTime dt = new DateTime(1901, 12, 30, 12, 0, 0, DateTimeKind.Utc);
+			DateTime expected = new DateTime(1901, 12, 30, 8, 15, 9, DateTimeKind.Unspecified);
+
+			#region T4ZNet
+#pragma warning disable CS0618 // Type or member is obsolete
+			OlsonTimeZone timezone = TimeZoneUtil.GetInstanceFromOlsonName(MONTEVIDEO_IANA_TIMEZONE_ID);
+			DateTime result = DateTimeUtil.DBserver2local(dt, timezone);
+#pragma warning restore CS0618 // Type or member is obsolete
+			Assert.Equal(expected, result);
+			#endregion
+
+			#region NodaTime
+			result = DateTimeUtil.DBserver2local(dt, MONTEVIDEO_IANA_TIMEZONE_ID);
+			Assert.Equal(expected, result);
+			#endregion
+
+		}
+		[Fact]
+		public void Year1902Conversion()
+		{
+
+			DateTime dt = new DateTime(1902, 12, 30, 12, 0, 0, DateTimeKind.Utc);
+			DateTime expected = new DateTime(1902, 12, 30, 8, 15, 9, DateTimeKind.Unspecified);
+
+			#region T4ZNet
+#pragma warning disable CS0618 // Type or member is obsolete
+			OlsonTimeZone timezone = TimeZoneUtil.GetInstanceFromOlsonName(MONTEVIDEO_IANA_TIMEZONE_ID);
+			DateTime result = DateTimeUtil.DBserver2local(dt, timezone);
+#pragma warning restore CS0618 // Type or member is obsolete
+			Assert.Equal(expected, result);
+			#endregion
+
+			#region NodaTime
+			result = DateTimeUtil.DBserver2local(dt, MONTEVIDEO_IANA_TIMEZONE_ID);
+			Assert.Equal(expected, result);
+			#endregion
+
+		}
+		[Fact]
+		public void Year1901MorningConversion()
+		{
+
+			DateTime dt = new DateTime(1901, 12, 13, 11, 0, 0, DateTimeKind.Utc);
+			DateTime expected = new DateTime(1901, 12, 13, 8, 0, 0, DateTimeKind.Unspecified);
+
+			#region T4ZNet
+#pragma warning disable CS0618 // Type or member is obsolete
+			OlsonTimeZone timezone = TimeZoneUtil.GetInstanceFromOlsonName(MONTEVIDEO_IANA_TIMEZONE_ID);
+			DateTime result = DateTimeUtil.DBserver2local(dt, timezone);
+#pragma warning restore CS0618 // Type or member is obsolete
+			Assert.Equal(expected, result); 
+			#endregion
+
+			#region NodaTime
+			result = DateTimeUtil.DBserver2local(dt, MONTEVIDEO_IANA_TIMEZONE_ID);
+			Assert.Equal(expected, result);
+			#endregion
+
+		}
+		[Fact]
+		public void Year1901AfternoonConversion()
+		{
+
+			DateTime dt = new DateTime(1901, 12, 13, 15, 0, 0, DateTimeKind.Utc);
+			DateTime expected = new DateTime(1901, 12, 13, 12, 0, 0, DateTimeKind.Unspecified);
+
+			#region T4ZNet
+#pragma warning disable CS0618 // Type or member is obsolete
+			OlsonTimeZone timezone = TimeZoneUtil.GetInstanceFromOlsonName(MONTEVIDEO_IANA_TIMEZONE_ID);
+			DateTime result = DateTimeUtil.DBserver2local(dt, timezone);
+#pragma warning restore CS0618 // Type or member is obsolete
+			Assert.Equal(expected, result); 
+			#endregion
+
+			#region NodaTime
+			result = DateTimeUtil.DBserver2local(dt, MONTEVIDEO_IANA_TIMEZONE_ID);
+			Assert.Equal(expected, result);
+			#endregion
+
+		}
+		[Fact]
+		public void Year2039Conversion()
+		{
+			DateTime dt = new DateTime(2039, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+			DateTime expected = new DateTime(2038, 12, 31, 21, 0, 0, DateTimeKind.Unspecified);
+
+			#region T4ZNet
+#pragma warning disable CS0618 // Type or member is obsolete
+			OlsonTimeZone timezone = TimeZoneUtil.GetInstanceFromOlsonName(MONTEVIDEO_IANA_TIMEZONE_ID);
+			DateTime result = DateTimeUtil.DBserver2local(dt, timezone);
+#pragma warning restore CS0618 // Type or member is obsolete
+			Assert.Equal(expected, result); 
+			#endregion
+
+			#region NodaTime
+			result = DateTimeUtil.DBserver2local(dt, MONTEVIDEO_IANA_TIMEZONE_ID);
+			Assert.Equal(expected, result);
+			#endregion
+
+		}
+		[Fact]
+		public void Year2050Conversion()
+		{
+			DateTime dt = new DateTime(2050, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+			DateTime expected = new DateTime(2049, 12, 31, 21, 0, 0, DateTimeKind.Unspecified);
+
+			#region T4ZNet
+#pragma warning disable CS0618 // Type or member is obsolete
+			OlsonTimeZone timezone = TimeZoneUtil.GetInstanceFromOlsonName(MONTEVIDEO_IANA_TIMEZONE_ID);
+			DateTime result = DateTimeUtil.DBserver2local(dt, timezone);
+#pragma warning restore CS0618 // Type or member is obsolete
+			Assert.Equal(expected, result);
+			#endregion
+
+			#region NodaTime
+			result = DateTimeUtil.DBserver2local(dt, MONTEVIDEO_IANA_TIMEZONE_ID);
+			Assert.Equal(expected, result);
+			#endregion
+
+		}
+
 	}
 }


### PR DESCRIPTION
Compatibility: Keep considering 12/13/1901 8:45:52 PM as the minimum gregorian datetime having timezone info. So the same result is get when converting datetimes < OlsonMinTime.
Issue:102852