### PR TITLE
Fix log4net GX_LOG_OUTPUT environment variable crash

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Configuration/LogConfiguration.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Configuration/LogConfiguration.cs
@@ -53,10 +53,10 @@ namespace GeneXus.Configuration
 			if (!String.IsNullOrEmpty(appenderName))
 			{
 				Hierarchy h = (Hierarchy) LogManager.GetRepository();
-				IAppender appenderToAdd = h.GetAppenders().First(a => a.Name == appenderName);
+				IAppender appenderToAdd = h.GetAppenders().FirstOrDefault(a => a.Name == appenderName);
 				if (appenderToAdd == null)
 				{
-					LogConfiguration.logger.Error($"Appender '{appenderName}' was not found on Log4Net Config file");
+					LogConfiguration.logger.Warning($"Appender '{appenderName}' was not found on Log4Net Config file");
 					return;
 				}
 				

--- a/dotnet/src/dotnetframework/GxClasses/Configuration/LogConfiguration.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Configuration/LogConfiguration.cs
@@ -56,7 +56,7 @@ namespace GeneXus.Configuration
 				IAppender appenderToAdd = h.GetAppenders().FirstOrDefault(a => a.Name == appenderName);
 				if (appenderToAdd == null)
 				{
-					LogConfiguration.logger.Warning($"Appender '{appenderName}' was not found on Log4Net Config file");
+					LogConfiguration.logger.Warn($"Appender '{appenderName}' was not found on Log4Net Config file");
 					return;
 				}
 				


### PR DESCRIPTION
Issue: 103651

Fix exception:
```
Application startup exception: System.InvalidOperationException: Sequence contains no matching element
   at System.Linq.ThrowHelper.ThrowNoMatchException()
   at GeneXus.Configuration.LogConfiguration.SetupLog4NetFromEnvironmentVariables()
   at GeneXus.Application.Startup.Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Span`1& arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.AspNetCore.Hosting.ConfigureBuilder.Invoke(Object instance, IApplicationBuilder builder)
   at Microsoft.AspNetCore.Hosting.ConfigureBuilder.<>c__DisplayClass4_0.<Build>b__0(IApplicationBuilder builder)
   at Microsoft.AspNetCore.Hosting.ConventionBasedStartup.Configure(IApplicationBuilder app)
   at Microsoft.AspNetCore.Mvc.Filters.MiddlewareFilterBuilderStartupFilter.<>c__DisplayClass0_0.<Configure>g__MiddlewareFilterBuilder|0(IApplicationBuilder builder)
   at Microsoft.AspNetCore.HostFilteringStartupFilter.<>c__DisplayClass0_0.<Configure>b__0(IApplicationBuilder app)
   at Microsoft.AspNetCore.Hosting.WebHost.BuildApplication()
```