### PR TITLE
Update BouncyCastle dependency on SecurityApi modules

### DIFF
--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusCryptography/GeneXusCryptography.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusCryptography/GeneXusCryptography.csproj
@@ -6,10 +6,10 @@
     <NoWarn>CA1031, CA1801, CA1724</NoWarn>
     <PackageId>GeneXus.SecurityApi.Cryptography</PackageId>
   </PropertyGroup>
+ <ItemGroup>
+   <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
+ </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SecurityAPICommons\SecurityAPICommons.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
   </ItemGroup>
 </Project>

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusCryptography/Symmetric/SymmetricStreamCipher.cs
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusCryptography/Symmetric/SymmetricStreamCipher.cs
@@ -152,9 +152,6 @@ namespace GeneXusCryptography.Symmetric
 				case SymmetricStreamAlgorithm.ISAAC:
 					engine = new IsaacEngine();
 					break;
-				case SymmetricStreamAlgorithm.VMPC:
-					engine = new VmpcEngine();
-					break;
 				default:
 					this.GetError().setError("SS005", "Cipher " + algorithm + " not recognised.");
 					break;

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusCryptography/SymmetricUtils/SymmetricStreamAlgorithm.cs
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusCryptography/SymmetricUtils/SymmetricStreamAlgorithm.cs
@@ -15,7 +15,7 @@ namespace GeneXusCryptography.SymmetricUtils
 	public enum SymmetricStreamAlgorithm
 	{
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-		NONE, RC4, HC128, HC256, CHACHA20, SALSA20, XSALSA20, ISAAC, VMPC
+		NONE, RC4, HC128, HC256, CHACHA20, SALSA20, XSALSA20, ISAAC
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 	}
 
@@ -56,8 +56,6 @@ namespace GeneXusCryptography.SymmetricUtils
 					return SymmetricStreamAlgorithm.XSALSA20;
 				case "ISAAC":
 					return SymmetricStreamAlgorithm.ISAAC;
-				case "VMPC":
-					return SymmetricStreamAlgorithm.VMPC;
 				default:
 					error.setError("SSA01", "Unrecognized SymmetricStreamAlgorithm");
 					return SymmetricStreamAlgorithm.NONE;
@@ -88,8 +86,6 @@ namespace GeneXusCryptography.SymmetricUtils
 					return "XSALSA20";
 				case SymmetricStreamAlgorithm.ISAAC:
 					return "ISAAC";
-				case SymmetricStreamAlgorithm.VMPC:
-					return "VMPC";
 				default:
 					error.setError("SSA02", "Unrecognized SymmetricStreamAlgorithm");
 					return "Unrecognized algorithm";
@@ -133,11 +129,6 @@ namespace GeneXusCryptography.SymmetricUtils
 					keySize[1] = 32;
 					keySize[2] = 8192;
 					break;
-				case SymmetricStreamAlgorithm.VMPC:
-					keySize[0] = 0;
-					keySize[1] = 8;
-					keySize[2] = 6144;
-					break;
 				default:
 					error.setError("SSA03", "Unrecognized SymmetricStreamAlgorithm");
 					break;
@@ -164,7 +155,6 @@ namespace GeneXusCryptography.SymmetricUtils
 				case SymmetricStreamAlgorithm.SALSA20:
 				case SymmetricStreamAlgorithm.CHACHA20:
 				case SymmetricStreamAlgorithm.XSALSA20:
-				case SymmetricStreamAlgorithm.VMPC:
 					return true;
 				default:
 					error.setError("SSA04", "Unrecognized SymmetricStreamAlgorithm");

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusJWT/GeneXusJWT.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusJWT/GeneXusJWT.csproj
@@ -16,11 +16,11 @@
     <None Include="App.Release.config" />
   </ItemGroup>
     <ItemGroup>
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="6.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.5.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.1" />
   </ItemGroup>
 

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusXmlSignature/GeneXusXmlSignature.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusXmlSignature/GeneXusXmlSignature.csproj
@@ -6,9 +6,11 @@
 	 <NoWarn>CA1031</NoWarn>
 	 <PackageId>GeneXus.SecurityApi.XmlSignature</PackageId>
   </PropertyGroup>
+ <ItemGroup>
+   <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
+ </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SecurityAPICommons\SecurityAPICommons.csproj" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Security" />

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/SecurityAPICommons/SecurityAPICommons.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/SecurityAPICommons/SecurityAPICommons.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
   </ItemGroup>

--- a/dotnet/src/extensions/SecurityAPI/test/dotnetframework/SecurityAPITest/Cryptography/Symmetric/TestStreamEncryption.cs
+++ b/dotnet/src/extensions/SecurityAPI/test/dotnetframework/SecurityAPITest/Cryptography/Symmetric/TestStreamEncryption.cs
@@ -1,4 +1,4 @@
-﻿using SecurityAPITest.SecurityAPICommons.commons;
+using SecurityAPITest.SecurityAPICommons.commons;
 using NUnit.Framework;
 using SecurityAPICommons.Config;
 using SecurityAPICommons.Keys;
@@ -116,28 +116,6 @@ namespace SecurityAPITest.Cryptography.Symmetric
 			// ISAAC 32, 8192 key, no nonce
 			testBulkAlgorithms("ISAAC", key32, "");
 			testBulkAlgorithms("ISAAC", key8192, "");
-		}
-
-		[Test]
-		public void TestVMPC()
-		{
-			// key 8 o 6144, nonce 1...6144 bits
-			testBulkAlgorithms("VMPC", key8, IV64);
-			testBulkAlgorithms("VMPC", key8, IV128);
-			testBulkAlgorithms("VMPC", key8, IV192);
-			testBulkAlgorithms("VMPC", key8, IV256);
-			testBulkAlgorithms("VMPC", key8, IV512);
-			testBulkAlgorithms("VMPC", key8, IV1024);
-			testBulkAlgorithms("VMPC", key8, IV6144);
-
-			testBulkAlgorithms("VMPC", key6144, IV64);
-			testBulkAlgorithms("VMPC", key6144, IV128);
-			testBulkAlgorithms("VMPC", key6144, IV192);
-			testBulkAlgorithms("VMPC", key6144, IV256);
-			testBulkAlgorithms("VMPC", key6144, IV512);
-			testBulkAlgorithms("VMPC", key6144, IV1024);
-			testBulkAlgorithms("VMPC", key6144, IV6144);
-
 		}
 
 		private void testBulkAlgorithms(string algorithm, string key, string IV)

--- a/dotnet/src/extensions/SecurityAPI/test/dotnetframework/SecurityAPITest/SecurityAPITest.csproj
+++ b/dotnet/src/extensions/SecurityAPI/test/dotnetframework/SecurityAPITest/SecurityAPITest.csproj
@@ -369,7 +369,7 @@
     <None Update="dummycerts\RSA_sha256_2048\sha256e_cert.p12">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-		<None Update="dummycerts\RSA_sha256_2048\sha256_pubckey.pem">
+		<None Update="dummycerts\RSA_sha256_2048\sha256_pubkey.pem">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
     <None Update="dummycerts\RSA_sha256_2048\sha256_cert.crt">


### PR DESCRIPTION
Issue:105722

Change Portable.BouncyCastle version 1.9.0 to BouncyCastle.Cryptography version 2.2.1(latest).
Delete VMPC stram encryption algorithm because of a BouncyCastle new version bug.

#GXSEC