### PR TITLE
Setting Header no-store was throwing an exception 

### DIFF
--- a/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
@@ -1,4 +1,9 @@
+using System.IO;
 using System.Net;
+using System.Reflection;
+using System.Web.SessionState;
+using System.Web;
+using GeneXus.Application;
 using GeneXus.Http.Client;
 using Xunit;
 
@@ -40,5 +45,19 @@ namespace xUnitTesting
 			}
 		}
 
+
+		[Fact]
+		public void NoStoreHeader()
+		{
+			var httpRequest = new HttpRequest("", "http://localhost/", "");
+			var httpResponce = new HttpResponse(new StringWriter());
+			var httpContext = new HttpContext(httpRequest, httpResponce);
+			HttpContext.Current = httpContext;
+
+			GxContext gxcontext = new GxContext();
+			gxcontext.HttpContext = HttpContext.Current;
+			byte result = gxcontext.SetHeader("CACHE", "no-store");
+			Assert.Equal(0, result);
+		}
 	}
 }

--- a/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
@@ -1,11 +1,12 @@
 using System.IO;
 using System.Net;
-using System.Reflection;
-using System.Web.SessionState;
-using System.Web;
 using GeneXus.Application;
 using GeneXus.Http.Client;
 using Xunit;
+#if !NETCORE
+using System.Web.SessionState;
+using System.Web;
+#endif
 
 namespace xUnitTesting
 {
@@ -44,8 +45,7 @@ namespace xUnitTesting
 				Assert.NotEqual(((int)HttpStatusCode.InternalServerError), httpclient.StatusCode);
 			}
 		}
-
-
+#if !NETCORE
 		[Fact]
 		public void NoStoreHeader()
 		{
@@ -59,5 +59,6 @@ namespace xUnitTesting
 			byte result = gxcontext.SetHeader("CACHE", "no-store");
 			Assert.Equal(0, result);
 		}
+#endif
 	}
 }


### PR DESCRIPTION
The error was throw when assigned with the expression HttpContext.Current.Response.CacheControl = parsedValue.ToString();