### PR TITLE
Add timezone validation when reading ClientTimeZoneId 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -3591,7 +3591,8 @@ namespace GeneXus.Application
 				}
 				try
 				{
-					_currentTimeZoneId = String.IsNullOrEmpty(sTZ) ? DateTimeZoneProviders.Tzdb.GetSystemDefault().Id : sTZ;
+					_currentTimeZoneId = !DateTimeUtil.ValidTimeZone(sTZ) ? DateTimeZoneProviders.Tzdb.GetSystemDefault().Id : sTZ;
+
 				}
 				catch (Exception e1)
 				{
@@ -3636,14 +3637,15 @@ namespace GeneXus.Application
 		public Boolean SetTimeZone(String sTZ)
 		{
 			sTZ = StringUtil.RTrim(sTZ);
-			Boolean ret = false;
+			bool ret = false;
 #if NODATIME
 			string tzId;
 			try
 			{
-				if (DateTimeZoneProviders.Tzdb[sTZ] != null)
+				DateTimeZone zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(sTZ);
+				if (zone != null)
 				{
-					tzId = DateTimeZoneProviders.Tzdb[sTZ].Id;
+					tzId = zone.Id;
 				}
 				else
 				{

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -2319,6 +2319,20 @@ namespace GeneXus.Application
 			}
 			return cookieVal;
 		}
+		internal string GetUndecodedCookie(string name)
+		{
+			string cookieVal = string.Empty;
+			HttpCookie cookie = TryGetCookie(localCookies, name);
+			if (cookie == null && _HttpContext != null)
+			{
+				cookie = TryGetCookie(_HttpContext.Request.GetCookies(), name);
+			}
+			if (cookie != null && cookie.Value != null)
+			{
+				cookieVal = cookie.Value;
+			}
+			return cookieVal;
+		}
 
 		private HttpCookie TryGetCookie(HttpCookieCollection cookieColl, string name)
 		{
@@ -3588,6 +3602,11 @@ namespace GeneXus.Application
 				{
 					sTZ = (string)GetCookie(GX_REQUEST_TIMEZONE);
 					GXLogging.Debug(log, "ClientTimeZone GX_REQUEST_TIMEZONE cookie:", sTZ);
+				}
+				if (!DateTimeUtil.ValidTimeZone(sTZ))
+				{
+					sTZ = (string)GetUndecodedCookie(GX_REQUEST_TIMEZONE);
+					GXLogging.Debug(log, "Try reading undecoded ClientTimeZone GX_REQUEST_TIMEZONE cookie:", sTZ);
 				}
 				try
 				{

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -2430,9 +2430,9 @@ namespace GeneXus.Utils
 
 		static private TimeSpan CurrentOffset(string clientTimeZone)
 		{
-			DateTimeZone clientTimeZoneObj = DateTimeZoneProviders.Tzdb[clientTimeZone];
+			DateTimeZone clientTimeZoneObj = DateTimeZoneProviders.Tzdb.GetZoneOrNull(clientTimeZone);
 			if (clientTimeZoneObj == null)
-				clientTimeZoneObj = DateTimeZoneProviders.Tzdb[LocalTimeZoneId];
+				clientTimeZoneObj = DateTimeZoneProviders.Tzdb.GetZoneOrNull(LocalTimeZoneId);
 			Instant now = SystemClock.Instance.GetCurrentInstant();
 
 			try
@@ -3246,7 +3246,7 @@ namespace GeneXus.Utils
 			DateTime ret = toUniversalTime(dt, fromTimezone);
 
 
-			if (string.IsNullOrEmpty(toTimezone) || DateTimeZoneProviders.Tzdb[toTimezone]==null)
+			if (!ValidTimeZone(toTimezone))
 				toTimezone = DateTimeZoneProviders.Tzdb.GetSystemDefault().Id;
 
 			if (ret < OlsonMinTime)
@@ -3260,6 +3260,11 @@ namespace GeneXus.Utils
 			}
 			return dtconverted.AddMilliseconds(milliSeconds);
 		}
+		internal static bool ValidTimeZone(string timeZone)
+		{
+			return !string.IsNullOrEmpty(timeZone) && DateTimeZoneProviders.Tzdb.GetZoneOrNull(timeZone) != null;
+		}
+
 		internal static DateTime Local2DBserver(DateTime dt, string clientTimezone)
 		{
 			try
@@ -3562,7 +3567,10 @@ namespace GeneXus.Utils
 		static public DateTime FromTimeZone(DateTime dt, String sTZ, IGxContext context)
 		{
 #if NODATIME
-			return ConvertDateTime(dt, sTZ, context.GetTimeZone());
+			if (ValidTimeZone(sTZ))
+				return ConvertDateTime(dt, sTZ, context.GetTimeZone());
+			else
+				return dt;
 #else
 			OlsonTimeZone fromTimeZone = TimeZoneUtil.GetInstanceFromOlsonName(sTZ);
 			if (fromTimeZone != null)

--- a/dotnet/test/DotNetUnitTest/Domain/TimeZoneTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/TimeZoneTest.cs
@@ -13,39 +13,6 @@ namespace xUnitTesting
 		const string GUADALAJARA_IANA_TIMEZONE_ID = "America/Mexico_City";
 		const string PARIS_IANA_TIMEZONE_ID = "Europe/Paris";
 		[Fact]
-		public void TimeHeaderValidation()
-		{
-			string tz = "Etc/GMT 3";
-			GxContext ctx = GxContext.CreateDefaultInstance();
-			ctx.SetTimeZone(tz);
-			string nodaTimeZone = ctx.GetTimeZone();
-			string t4znetTimeZone = Context_SetTimeZone_TZ4Net(tz);
-			Assert.Equal(nodaTimeZone, t4znetTimeZone);
-
-		}
-#pragma warning disable CS0618 // Type or member is obsolete
-		string Context_SetTimeZone_TZ4Net(string sTZ)
-		{
-			OlsonTimeZone _currentTimeZone;
-			try
-			{
-				_currentTimeZone = TimeZoneUtil.GetInstanceFromOlsonName(sTZ);
-			}
-			catch (Exception)
-			{
-				try
-				{
-					_currentTimeZone = TimeZoneUtil.GetInstanceFromWin32Id(sTZ);
-				}
-				catch (Exception)
-				{
-					_currentTimeZone = TimeZoneUtil.GetInstanceFromWin32Id(TimeZoneInfo.Local.Id);
-				}
-			}
-			return _currentTimeZone.Name;
-		}
-#pragma warning restore CS0618 // Type or member is obsolete
-		[Fact]
 		public void MontevideoTimeZoneConversion_offset3()
 		{
 			DateTime dt = new DateTime(1967, 10, 28, 7, 10, 0, DateTimeKind.Utc);

--- a/dotnet/test/DotNetUnitTest/Domain/TimeZoneTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/TimeZoneTest.cs
@@ -1,4 +1,5 @@
 using System;
+using GeneXus.Application;
 using GeneXus.Utils;
 using TZ4Net;
 using Xunit;
@@ -11,6 +12,39 @@ namespace xUnitTesting
 		const string MONTEVIDEO_IANA_TIMEZONE_ID = "America/Montevideo";
 		const string GUADALAJARA_IANA_TIMEZONE_ID = "America/Mexico_City";
 		const string PARIS_IANA_TIMEZONE_ID = "Europe/Paris";
+		[Fact]
+		public void TimeHeaderValidation()
+		{
+			string tz = "Etc/GMT 3";
+			GxContext ctx = GxContext.CreateDefaultInstance();
+			ctx.SetTimeZone(tz);
+			string nodaTimeZone = ctx.GetTimeZone();
+			string t4znetTimeZone = Context_SetTimeZone_TZ4Net(tz);
+			Assert.Equal(nodaTimeZone, t4znetTimeZone);
+
+		}
+#pragma warning disable CS0618 // Type or member is obsolete
+		string Context_SetTimeZone_TZ4Net(string sTZ)
+		{
+			OlsonTimeZone _currentTimeZone;
+			try
+			{
+				_currentTimeZone = TimeZoneUtil.GetInstanceFromOlsonName(sTZ);
+			}
+			catch (Exception)
+			{
+				try
+				{
+					_currentTimeZone = TimeZoneUtil.GetInstanceFromWin32Id(sTZ);
+				}
+				catch (Exception)
+				{
+					_currentTimeZone = TimeZoneUtil.GetInstanceFromWin32Id(TimeZoneInfo.Local.Id);
+				}
+			}
+			return _currentTimeZone.Name;
+		}
+#pragma warning restore CS0618 // Type or member is obsolete
 		[Fact]
 		public void MontevideoTimeZoneConversion_offset3()
 		{


### PR DESCRIPTION
The error "the time zone Etc/GMT 3 is unknown to source TZDB: 2023c" occurred due to the absence of timezone validation when retrieving the ClientTimeZoneId from headers and cookies.

Issue:104095