### PR TITLE
Modify SetHeader method in the Context to enable the overriding of existing values.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -13,10 +13,12 @@ namespace GeneXus.Application
 	using System.Messaging;
 	using System.ServiceModel.Web;
 	using GeneXus.UserControls;
+	using System.Net.Http.Headers;
 #else
 	using Microsoft.AspNetCore.Http;
 	using GxClasses.Helpers;
 	using Experimental.System.Messaging;
+	using Microsoft.Net.Http.Headers;
 #endif
 	using GeneXus.Configuration;
 	using GeneXus.Metadata;
@@ -47,7 +49,7 @@ namespace GeneXus.Application
 	using System.Threading;
 	using System.Security.Claims;
 	using System.Security;
-	
+
 	public interface IGxContext
 	{
 		void disableOutput();
@@ -2359,8 +2361,8 @@ namespace GeneXus.Application
 				Secure = cookie.Secure
 			};
 			string sameSite;
-			SameSiteMode sameSiteMode = SameSiteMode.Unspecified;
-			if (Config.GetValueOf("SAMESITE_COOKIE", out sameSite) && Enum.TryParse<SameSiteMode>(sameSite, out sameSiteMode))
+            Microsoft.AspNetCore.Http.SameSiteMode sameSiteMode = Microsoft.AspNetCore.Http.SameSiteMode.Unspecified;
+			if (Config.GetValueOf("SAMESITE_COOKIE", out sameSite) && Enum.TryParse<Microsoft.AspNetCore.Http.SameSiteMode>(sameSite, out sameSiteMode))
 			{
 				cookieOptions.SameSite = sameSiteMode;
 			}
@@ -2431,31 +2433,41 @@ namespace GeneXus.Application
 		{
 			try
 			{
+
 #if !NETCORE
+				
 				switch (name.ToUpper())
 				{
 					case "CACHE-CONTROL":
-						var Cache = _HttpContext.Response.Cache;
-						string[] values = value.Split(',');
-						foreach (string v in values)
+						if (CacheControlHeaderValue.TryParse(value, out CacheControlHeaderValue parsedValue))
 						{
-							switch (v.Trim().ToUpper())
+							HttpContext.Current.Response.Headers[name] = parsedValue.ToString();
+						}
+						else
+						{
+							var Cache = _HttpContext.Response.Cache;
+							string[] values = value.Split(',');
+							foreach (string v in values)
 							{
-								case "PUBLIC":
-									Cache.SetCacheability(HttpCacheability.Public);
-									break;
-								case "PRIVATE":
-									Cache.SetCacheability(HttpCacheability.Private);
-									break;
-								case "NO-CACHE":
-									Cache.SetCacheability(HttpCacheability.NoCache);
-									break;
-								case "NO-STORE":
-									Cache.AppendCacheExtension("no-store, must-revalidate");
-									break;
-								default:
-									break;
+								switch (v.Trim().ToUpper())
+								{
+									case "PUBLIC":
+										Cache.SetCacheability(HttpCacheability.Public);
+										break;
+									case "PRIVATE":
+										Cache.SetCacheability(HttpCacheability.Private);
+										break;
+									case "NO-CACHE":
+										Cache.SetCacheability(HttpCacheability.NoCache);
+										break;
+									case "NO-STORE":
+										Cache.AppendCacheExtension("no-store, must-revalidate");
+										break;
+									default:
+										break;
+								}
 							}
+							_HttpContext.Response.Headers[name] = value;
 						}
 						break;
 					default:
@@ -2463,28 +2475,36 @@ namespace GeneXus.Application
 						break;
 				}
 #else
-			switch (name.ToUpper())
-			{
-				case "CACHE-CONTROL":
-					switch (value.ToUpper())
-					{
-						case "PUBLIC":
-							_HttpContext.Response.AddHeader("Cache-Control", "public");
-							break;
-						case "PRIVATE":
-							_HttpContext.Response.AddHeader("Cache-Control", "private");
-							break;
-						default:
-							GXLogging.Warn(log, String.Format("Could not set Cache Control Http Header Value '{0}' to HttpResponse", value));
-							break;
-					}
-					break;
-				default:
-					_HttpContext.Response.AddHeader(name, value);
-					break;
-			}
+				switch (name.ToUpper())
+				{
+					case "CACHE-CONTROL":
+						if (CacheControlHeaderValue.TryParse(value, out CacheControlHeaderValue parsedValue))
+						{
+							_HttpContext.Response.GetTypedHeaders().CacheControl = parsedValue;
+						}
+						else
+						{
+							switch (value.ToUpper())
+							{
+								case "PUBLIC":
+									_HttpContext.Response.AddHeader("Cache-Control", "public");
+									break;
+								case "PRIVATE":
+									_HttpContext.Response.AddHeader("Cache-Control", "private");
+									break;
+								default:
+									GXLogging.Warn(log, String.Format("Could not set Cache Control Http Header Value '{0}' to HttpResponse", value));
+									break;
+							}
+						}
+						break;
+					default:
+						_HttpContext.Response.AddHeader(name, value);
+						break;
+				}
 #endif
-			}catch (Exception ex)
+			}
+			catch (Exception ex)
 			{
 				GXLogging.Error(log, ex, "Error adding header ", name, value);
 			}

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -2429,8 +2429,6 @@ namespace GeneXus.Application
 
 		private void SetCustomHttpHeader(string name, string value)
 		{
-			_HttpContext.Response.AppendHeader(name, value);
-
 #if !NETCORE
 			switch (name.ToUpper())
 			{
@@ -2458,6 +2456,9 @@ namespace GeneXus.Application
 						}
 					}
 					break;
+				default:
+					_HttpContext.Response.Headers[name]=value;
+					break;
 			}
 #else
 			switch (name.ToUpper())
@@ -2475,6 +2476,9 @@ namespace GeneXus.Application
 							GXLogging.Warn(log, String.Format("Could not set Cache Control Http Header Value '{0}' to HttpResponse", value));
 							break;
 					}
+					break;
+				default:
+					_HttpContext.Response.Headers[name] = value;
 					break;
 			}
 #endif

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -2464,10 +2464,10 @@ namespace GeneXus.Application
 										Cache.AppendCacheExtension("no-store, must-revalidate");
 										break;
 									default:
+										GXLogging.Warn(log, String.Format("Could not set Cache Control Http Header Value '{0}' to HttpResponse", value));
 										break;
 								}
 							}
-							_HttpContext.Response.Headers[name] = value;
 						}
 						break;
 					default:

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -47,7 +47,7 @@ namespace GeneXus.Application
 	using System.Threading;
 	using System.Security.Claims;
 	using System.Security;
-
+	
 	public interface IGxContext
 	{
 		void disableOutput();
@@ -2429,37 +2429,39 @@ namespace GeneXus.Application
 
 		private void SetCustomHttpHeader(string name, string value)
 		{
-#if !NETCORE
-			switch (name.ToUpper())
+			try
 			{
-				case "CACHE-CONTROL":
-					var Cache = _HttpContext.Response.Cache;
-					string[] values = value.Split(',');
-					foreach (string v in values)
-					{
-						switch (v.Trim().ToUpper())
+#if !NETCORE
+				switch (name.ToUpper())
+				{
+					case "CACHE-CONTROL":
+						var Cache = _HttpContext.Response.Cache;
+						string[] values = value.Split(',');
+						foreach (string v in values)
 						{
-							case "PUBLIC":
-								Cache.SetCacheability(HttpCacheability.Public);
-								break;
-							case "PRIVATE":
-								Cache.SetCacheability(HttpCacheability.Private);
-								break;
-							case "NO-CACHE":
-								Cache.SetCacheability(HttpCacheability.NoCache);
-								break;
-							case "NO-STORE":
-								Cache.AppendCacheExtension("no-store, must-revalidate");
-								break;
-							default:
-								break;
+							switch (v.Trim().ToUpper())
+							{
+								case "PUBLIC":
+									Cache.SetCacheability(HttpCacheability.Public);
+									break;
+								case "PRIVATE":
+									Cache.SetCacheability(HttpCacheability.Private);
+									break;
+								case "NO-CACHE":
+									Cache.SetCacheability(HttpCacheability.NoCache);
+									break;
+								case "NO-STORE":
+									Cache.AppendCacheExtension("no-store, must-revalidate");
+									break;
+								default:
+									break;
+							}
 						}
-					}
-					break;
-				default:
-					_HttpContext.Response.Headers[name]=value;
-					break;
-			}
+						break;
+					default:
+						_HttpContext.Response.Headers[name] = value;
+						break;
+				}
 #else
 			switch (name.ToUpper())
 			{
@@ -2478,10 +2480,14 @@ namespace GeneXus.Application
 					}
 					break;
 				default:
-					_HttpContext.Response.Headers[name] = value;
+					_HttpContext.Response.AddHeader(name, value);
 					break;
 			}
 #endif
+			}catch (Exception ex)
+			{
+				GXLogging.Error(log, ex, "Error adding header ", name, value);
+			}
 		}
 
 		public string GetHeader(string name)

--- a/dotnet/test/DotNetCoreUnitTest/Domain/GxHttpResponseTest.cs
+++ b/dotnet/test/DotNetCoreUnitTest/Domain/GxHttpResponseTest.cs
@@ -1,0 +1,41 @@
+using System;
+using GeneXus.Application;
+using GeneXus.Http.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace xUnitTesting
+{
+
+	public class GxHttpResponseTest
+	{
+		[Fact]
+		public void CacheControlHeaderTest()
+		{
+			DefaultHttpContext httpContext = new DefaultHttpContext();
+
+			httpContext.Features.Set<IHttpRequestFeature>(new HttpRequestFeature());
+			httpContext.Features.Set<IHttpResponseFeature>(new HttpResponseFeature());
+
+			int maxAgeSeconds = 1800;
+			int sharedMaxAgeSeconds = 3900;
+			GxContext context = new GxContext();
+			context.HttpContext = httpContext;
+			GxHttpResponse httpresponse = new GxHttpResponse(context);
+			httpresponse.AppendHeader("Cache-Control", $"public, s-maxage={sharedMaxAgeSeconds}, max-age={maxAgeSeconds}, stale-while-revalidate=15, stale-if-error=3600");
+
+			CacheControlHeaderValue cacheControlHeaderValue = httpresponse.Response.GetTypedHeaders().CacheControl;
+
+			TimeSpan maxAge = TimeSpan.FromSeconds(maxAgeSeconds);
+			TimeSpan sMaxAge = TimeSpan.FromSeconds(sharedMaxAgeSeconds);
+
+			Assert.True(cacheControlHeaderValue.Public);
+			Assert.Equal(sMaxAge, cacheControlHeaderValue.SharedMaxAge);
+			Assert.Equal(maxAge, cacheControlHeaderValue.MaxAge);
+			Assert.Contains("stale-if-error=3600", cacheControlHeaderValue.ToString(), StringComparison.OrdinalIgnoreCase);
+		}
+	
+	}
+}


### PR DESCRIPTION
Issue:103629
Starting from #823, headers are set at the beginning of the execution. Therefore, in order for the changes made with the "SetHeader" method to take effect, overriding is necessary.