### PR TITLE
Manage exceptions on JWT creation with null keys.

### DIFF
--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusJWT/JWT/JWTCreator.cs
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusJWT/JWT/JWTCreator.cs
@@ -182,6 +182,11 @@ namespace GeneXusJWT.GenexusJWT
 			{
 
 				PrivateKeyManager key = options.GetPrivateKey();
+				if(key == null)
+				{
+					this.error.setError("JW018", "Add the private key using JWTOptions.SetPrivateKey function");
+					return "";
+				}
 				if (key.HasError())
 				{
 					this.error = key.GetError();
@@ -209,6 +214,11 @@ namespace GeneXusJWT.GenexusJWT
 			}
 			else
 			{
+				if(options.getSecret() == null)
+				{
+					this.error.setError("JW021", "Set the secret using JWTOptions.SetSecret function");
+					return "";
+				}
 				SymmetricSecurityKey symKey = new SymmetricSecurityKey(options.getSecret());
 				genericKey = symKey;
 			}
@@ -318,6 +328,11 @@ namespace GeneXusJWT.GenexusJWT
 			if (JWTAlgorithmUtils.isPrivate(alg))
 			{
 				PublicKey cert = options.GetPublicKey();
+				if(cert == null)
+				{
+					this.error.setError("JW022", "Public key or certificate not loaded for verification");
+					return false;
+				}
 				if (cert.HasError())
 				{
 					this.error = cert.GetError();
@@ -345,6 +360,11 @@ namespace GeneXusJWT.GenexusJWT
 			}
 			else
 			{
+				if(options.getSecret() == null)
+				{
+					this.error.setError("JW022", "Symmetric key not loaded for verification");
+					return false;
+				}	
 				SymmetricSecurityKey symKey = new SymmetricSecurityKey(options.getSecret());
 				genericKey = symKey;
 			}

--- a/dotnet/src/extensions/SecurityAPI/test/dotnetcore/SecurityAPITestNetCore/SecurityAPITestNetCore.csproj
+++ b/dotnet/src/extensions/SecurityAPI/test/dotnetcore/SecurityAPITestNetCore/SecurityAPITestNetCore.csproj
@@ -38,6 +38,7 @@
     <Compile Include="..\..\dotnetframework\SecurityAPITest\Jwt\Features\TestJwtRevocationList.cs" Link="Jwt\Features\TestJwtRevocationList.cs" />
     <Compile Include="..\..\dotnetframework\SecurityAPITest\Jwt\Features\TestJwtVerifyJustSignature.cs" Link="Jwt\Features\TestJwtVerifyJustSignature.cs" />
     <Compile Include="..\..\dotnetframework\SecurityAPITest\Jwt\Other\TestIssue81664.cs" Link="Jwt\Others\TestIssue81664.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPITest\Jwt\Other\TestIssue103626.cs" Link="Jwt\Others\TestIssue103626.cs" />
     <Compile Include="..\..\dotnetframework\SecurityAPITest\Jwt\Other\TestIssue83649.cs" Link="Jwt\Others\TestIssue83649.cs" />
     <Compile Include="..\..\dotnetframework\SecurityAPITest\Jwt\Other\TestIssue84142.cs" Link="Jwt\Others\TestIssue84142.cs" />
     <Compile Include="..\..\dotnetframework\SecurityAPITest\Jwt\Other\TestIssue84859.cs" Link="Jwt\Others\TestIssue84859.cs" />

--- a/dotnet/src/extensions/SecurityAPI/test/dotnetframework/SecurityAPITest/Jwt/Other/TestIssue103626.cs
+++ b/dotnet/src/extensions/SecurityAPI/test/dotnetframework/SecurityAPITest/Jwt/Other/TestIssue103626.cs
@@ -1,0 +1,45 @@
+using GeneXusJWT.GenexusComons;
+using GeneXusJWT.GenexusJWT;
+using GeneXusJWT.GenexusJWTClaims;
+using NUnit.Framework;
+using SecurityAPITest.SecurityAPICommons.commons;
+
+namespace SecurityAPITest.Jwt.Other
+{
+	[TestFixture]
+	public class TestIssue103626: SecurityAPITestObject
+	{
+		protected static JWTOptions options;
+		protected static PrivateClaims claims;
+		protected static JWTCreator jwt;
+		protected static string token;
+
+		[SetUp]
+		public virtual void SetUp()
+		{
+			jwt = new JWTCreator();
+			options = new JWTOptions();
+			claims = new PrivateClaims();
+
+			claims.setClaim("hola1", "hola1");
+			claims.setClaim("hola2", "hola2");
+
+		}
+
+		[Test]
+		public void Test_SymmetricError()
+		{
+			string dummytoken = jwt.DoCreate("HS256", claims, options);
+			Assert.IsTrue(jwt.HasError());
+
+		}
+
+		[Test]
+		public void Test_AsymmetricError()
+		{
+			string dummytoken = jwt.DoCreate("RS256", claims, options);
+			Assert.IsTrue(jwt.HasError());
+
+		}
+	}
+}


### PR DESCRIPTION
Issue:103626
Generate an error when keys are not loaded at JWT creation.