### PR TITLE
Send service headers prior to invoking the execute method 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -136,14 +136,14 @@ namespace GeneXus.Application
 				{
 					innerMethod = this._serviceMethod;
 					bodyParameters = PreProcessApiSdtParameter( _procWorker, innerMethod, bodyParameters, this._variableAlias);
-				}				
+				}
+				ServiceHeaders();
 				Dictionary<string, object> outputParameters = ReflectionHelper.CallMethod(_procWorker, innerMethod, bodyParameters, _gxContext);
 				Dictionary<string, string> formatParameters = ReflectionHelper.ParametersFormat(_procWorker, innerMethod);				
 				setWorkerStatus(_procWorker);
 				_procWorker.cleanup();
 				RestProcess(_procWorker, outputParameters);
 				wrapped = GetWrappedStatus(_procWorker, wrapped, outputParameters, outputParameters.Count);
-				ServiceHeaders();
 				return Serialize(outputParameters, formatParameters, wrapped);
 			}
 			catch (Exception e)
@@ -312,6 +312,7 @@ namespace GeneXus.Application
 				string innerMethod = EXECUTE_METHOD;
 				Dictionary<string, object> outputParameters;
 				Dictionary<string, string> formatParameters = new Dictionary<string, string>();
+				ServiceHeaders();
 				if (!string.IsNullOrEmpty(_serviceMethodPattern))
 				{
 					innerMethod = _serviceMethodPattern;
@@ -332,7 +333,6 @@ namespace GeneXus.Application
 				RestProcess(_procWorker, outputParameters);			  
 				bool wrapped = false;
 				wrapped = GetWrappedStatus(_procWorker, wrapped, outputParameters, parCount);
-				ServiceHeaders();
 				return Serialize(outputParameters, formatParameters, wrapped);
 			}
 			catch (Exception e)

--- a/dotnet/test/DotNetCoreWebUnitTest/apps/append.cs
+++ b/dotnet/test/DotNetCoreWebUnitTest/apps/append.cs
@@ -4,6 +4,7 @@ using GeneXus.Data.NTier;
 using GeneXus.Procedure;
 using System;
 using GX;
+using GeneXus.Http.Server;
 
 namespace GeneXus.Programs.apps
 {
@@ -49,6 +50,7 @@ namespace GeneXus.Programs.apps
 		{
 			/* GeneXus formulas */
 			/* Output device settings */
+			httpResponse.AddString("OK");
 			AV20character2 = StringUtil.Str((decimal)(AV18numeric1), 10, 0) + AV17Character + StringUtil.Str(AV19numeric2, 10, 0) + ClientInformation.Id.ToString();
 			AV8datetime = DateTimeUtil.ResetTime(context.localUtil.YMDToD(2022, 5, 24));
 			AV8rappo00B.gxTpr_Rapdaa = DateTimeUtil.ResetTime(context.localUtil.YMDToD(2022, 5, 24));
@@ -85,6 +87,7 @@ namespace GeneXus.Programs.apps
 			AV8datetime = (DateTime.MinValue);
 			/* GeneXus formulas. */
 			context.Gx_err = 0;
+			httpResponse = new GxHttpResponse(context);
 		}
 		private short AV18numeric1;
 		private decimal AV19numeric2;
@@ -92,6 +95,7 @@ namespace GeneXus.Programs.apps
 		private string AV20character2;
 		private DateTime AV8datetime;
 		private Sdtrappo00b AV8rappo00B;
+		private GxHttpResponse httpResponse;
 	}
 
 }


### PR DESCRIPTION
To address cases where the service writes directly to the response using the HttpResponse data type.
Issue:105140