### PR TITLE
Fix paging statements with SqlServer 2005 when the statement uses aliases

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -5470,7 +5470,7 @@ namespace GeneXus.Utils
 			try
 			{
 				IDictionary<string, string> maps = new Dictionary<string, string>();
-				foreach (Match match in Regex.Matches(pagingSelect, @"GX_ICTE\.(\[\w+\]) AS \b(\w+)\b", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+				foreach (Match match in Regex.Matches(pagingSelect, @"GX_ICTE\.(\[\w+]) AS \b(\w+)\b(?=,|$)", RegexOptions.Compiled | RegexOptions.CultureInvariant))
 				{
 					if (match.Groups.Count == 3)
 					{

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -5467,6 +5467,25 @@ namespace GeneXus.Utils
 				pagingSelect = pagingSelect.Substring(9);
 
 			pagingSelect = Regex.Replace(pagingSelect, @"T\d+\.", "GX_ICTE.");
+			try
+			{
+				IDictionary<string, string> maps = new Dictionary<string, string>();
+				foreach (Match match in Regex.Matches(pagingSelect, @"GX_ICTE\.(\[\w+\]) AS \b(\w+)\b", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+				{
+					if (match.Groups.Count == 3)
+					{
+						maps[match.Groups[0].Value] = $"GX_ICTE.[{match.Groups[2].Value}]";
+						maps[match.Groups[1].Value] = $"[{match.Groups[2].Value}]";
+					}
+				}
+				foreach (KeyValuePair<string, string> map in maps)
+					pagingSelect = pagingSelect.Replace(map.Key, map.Value);
+			}
+			catch (RegexMatchTimeoutException ex)
+			{
+				GXLogging.Warn(log, ex, "Timeout parsing paging select");
+			}
+
 			return pagingSelect;
 		}
 


### PR DESCRIPTION
Some paging statements generated for SQLServer 2005-2008 require an external subselect which is qualified with table name GX_ICTE. When the inner select uses aliases for some attribute (for example when using subtypes) the outer select must qualify them with GX_ICTE table and the alias used.
This code applies the alias mapping to the outer select.
Issue 71081