### PR TITLE
Upgrade CodeQL Action deprecated on January 18th, 2023.

### DIFF
--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -90,7 +90,7 @@ jobs:
         pipeline-results-json: results.json
         source-base-path-1: "^.*/${{ github.event.repository.name }}/dotnet/:dotnet/"
         
-    - uses: github/codeql-action/upload-sarif@v1
+    - uses: github/codeql-action/upload-sarif@v2
       with:
         # Path to SARIF file relative to the root of the repository
         sarif_file: veracode-results.sarif


### PR DESCRIPTION
https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/