### PR TITLE
Conversion functions involving time must include the context parameter

### DIFF
--- a/dotnet/src/dotnetcore/GxClasses.Web/Middleware/GXRouting.cs
+++ b/dotnet/src/dotnetcore/GxClasses.Web/Middleware/GXRouting.cs
@@ -462,7 +462,7 @@ namespace GxClasses.Web.Middleware
 				return fileName;
 			else
 			{
-				GXLogging.Warn(log, "svc not fount:" + controllerFullName);
+				GXLogging.Warn(log, "Service file not found:" + controllerFullName);
 				return null;
 			}
 			

--- a/dotnet/src/dotnetcore/GxClasses.Web/Middleware/GXRouting.cs
+++ b/dotnet/src/dotnetcore/GxClasses.Web/Middleware/GXRouting.cs
@@ -58,6 +58,7 @@ namespace GxClasses.Web.Middleware
 			ServicesGroupSetting();
 			ServicesFunctionsMetadata();
 			GetAzureDeploy();
+			SvcFiles();
 		}
 
 		static public List<ControllerInfo> GetRouteController(Dictionary<string, string> apiPaths,
@@ -397,7 +398,7 @@ namespace GxClasses.Web.Middleware
 			bool privateDirExists = Directory.Exists(privateDir);
 
 			GXLogging.Debug(log, $"PrivateDir:{privateDir} asssemblycontroller:{asssemblycontroller}");
-
+			string svcFile=null;
 			if (privateDirExists && File.Exists(Path.Combine(privateDir, $"{asssemblycontroller.ToLower()}.grp.json")))
 			{
 				controller = tmpController;
@@ -412,9 +413,7 @@ namespace GxClasses.Web.Middleware
 			else
 			{
 				string controllerLower = controller.ToLower();
-				string svcFile = SvcFile($"{controller}{SvcExtension}");
-				if (svcFile==null)
-					svcFile = SvcFile($"{controllerLower}{SvcExtension}");
+				svcFile = SvcFile($"{controller}{SvcExtension}");
 				if (File.Exists(svcFile))
 				{
 					string[] controllerAssemblyQualifiedName = new string(File.ReadLines(svcFile).First().SkipWhile(c => c != '"')
@@ -446,22 +445,26 @@ namespace GxClasses.Web.Middleware
 			GXLogging.Warn(log, $"Controller was not found");
 			return null;
 		}
+
+		private void SvcFiles()
+		{
+			svcFiles = new HashSet<string>(new CaseInsensitiveStringEqualityComparer());
+			foreach (string file in Directory.GetFiles(ContentRootPath, SvcExtensionPattern, SearchOption.AllDirectories))
+			{
+				svcFiles.Add(file);
+			}
+		}
 		string SvcFile(string controller)
 		{
-			if (svcFiles == null)
-			{
-				svcFiles = new HashSet<string>();
-				foreach (string file in Directory.GetFiles(ContentRootPath, SvcExtensionPattern, SearchOption.AllDirectories))
-				{
-					svcFiles.Add(file);
-				}
-			}
 			string fileName;
-			string controllerFullName = Path.Combine(ContentRootPath, controller);
-			if (svcFiles.TryGetValue(new FileInfo(controllerFullName).FullName, out fileName))
+			string controllerFullName = new FileInfo(Path.Combine(ContentRootPath, controller)).FullName;
+			if (svcFiles.TryGetValue(controllerFullName, out fileName))
 				return fileName;
 			else
+			{
+				GXLogging.Warn(log, "svc not fount:" + controllerFullName);
 				return null;
+			}
 			
 		}
 		public void ServicesGroupSetting()
@@ -601,7 +604,18 @@ namespace GxClasses.Web.Middleware
 
 
 	}
+	internal class CaseInsensitiveStringEqualityComparer : IEqualityComparer<string>
+	{
+		public bool Equals(string x, string y)
+		{
+			return string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
+		}
 
+		public int GetHashCode(string obj)
+		{
+			return obj.ToLower().GetHashCode();
+		}
+	}
 	public static class AzureFeature
 	{
 		public const string AzureServerless = "AzureServerless";

--- a/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXUtilsCommon.cs
@@ -2656,18 +2656,18 @@ namespace GeneXus.Utils
 			}
 			return nullDate;
 		}
-		internal static DateTime CToDT2(string jsonDate) {
+		internal static DateTime CToDT2(string jsonDate, IGxContext context) {
 
 			if (!string.IsNullOrEmpty(jsonDate) && (jsonDate.Contains(ISO_8601_TIME_SEPARATOR) || jsonDate.Contains(ISO_8601_TIME_SEPARATOR_1)))
 			{
-				return CToT2(jsonDate);
+				return CToT2(jsonDate, context);
 			}
 			else
 			{
 				return CToD2(jsonDate);
 			}
 		}
-		public static DateTime CToT2(string value)
+		public static DateTime CToT2(string value, IGxContext context)
 		{
 			if (isNullJsonDate(value))
 				return nullDate;
@@ -2684,38 +2684,76 @@ namespace GeneXus.Utils
 					}
 				}
 				if (Preferences.useTimezoneFix())
-					ret = fromUniversalTime(ret);
+				{
+					if (context==null)
+						ret = fromUniversalTime(ret);
+					else
+						ret = fromUniversalTime(ret, context);
+				}
 				return ret;
 			}
 		}
+		//[Obsolete("CToT2 is deprecated, use CToT2(string, IGxContext) instead", false)]
+		public static DateTime CToT2(string value)
+		{
+			return CToT2(value, null);
+		}
+		//[Obsolete("TToC2 is deprecated, use TToC2(DateTime, IGxContext) instead", false)]
 		public static string TToC2(DateTime dt)
 		{
 			return TToC2(dt, true);
 		}
+		public static string TToC2(DateTime dt, IGxContext context)
+		{
+			return TToC2(dt, true, context);
+		}
+		//[Obsolete("TToC2 is deprecated, use TToC2(DateTime, bool, IGxContext) instead", false)]
 		public static string TToC2(DateTime dt, bool toUTC)
 		{
-			return TToCRest(dt, "0000-00-00T00:00:00", JsonDateFormat, toUTC);
+			return TToCRest(dt, "0000-00-00T00:00:00", JsonDateFormat, null, toUTC);
 		}
+		internal static string TToC2(DateTime dt, bool toUTC, IGxContext context)
+		{
+			return TToCRest(dt, "0000-00-00T00:00:00", JsonDateFormat, context, toUTC);
+		}
+		//[Obsolete("TToC3 is deprecated, use TToC3(DateTime, IGxContext) instead", false)]
 
 		public static string TToC3(DateTime dt)
 		{
 			return TToC3(dt, true);
 		}
+		public static string TToC3(DateTime dt, IGxContext context)
+		{
+			return TToC3(dt, true, context);
+		}
 		internal const string JsonDateFormatMillis = "yyyy-MM-ddTHH:mm:ss.fff";
 		internal const string JsonDateFormat = "yyyy-MM-ddTHH:mm:ss";
-		
+
+		//[Obsolete("TToC3 is deprecated, use TToC3(DateTime, bool, IGxContext) instead", false)]
 		public static string TToC3(DateTime dt, bool toUTC)
 		{
-			return TToCRest(dt, "0000-00-00T00:00:00.000", JsonDateFormatMillis, toUTC);
+			return TToCRest(dt, "0000-00-00T00:00:00.000", JsonDateFormatMillis, null, toUTC);
+		}
+		internal static string TToC3(DateTime dt, bool toUTC, IGxContext context)
+		{
+			return TToCRest(dt, "0000-00-00T00:00:00.000", JsonDateFormatMillis, context, toUTC);
 		}
 
-		static string TToCRest(DateTime dt, String nullString, String formatStr, bool toUTC=true)
+		static string TToCRest(DateTime dt, String nullString, String formatStr, IGxContext context, bool toUTC=true)
 		{
 			if (dt == nullDate)
 				return FormatEmptyDate(nullString);
 			else
 			{
-				DateTime ret = Preferences.useTimezoneFix() ? (toUTC ? toUniversalTime(dt) : dt) : dt;
+				DateTime ret;
+				if (context != null)
+				{
+					ret = Preferences.useTimezoneFix() ? (toUTC ? toUniversalTime(dt, context) : dt) : dt;
+				}
+				else
+				{
+					ret = Preferences.useTimezoneFix() ? (toUTC ? toUniversalTime(dt) : dt) : dt;
+				}
 				return ret.ToString(formatStr, CultureInfo.InvariantCulture);
 			}
 		}
@@ -3536,7 +3574,7 @@ namespace GeneXus.Utils
 			else
 				return isNullDate(dt);
 		}
-
+		//[Obsolete("fromUniversalTime is deprecated, use fromUniversalTime(DateTime, IGxContext) instead", false)]
 		static public DateTime fromUniversalTime(DateTime dt)
 		{
 #if NODATIME
@@ -3545,7 +3583,15 @@ namespace GeneXus.Utils
 			return isNullDateCompatible(dt) ? dt : fromUniversalTime(dt, GxContext.Current.GetOlsonTimeZone());
 #endif
 		}
-
+		static public DateTime fromUniversalTime(DateTime dt, IGxContext context)
+		{
+#if NODATIME
+			return isNullDateCompatible(dt) ? dt : fromUniversalTime(dt, context.GetTimeZone());
+#else
+			return isNullDateCompatible(dt) ? dt : fromUniversalTime(dt, context.GetOlsonTimeZone());
+#endif
+		}
+		//[Obsolete("toUniversalTime is deprecated, use toUniversalTime(DateTime, IGxContext) instead", false)]
 		static public DateTime toUniversalTime(DateTime dt)
 		{
 #if NODATIME

--- a/dotnet/src/dotnetframework/GxClasses/Services/ReflectionHelper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/ReflectionHelper.cs
@@ -150,7 +150,7 @@ namespace GeneXus.Application
 			else if (newType == typeof(DateTime))
 			{
 				string jsonDate = value as string;
-				return DateTimeUtil.CToDT2(jsonDate);
+				return DateTimeUtil.CToDT2(jsonDate, context);
 			}
 			else if (newType == typeof(Geospatial))
 			{


### PR DESCRIPTION
Issue:105966
The use of GxContext.Current is deprecated and should be avoided.
Load service files during startup to better handle a request storm at the startup of kestrel.