### PR TITLE
- Fix dispatch of PUT Services in NET Framework

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Middleware/HandlerFactory.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/HandlerFactory.cs
@@ -208,7 +208,7 @@ namespace GeneXus.HttpHandlerFactory
 			{
 				foreach (SingleMap m in GXAPIModule.servicesMap[actualPath].Values)
 				{
-					if (!m.Path.Equals(m.PathRegexp) && GxRegex.IsMatch(objectName, m.PathRegexp))
+					if (!m.Path.Equals(m.PathRegexp) && GxRegex.IsMatch(objectName, m.PathRegexp) && m.Verb.Equals(requestType))
 					{
 						mapName = m.Name;						
 						routeParms = new Dictionary<string, object>();


### PR DESCRIPTION
- Fix dispatch of PUT Services in NET Framework when the URI is dupllicate and has path variables. Issue 104881