### PR TITLE
Add support for chunked httpclient and httpresponse.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/Web/GxHttpServer.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/Web/GxHttpServer.cs
@@ -12,12 +12,6 @@ namespace GeneXus.Http.Server
 	using System.Linq;
 	using Microsoft.AspNetCore.Http.Features;
 	using System.Text;
-	using System.Threading.Tasks;
-	using Microsoft.AspNetCore.Mvc.Formatters;
-	using System.Net.Http;
-	using Stubble.Core.Contexts;
-	using System.Net.Mime;
-
 #endif
 
 	public class GxHttpCookie
@@ -96,9 +90,6 @@ namespace GeneXus.Http.Server
 	{
         HttpResponse _httpRes;
         IGxContext _context;
-#if !NETCORE
-		bool _chunkedResponse;
-#endif
 		public GxHttpResponse(IGxContext context)
 		{
             _context = context;
@@ -139,12 +130,6 @@ namespace GeneXus.Http.Server
 		{
 			if (Response != null)
 			{
-#if !NETCORE
-				if (_chunkedResponse)
-				{
-					Response.Buffer = false;
-				}
-#endif
 				Response.Write(s);
 			}
 		}
@@ -156,23 +141,14 @@ namespace GeneXus.Http.Server
 				Response.WriteFile(fileName.Trim());
 			}
 		}
-		public void AppendHeader( string name, string value)
+		public void AppendHeader(string name, string value)
 		{
-			bool transferEncodingHeader = (name.Equals(HttpHeader.TRANSFER_ENCODING, StringComparison.OrdinalIgnoreCase) && value.Equals(HttpHeaderValue.TRANSFER_ENCODING_CHUNKED, StringComparison.OrdinalIgnoreCase));
-#if !NETCORE
-			if (transferEncodingHeader)
-				_chunkedResponse = true;
-#endif
-
 			if (string.Compare(name, "Content-Disposition", true) == 0)
 			{
 				value = GXUtil.EncodeContentDispositionHeader(value, _context.GetBrowserType());
 			}
-			if (!transferEncodingHeader)
-			{
-				if (_context != null)
-					_context.SetHeader(name, value);
-			}
+			if (_context != null)
+				_context.SetHeader(name, value);
 		}
 
 	}

--- a/dotnet/src/dotnetframework/GxClasses/Core/Web/GxHttpServer.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/Web/GxHttpServer.cs
@@ -90,6 +90,7 @@ namespace GeneXus.Http.Server
 	{
         HttpResponse _httpRes;
         IGxContext _context;
+
 		public GxHttpResponse(IGxContext context)
 		{
             _context = context;
@@ -131,7 +132,7 @@ namespace GeneXus.Http.Server
 			if (Response != null)
 			{
 				Response.Write(s);
-			}
+			}			
 		}
 
 		public void AddFile( string fileName)
@@ -141,16 +142,16 @@ namespace GeneXus.Http.Server
 				Response.WriteFile(fileName.Trim());
 			}
 		}
-		public void AppendHeader(string name, string value)
+		public void AppendHeader( string name, string value)
 		{
-			if (string.Compare(name, "Content-Disposition", true) == 0)
+			if(string.Compare(name, "Content-Disposition", true) == 0)
 			{
 				value = GXUtil.EncodeContentDispositionHeader(value, _context.GetBrowserType());
 			}
-			if (_context != null)
-				_context.SetHeader(name, value);
+            if (_context!=null) 
+                _context.SetHeader(name, value);
 		}
-
+	
 	}
 
 	public class GxSoapRequest : GxHttpRequest

--- a/dotnet/src/dotnetframework/GxClasses/Core/Web/GxHttpServer.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/Web/GxHttpServer.cs
@@ -96,7 +96,9 @@ namespace GeneXus.Http.Server
 	{
         HttpResponse _httpRes;
         IGxContext _context;
-
+#if !NETCORE
+		bool _chunkedResponse;
+#endif
 		public GxHttpResponse(IGxContext context)
 		{
             _context = context;
@@ -137,8 +139,14 @@ namespace GeneXus.Http.Server
 		{
 			if (Response != null)
 			{
+#if !NETCORE
+				if (_chunkedResponse)
+				{
+					Response.Buffer = false;
+				}
+#endif
 				Response.Write(s);
-			}			
+			}
 		}
 
 		public void AddFile( string fileName)
@@ -150,14 +158,23 @@ namespace GeneXus.Http.Server
 		}
 		public void AppendHeader( string name, string value)
 		{
-			if(string.Compare(name, "Content-Disposition", true) == 0)
+			bool transferEncodingHeader = (name.Equals(HttpHeader.TRANSFER_ENCODING, StringComparison.OrdinalIgnoreCase) && value.Equals(HttpHeaderValue.TRANSFER_ENCODING_CHUNKED, StringComparison.OrdinalIgnoreCase));
+#if !NETCORE
+			if (transferEncodingHeader)
+				_chunkedResponse = true;
+#endif
+
+			if (string.Compare(name, "Content-Disposition", true) == 0)
 			{
 				value = GXUtil.EncodeContentDispositionHeader(value, _context.GetBrowserType());
 			}
-            if (_context!=null) 
-                _context.SetHeader(name, value);
+			if (!transferEncodingHeader)
+			{
+				if (_context != null)
+					_context.SetHeader(name, value);
+			}
 		}
-	
+
 	}
 
 	public class GxSoapRequest : GxHttpRequest

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -679,7 +679,6 @@ namespace GeneXus.Http.Client
 			handler.ReceiveDataTimeout = milliseconds;
 			handler.ReceiveHeadersTimeout = milliseconds;
 #endif
-
 			using (client = new HttpClient(handler))
 			{
 				client.Timeout = milliseconds;

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -134,6 +134,14 @@ namespace GeneXus.Http.Client
 		{
 			get
 			{
+				if (_chunkedResponse && _receiveData == null && _receiveStream!=null)
+				{
+					using (MemoryStream memstream = new MemoryStream())
+					{
+						_receiveStream.BaseStream.CopyTo(memstream);
+						_receiveData = memstream.ToArray();
+					}
+				}
 				return _receiveData;
 			}
 		}
@@ -739,6 +747,7 @@ namespace GeneXus.Http.Client
 						_encoding = Encoding.UTF8;
 
 					_receiveStream = new StreamReader(stream, _encoding);
+					_receiveData = null;
 				}
 				else
 				{
@@ -1520,6 +1529,7 @@ namespace GeneXus.Http.Client
 				{
 					_receiveData = null;
 					_sendStream?.Dispose();
+					_receiveStream?.Dispose();
 				}
 				disposedValue = true;
 			}

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/GXMetadata.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/GXMetadata.cs
@@ -269,7 +269,14 @@ namespace GeneXus.Metadata
 							pm[2] = pi.ParameterType.IsByRef;
 							pms[i] = pm;
 						}
-						o.GetType().InvokeMember(mthd, BindingFlags.InvokeMethod, null, o, args, pms, null, null);
+						try
+						{
+							o.GetType().InvokeMember(mthd, BindingFlags.InvokeMethod, null, o, args, pms, null, null);
+
+						}catch(MissingMethodException)
+						{
+							throw new GxClassLoaderException("Method " + mi.DeclaringType.FullName + "." + mi.Name + " for " + args.Length + " parameters ("+ String.Join(",", args) + ") not found");
+						}
 					}
 					else
 					{

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
@@ -48,6 +48,13 @@ namespace GeneXus.Http
 		public static string LAST_MODIFIED = "Last-Modified";
 		public static string EXPIRES = "Expires";
 		public static string XGXFILENAME = "x-gx-filename";
+		internal static string ACCEPT = "Accept";
+		internal static string TRANSFER_ENCODING = "Transfer-Encoding";
+	}
+	internal class HttpHeaderValue
+	{
+		internal static string ACCEPT_SERVER_SENT_EVENT = "text/event-stream";
+		internal static string TRANSFER_ENCODING_CHUNKED = "chunked";
 	}
 	[DataContract()]
 	public class HttpJsonError

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -1992,9 +1992,15 @@ namespace GeneXus.Http
 #if !NETCORE
 			if (ChunkedStreaming())
 			{
+				BringSessionStateToLife();
 				context.HttpContext.Response.BufferOutput = false;
 			}
 #endif
+		}
+		private void BringSessionStateToLife()
+		{
+			string sessionId = context.HttpContext.Session.SessionID;
+			GXLogging.Debug(log, "Session is alive: " + sessionId);
 		}
 		internal string DumpHeaders(HttpContext httpContext)
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -45,6 +45,9 @@ namespace GeneXus.Http
 	using Web.Security;
 	using System.Web.SessionState;
 #endif
+
+
+
 #if NETCORE
 	public abstract class GXHttpHandler : GXBaseObject, IHttpHandler
 #else
@@ -1545,8 +1548,6 @@ namespace GeneXus.Http
 		{
 			SendResponseStatus((int)statusCode, string.Empty);
 		}
-
-
 #if !NETCORE
 		protected void SendResponseStatus(int statusCode, string statusDescription)
 		{
@@ -1851,6 +1852,8 @@ namespace GeneXus.Http
 			get { return _isMain; }
 		}
 #endif
+
+
 		public void ProcessRequest(HttpContext httpContext)
 		{
 			localHttpContext = httpContext;

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -1851,8 +1851,6 @@ namespace GeneXus.Http
 			get { return _isMain; }
 		}
 #endif
-
-
 		public void ProcessRequest(HttpContext httpContext)
 		{
 			localHttpContext = httpContext;
@@ -1877,6 +1875,7 @@ namespace GeneXus.Http
 			InitPrivates();
 			try
 			{
+				SetStreaming();
 				SendHeaders();
 				string clientid = context.ClientID; //Send clientid cookie (before response HasStarted) if necessary, since UseResponseBuffering is not in .netcore3.0
 
@@ -1927,6 +1926,17 @@ namespace GeneXus.Http
 				handleException(exceptionToHandle.GetType().FullName, exceptionToHandle.Message, exceptionToHandle.StackTrace);
 				throw new Exception("GXApplication exception", e);
 			}
+		}
+		protected virtual bool ChunkedStreaming() { return false; }
+
+		private void SetStreaming()
+		{
+#if !NETCORE
+			if (ChunkedStreaming())
+			{
+				context.HttpContext.Response.Buffer = false;
+			}
+#endif
 		}
 		internal string DumpHeaders(HttpContext httpContext)
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -1997,11 +1997,13 @@ namespace GeneXus.Http
 			}
 #endif
 		}
+#if !NETCORE
 		private void BringSessionStateToLife()
 		{
 			string sessionId = context.HttpContext.Session.SessionID;
 			GXLogging.Debug(log, "Session is alive: " + sessionId);
 		}
+#endif
 		internal string DumpHeaders(HttpContext httpContext)
 		{
 			StringBuilder str = new StringBuilder();

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -2161,11 +2161,7 @@ namespace GeneXus.Http
 						return;
 
 					string safeIECompMode = IE_COMP_Edge.Equals(IE_COMP_EmulateIE7) ? IE_COMP_Edge : IE_COMP_Edge;
-#if NETCORE
 					localHttpContext.Response.Headers["X-UA-Compatible"] = "IE=" + safeIECompMode;
-#else
-					localHttpContext.Response.AddHeader("X-UA-Compatible", "IE=" + safeIECompMode);
-#endif
 				}
 			}
 
@@ -2173,11 +2169,7 @@ namespace GeneXus.Http
 
 		protected virtual void sendSpaHeaders()
 		{
-#if NETCORE
 			localHttpContext.Response.Headers[GX_SPA_GXOBJECT_RESPONSE_HEADER] = GetPgmname().ToLower();
-#else
-			localHttpContext.Response.AddHeader(GX_SPA_GXOBJECT_RESPONSE_HEADER, GetPgmname().ToLower());
-#endif
 		}
 
 		private void webExecuteWorker(object target)

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -2041,7 +2041,6 @@ namespace GeneXus.Http
 #else
 			bool isExpired = IsFullAjaxRequest(HttpContext.Current) && this.AjaxOnSessionTimeout() == "Warn" && GxWebSession.IsSessionExpired(localHttpContext);
 #endif
-
 			if (isExpired)
 			{
 				GXLogging.Info(log, "440 Session timeout. Web Session has expired and GX' OnSessionTimeout' Pty is set to 'WARN'");

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -1937,7 +1937,7 @@ namespace GeneXus.Http
 #if !NETCORE
 			if (ChunkedStreaming())
 			{
-				context.HttpContext.Response.Buffer = false;
+				context.HttpContext.Response.BufferOutput = false;
 			}
 #endif
 		}

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -1877,10 +1877,9 @@ namespace GeneXus.Http
 			InitPrivates();
 			try
 			{
-#if NETCORE
 				SendHeaders();
 				string clientid = context.ClientID; //Send clientid cookie (before response HasStarted) if necessary, since UseResponseBuffering is not in .netcore3.0
-#endif
+
 				bool validSession = ValidWebSession();
 				if (validSession && IntegratedSecurityEnabled)
 					validSession = ValidSession();
@@ -1915,9 +1914,6 @@ namespace GeneXus.Http
 						context.DispatchAjaxCommands();
 				}
 				SetCompression(httpContext);
-#if !NETCORE
-				SendHeaders();
-#endif
 				context.ResponseCommited = true;
 			}
 			catch (Exception e)

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -3004,15 +3004,6 @@ namespace GeneXus.Http
 
 		protected GXMasterPage MasterPageObj { get; set; }
 
-		protected override void sendSpaHeaders()
-		{
-			base.sendSpaHeaders();
-			if (MasterPageObj != null)
-			{
-				localHttpContext.Response.AddHeader(GX_SPA_MASTERPAGE_HEADER, MasterPageObj.GetPgmname());
-			}
-		}
-
 		protected override void ValidateSpaRequest()
 		{
 			string sourceMasterPage = localHttpContext.Request.Headers[GX_SPA_MASTERPAGE_HEADER];
@@ -3020,6 +3011,10 @@ namespace GeneXus.Http
 			{
 				context.DisableSpaRequest();
 				sendSpaHeaders();
+			}
+			if (MasterPageObj != null)
+			{
+				localHttpContext.Response.Headers[GX_SPA_MASTERPAGE_HEADER] = MasterPageObj.GetPgmname();
 			}
 		}
 	}

--- a/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
@@ -8,6 +8,11 @@ namespace GeneXus.Procedure
 	using System.Threading;
 	using GeneXus.Mime;
 	using GeneXus.Utils;
+#if NETCORE
+	using Microsoft.AspNetCore.Http;
+#else
+	using System.Web;
+#endif
 
 	public class GXWebProcedure : GXHttpHandler
 	{
@@ -35,6 +40,7 @@ namespace GeneXus.Procedure
 		public override void initialize() { }
 		protected override void createObjects() { }
 		public override void skipLines(long nToSkip) { }
+		protected virtual bool ChunkedStreaming() { return false; }
 
 		public override void cleanup()
 		{
@@ -43,7 +49,22 @@ namespace GeneXus.Procedure
 				context.DeleteReferer();
 			}
 		}
-
+		public GXWebProcedure()
+		{
+#if !NETCORE
+			if (ChunkedStreaming())
+			{
+				context.HttpContext.Response.Buffer = false;
+			}
+#endif
+		}
+		protected override void SetCompression(HttpContext httpContext)
+		{
+			if (!ChunkedStreaming())
+			{
+				base.SetCompression(httpContext);
+			}
+		}
 		public void setContextReportHandler()
 		{
 

--- a/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
@@ -18,6 +18,7 @@ namespace GeneXus.Procedure
 		protected IReportHandler oldReportHandler;
 		string outputFileName;
 		string outputType;
+		bool fileContentInline;
 
 		protected int lineHeight;
 		protected int Gx_line;
@@ -115,18 +116,20 @@ namespace GeneXus.Procedure
 
 		private void setOuputFileName()
 		{
-			string fileName = GetType().Name;
-			string fileType = "pdf";
-			if (!string.IsNullOrEmpty(outputFileName))
+			if (fileContentInline)
 			{
-				fileName = outputFileName;
+				string fileName = GetType().Name;
+				string fileType = "pdf";
+				if (!string.IsNullOrEmpty(outputFileName))
+				{
+					fileName = outputFileName;
+				}
+				if (!string.IsNullOrEmpty(outputType))
+				{
+					fileType = outputType.ToLower();
+				}
+				context.HttpContext.Response.AddHeader(HttpHeader.CONTENT_DISPOSITION, $"inline; filename={fileName}.{fileType}");
 			}
-			if (!string.IsNullOrEmpty(outputType))
-			{
-				fileType = outputType.ToLower();
-			}
-
-			context.HttpContext.Response.AddHeader(HttpHeader.CONTENT_DISPOSITION, $"inline; filename={fileName}.{fileType}");
 		}
 
 		public virtual int getOutputType()
@@ -138,6 +141,7 @@ namespace GeneXus.Procedure
 			string idiom;
 			if (!Config.GetValueOf("LANGUAGE", out idiom))
 				idiom = "eng";
+			fileContentInline = true;
 #if NETCORE
 			setOuputFileName();
 #endif

--- a/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
@@ -40,7 +40,6 @@ namespace GeneXus.Procedure
 		public override void initialize() { }
 		protected override void createObjects() { }
 		public override void skipLines(long nToSkip) { }
-		protected virtual bool ChunkedStreaming() { return false; }
 
 		public override void cleanup()
 		{
@@ -48,15 +47,6 @@ namespace GeneXus.Procedure
 			{
 				context.DeleteReferer();
 			}
-		}
-		public GXWebProcedure()
-		{
-#if !NETCORE
-			if (ChunkedStreaming())
-			{
-				context.HttpContext.Response.Buffer = false;
-			}
-#endif
 		}
 		protected override void SetCompression(HttpContext httpContext)
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
@@ -136,6 +136,7 @@ namespace GeneXus.Procedure
 			{
 				fileType = outputType.ToLower();
 			}
+
 			context.HttpContext.Response.AddHeader(HttpHeader.CONTENT_DISPOSITION, $"inline; filename={fileName}.{fileType}");
 		}
 

--- a/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/GXWebProcedure.cs
@@ -18,7 +18,6 @@ namespace GeneXus.Procedure
 		protected IReportHandler oldReportHandler;
 		string outputFileName;
 		string outputType;
-		bool fileContentInline;
 
 		protected int lineHeight;
 		protected int Gx_line;
@@ -116,20 +115,17 @@ namespace GeneXus.Procedure
 
 		private void setOuputFileName()
 		{
-			if (fileContentInline)
+			string fileName = GetType().Name;
+			string fileType = "pdf";
+			if (!string.IsNullOrEmpty(outputFileName))
 			{
-				string fileName = GetType().Name;
-				string fileType = "pdf";
-				if (!string.IsNullOrEmpty(outputFileName))
-				{
-					fileName = outputFileName;
-				}
-				if (!string.IsNullOrEmpty(outputType))
-				{
-					fileType = outputType.ToLower();
-				}
-				context.HttpContext.Response.AddHeader(HttpHeader.CONTENT_DISPOSITION, $"inline; filename={fileName}.{fileType}");
+				fileName = outputFileName;
 			}
+			if (!string.IsNullOrEmpty(outputType))
+			{
+				fileType = outputType.ToLower();
+			}
+			context.HttpContext.Response.AddHeader(HttpHeader.CONTENT_DISPOSITION, $"inline; filename={fileName}.{fileType}");
 		}
 
 		public virtual int getOutputType()
@@ -141,7 +137,6 @@ namespace GeneXus.Procedure
 			string idiom;
 			if (!Config.GetValueOf("LANGUAGE", out idiom))
 				idiom = "eng";
-			fileContentInline = true;
 #if NETCORE
 			setOuputFileName();
 #endif


### PR DESCRIPTION
Issue:103034
For .NET framework move SendHeaders() to the begining of the GxWebProcedure to support chunked responses at http procedures.