### PR TITLE
Add a configuration key to disable the flattening of API object output

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
@@ -1377,15 +1377,15 @@ namespace GeneXus.Configuration
 				return sessionTimeout;
 			}
 		}
-		const bool DefaultFlattenSingleApiOutput = true;
-		internal static bool FlattenSingleApiOutput
+		const bool DefaultWrapSingleApiOutput = false;
+		internal static bool WrapSingleApiOutput
 		{
 			get
 			{
-				if (Config.GetValueOf("FLATTEN_SINGLE_API_OUTPUT", out string flatten))
+				if (Config.GetValueOf("WRAP_SINGLE_API_OUTPUT", out string flatten))
 					return (int.TryParse(flatten, out int value) && value == 1);
 				else
-					return DefaultFlattenSingleApiOutput;
+					return DefaultWrapSingleApiOutput;
 			}
 		}
 		internal static string CorsAllowedOrigins()

--- a/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
@@ -1377,7 +1377,17 @@ namespace GeneXus.Configuration
 				return sessionTimeout;
 			}
 		}
-
+		const bool DefaultFlattenSingleApiOutput = true;
+		internal static bool FlattenSingleApiOutput
+		{
+			get
+			{
+				if (Config.GetValueOf("FLATTEN_SINGLE_API_OUTPUT", out string flatten))
+					return (int.TryParse(flatten, out int value) && value == 1);
+				else
+					return DefaultFlattenSingleApiOutput;
+			}
+		}
 		internal static string CorsAllowedOrigins()
 		{
 			if (Config.GetValueOf("CORS_ALLOW_ORIGIN", out string corsOrigin))

--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -372,7 +372,7 @@ namespace GeneXus.Application
 							}
 						}
 					}
-					if (originalParCount > 1 && Preferences.FlattenSingleApiOutput)
+					if (originalParCount > 1 && !Preferences.FlattenSingleApiOutput)
 					{
 						wrapped = true; //Ignore defaultWrapped parameter.
 					}

--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -333,7 +333,7 @@ namespace GeneXus.Application
 				_procWorker.cleanup();
 				int originalParameterCount = outputParameters.Count;
 				RestProcess(_procWorker, outputParameters);			  
-				bool wrapped = true;
+				bool wrapped = false;
 				wrapped = GetWrappedStatus(_procWorker, wrapped, outputParameters, parCount, originalParameterCount);
 				return Serialize(outputParameters, formatParameters, wrapped);
 			}
@@ -371,6 +371,10 @@ namespace GeneXus.Application
 								wrapped = (parCount > 1) ? true : false;
 							}
 						}
+					}
+					if (originalParCount > 1 && Preferences.FlattenSingleApiOutput)
+					{
+						wrapped = true; //Ignore defaultWrapped parameter.
 					}
 				}
 			}

--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -353,7 +353,7 @@ namespace GeneXus.Application
 			{
 				if (outputParameters.Count == 1)
 				{
-					if ((originalParCount == 1) || (originalParCount > 1 && Preferences.FlattenSingleApiOutput))
+					if ((originalParCount == 1) || (originalParCount > 1 && !Preferences.WrapSingleApiOutput))
 					{
 						wrapped = false;
 						Object v = outputParameters.First().Value;
@@ -372,7 +372,7 @@ namespace GeneXus.Application
 							}
 						}
 					}
-					if (originalParCount > 1 && !Preferences.FlattenSingleApiOutput)
+					if (originalParCount > 1 && Preferences.WrapSingleApiOutput)
 					{
 						wrapped = true; //Ignore defaultWrapped parameter.
 					}

--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -350,23 +350,30 @@ namespace GeneXus.Application
 			{
 				if (outputParameters.Count == 1)
 				{
-					wrapped = false;
-					Object v = outputParameters.First().Value;
+					if (Preferences.FlattenSingleApiOutput)
+					{
+						wrapped = false;
+						Object v = outputParameters.First().Value;
 
-					if (v.GetType().GetInterfaces().Contains(typeof(IGxGenericCollectionWrapped)))
-					{
-						IGxGenericCollectionWrapped icollwrapped = v as IGxGenericCollectionWrapped;
-						if (icollwrapped != null) 
-							wrapped = icollwrapped.GetIsWrapped();
-					}
-					if (v is IGxGenericCollectionItem item)
-					{
-						if (item.Sdt is GxSilentTrnSdt)
+						if (v.GetType().GetInterfaces().Contains(typeof(IGxGenericCollectionWrapped)))
 						{
-							wrapped = (parCount>1)?true:false;
+							IGxGenericCollectionWrapped icollwrapped = v as IGxGenericCollectionWrapped;
+							if (icollwrapped != null)
+								wrapped = icollwrapped.GetIsWrapped();
+						}
+						if (v is IGxGenericCollectionItem item)
+						{
+							if (item.Sdt is GxSilentTrnSdt)
+							{
+								wrapped = (parCount > 1) ? true : false;
+							}
 						}
 					}
-				}			
+					else
+					{
+						wrapped = true;
+					}
+				}
 			}
 			return wrapped;
 		}

--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -142,8 +142,9 @@ namespace GeneXus.Application
 				Dictionary<string, string> formatParameters = ReflectionHelper.ParametersFormat(_procWorker, innerMethod);				
 				setWorkerStatus(_procWorker);
 				_procWorker.cleanup();
+				int originalParameterCount = outputParameters.Count;
 				RestProcess(_procWorker, outputParameters);
-				wrapped = GetWrappedStatus(_procWorker, wrapped, outputParameters, outputParameters.Count);
+				wrapped = GetWrappedStatus(_procWorker, wrapped, outputParameters, outputParameters.Count, originalParameterCount);
 				return Serialize(outputParameters, formatParameters, wrapped);
 			}
 			catch (Exception e)
@@ -330,9 +331,10 @@ namespace GeneXus.Application
 				int parCount = outputParameters.Count;
 				setWorkerStatus(_procWorker);
 				_procWorker.cleanup();
+				int originalParameterCount = outputParameters.Count;
 				RestProcess(_procWorker, outputParameters);			  
-				bool wrapped = false;
-				wrapped = GetWrappedStatus(_procWorker, wrapped, outputParameters, parCount);
+				bool wrapped = true;
+				wrapped = GetWrappedStatus(_procWorker, wrapped, outputParameters, parCount, originalParameterCount);
 				return Serialize(outputParameters, formatParameters, wrapped);
 			}
 			catch (Exception e)
@@ -344,13 +346,14 @@ namespace GeneXus.Application
 				Cleanup();
 			}
 		}
-		bool GetWrappedStatus(GXBaseObject worker, bool wrapped, Dictionary<string, object> outputParameters, int parCount)
+		bool GetWrappedStatus(GXBaseObject worker, bool defaultWrapped, Dictionary<string, object> outputParameters, int parCount, int originalParCount)
 		{
+			bool wrapped = defaultWrapped;
 			if (worker.IsApiObject)
 			{
 				if (outputParameters.Count == 1)
 				{
-					if (Preferences.FlattenSingleApiOutput)
+					if ((originalParCount == 1) || (originalParCount > 1 && Preferences.FlattenSingleApiOutput))
 					{
 						wrapped = false;
 						Object v = outputParameters.First().Value;
@@ -368,10 +371,6 @@ namespace GeneXus.Application
 								wrapped = (parCount > 1) ? true : false;
 							}
 						}
-					}
-					else
-					{
-						wrapped = true;
 					}
 				}
 			}


### PR DESCRIPTION
It applies when it's a single SDT.
Issue:104772