### PR TITLE
SetLanguage: prevent updating the language when id is invalid.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -3459,7 +3459,7 @@ namespace GeneXus.Application
 
 		public int SetLanguage(string id)
 		{
-			if (Config.GetLanguageProperty(id, "code") != null)
+			if (Config.ValidLanguage(id))
 			{
 				SetProperty(GXLanguage, id);
 				_localUtil = GXResourceManager.GetLocalUtil(id);
@@ -3473,7 +3473,7 @@ namespace GeneXus.Application
 		}
 		private int SetLanguageWithoutSession(string id)
 		{
-			if (Config.GetLanguageProperty(id, "code") != null)
+			if (Config.ValidLanguage(id))
 			{
 				SetContextProperty(GXLanguage, id);
 				_localUtil = GXResourceManager.GetLocalUtil(id);

--- a/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
@@ -280,6 +280,22 @@ namespace GeneXus.Configuration
 				return null;
 		}
 #endif
+		internal static bool ValidLanguage(string language)
+		{
+			if (languages != null)
+				return languages.Contains(language);
+			else
+			{
+#if NETCORE
+				return false;
+#else
+#pragma warning disable CS0618 // Type or member is obsolete
+				Hashtable appsettings = (Hashtable)ConfigurationSettings.GetConfig("languages/" + language);
+#pragma warning restore CS0618 // Type or member is obsolete
+				return (appsettings != null);
+#endif
+			}
+		}
 		public static string GetLanguageProperty(string language, string property)
 		{
 			string sString = null;


### PR DESCRIPTION
Do not update the session language when the parameter "id" corresponds to a language that is not defined in the configuration file.
Issue:103384