### PR TITLE
Include defensive programming to handle unclosed tags 

### DIFF
--- a/dotnet/src/dotnetcore/GxClasses/Domain/GXXmlReadWrite.cs
+++ b/dotnet/src/dotnetcore/GxClasses/Domain/GXXmlReadWrite.cs
@@ -1132,7 +1132,7 @@ namespace GeneXus.XML
 
 			char[] trimChars = { '\t', ' ' };
 
-			if (node.NodeType != ElementType) return;
+			if (node==null || node.NodeType != ElementType) return;
 			switch (node.NodeType)
 			{
 				case ElementType:
@@ -2131,6 +2131,10 @@ namespace GeneXus.XML
 		public short WriteElement (string Name, string Value)
 		{
 			WriteStartElement(Name);
+			if (Value==null)
+			{
+				Value = string.Empty;
+			}
 			valueBuffer = Value;
 			return 0;
 		}

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GXXmlReadWrite.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GXXmlReadWrite.cs
@@ -2141,6 +2141,10 @@ namespace GeneXus.XML
 		public short WriteElement (string Name, string Value)
 		{
 			WriteStartElement(Name);
+			if (Value==null)
+			{
+				Value = string.Empty;
+			}
 			valueBuffer = Value;
 			return 0;
 		}
@@ -2154,7 +2158,7 @@ namespace GeneXus.XML
 
 		public short WriteElement (string Name)
 		{
-			WriteElement (Name, "");
+			WriteElement (Name, string.Empty);
 			return 0;
 		}
 

--- a/dotnet/test/DotNetUnitTest/Domain/XMLWriterTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/XMLWriterTest.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GeneXus.Application;
+using GeneXus.XML;
+using Xunit;
+
+namespace UnitTesting
+{
+	public class XMLWriterTest : FileSystemTest
+	{
+		[Fact]
+		public void dfwpnumNullElementTest()
+		{
+			string content = dfwpnumTest(null, false);
+			Assert.Contains("<varchar xmlns=\"StorageExpiration\" />", content, StringComparison.OrdinalIgnoreCase);
+		}
+		[Fact]
+		public void dfwpnumEmptyElementWithoutEndTest()
+		{
+			string content = dfwpnumTest("validValue", false);
+			Assert.Contains("<varchar xmlns=\"StorageExpiration\">validValue</varchar>", content, StringComparison.OrdinalIgnoreCase);
+		}
+		internal string dfwpnumTest(string varcharValue, bool closeElements)
+		{
+			GxContext context = new GxContext();
+			string fileName = Path.Combine(BaseDir, "dfwpnumTest.txt");
+			GXXMLWriter GXSoapXMLWriter = new GXXMLWriter(context.GetPhysicalPath());
+			GXSoapXMLWriter.Open(fileName);
+			GXSoapXMLWriter.WriteStartDocument("utf-8", 0);
+			GXSoapXMLWriter.WriteStartElement("SOAP-ENV:Envelope");
+			GXSoapXMLWriter.WriteElement("varchar", varcharValue);
+			GXSoapXMLWriter.WriteAttribute("xmlns", "StorageExpiration");
+			string sDateCnv = "0000-00-00";
+			GXSoapXMLWriter.WriteElement("date", sDateCnv);
+			GXSoapXMLWriter.WriteAttribute("xmlns", "StorageExpiration");
+			if (closeElements)
+			{
+				GXSoapXMLWriter.WriteEndElement();
+			}
+			GXSoapXMLWriter.Close();
+			return File.ReadAllText(fileName);
+		}
+
+	}
+}


### PR DESCRIPTION
It happens when the 'WriteElement' method receives a null value.
Issue:105366