### PR TITLE
Expiration time of an external file was not displayed when using File.GetURI() method

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GXFileIO.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GXFileIO.cs
@@ -585,7 +585,12 @@ public class GxExternalFileInfo : IGxFileInfo
 	private string URL
 	{
 		get {
-			return _provider == null ? String.Empty : _provider.GetUrl(_name, _fileTypeAtt, 0);
+			if (_provider == null)
+				return string.Empty;
+			else if (!string.IsNullOrEmpty(_url))
+				return _url;
+			else
+				return _provider.GetUrl(_name, _fileTypeAtt, 0);
 		}
 	}
 


### PR DESCRIPTION
The 'GetURL' method of the external file did not take into consideration the URL (which has specific attributes such as expiration time)
Issue:96279