### PR TITLE
Customize session id cookie name to allow multiple websites deployed under the same domain.

### DIFF
--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -196,6 +196,12 @@ namespace GeneXus.Application
 				options.Cookie.HttpOnly = true;
 				options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
 				options.Cookie.IsEssential = true;
+				string sessionCookieName = GxWebSession.GetSessionCookieName(VirtualPath);
+				if (!string.IsNullOrEmpty(sessionCookieName))
+				{
+					options.Cookie.Name=sessionCookieName;
+					GxWebSession.SessionCookieName = sessionCookieName;
+				}
 				string sameSite;
 				SameSiteMode sameSiteMode = SameSiteMode.Unspecified;
 				if (Config.GetValueOf("SAMESITE_COOKIE", out sameSite) && Enum.TryParse<SameSiteMode>(sameSite, out sameSiteMode))

--- a/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
@@ -157,7 +157,25 @@ namespace GeneXus.Configuration
 				return false;
 			}
 		}
-
+		internal static bool GetValueOrEnvironmentVarOf(string sId, out string sString)
+		{
+			try
+			{
+				sString = config.Get(sId);
+				if (String.IsNullOrEmpty(sString))
+				{
+					MappedValue(sId, sString);
+					if (string.IsNullOrEmpty(sString))
+						return false;
+				}
+				return true;
+			}
+			catch
+			{
+				sString = string.Empty;
+				return false;
+			}
+		}
 		public static bool GetValueOf(string sId)
 		{
 			string sString;

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxSession.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxSession.cs
@@ -5,10 +5,12 @@ using System.Web;
 using System.Web.SessionState;
 #else
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Session;
 #endif
 using GeneXus.Utils;
 using GeneXus.Encryption;
 using GeneXus.Application;
+using GeneXus.Configuration;
 
 namespace GeneXus.Http
 {
@@ -29,7 +31,12 @@ namespace GeneXus.Http
 	}
 
     public class GxWebSession : IGxSession
-    {
+	{
+#if NETCORE
+		const string SESSION_COOKIE_NAME = "SESSION_COOKIE_NAME";
+		const string ASPNETCORE_APPL_PATH = "ASPNETCORE_APPL_PATH";
+#endif
+
 		private static readonly IGXLogger log = GXLoggerFactory.GetLogger<GxWebSession>();
         private HttpSessionState _httpSession;
 		#region InternalKeys
@@ -215,19 +222,61 @@ namespace GeneXus.Http
 				if (httpContext.IsNewSession())
                 {
                     string CookieHeaders = httpContext.Request.Headers["Cookie"];
-
-                    if ((null != CookieHeaders) && ((CookieHeaders.IndexOf("ASP.NET_SessionId") >= 0)|| CookieHeaders.IndexOf(".AspNetCore.Session") >= 0))
-                    {
-                        // IsNewSession is true, but session cookie exists,
-                        // so, ASP.NET session is expired
-                        return true;
+					if ((null != CookieHeaders) && (CookieHeaders.IndexOf(SessionCookieName) >= 0))
+					{
+						// IsNewSession is true, but session cookie exists,
+						// so, ASP.NET session is expired
+						return true;
                     }
                 }
             }
             return false;
         }
+#if NETCORE
+		internal static string GetSessionCookieName(string virtualPath)
+		{
+			string cookieName;
+			if (Config.GetValueOrEnvironmentVarOf(SESSION_COOKIE_NAME, out cookieName))
+				return cookieName;
+			else
+			{
+				if (!string.IsNullOrEmpty(virtualPath))
+				{
+					return $"{SessionDefaults.CookieName}.{virtualPath.ToLower()}";
+				}
+				else
+				{
+					string applPath = Config.ConfigRoot[ASPNETCORE_APPL_PATH];
 
-    }
+					if (!string.IsNullOrEmpty(applPath))
+					{
+						cookieName = ToCookieName(applPath).ToLower();
+						return $"{SessionDefaults.CookieName}.{cookieName}";
+					}
+				}
+				return SessionDefaults.CookieName;
+			}
+		}
+		static string ToCookieName(string name)
+		{
+			char[] cookieName = new char[name.Length];
+			int index = 0;
+
+			foreach (char character in name)
+			{
+				if (char.IsLetter(character) || char.IsNumber(character))
+				{
+					cookieName[index] = character;
+					index++;
+				}
+			}
+			return new string(cookieName, 0, index);
+		}
+		internal static string SessionCookieName { get; set; }
+#else
+		const string SessionCookieName="ASP.NET_SessionId";
+#endif
+	}
 
     public class GxSession : IGxSession
     {


### PR DESCRIPTION
Issue:106039
This prevents conflicts between applications, as having the same cookie names set at the domain root path could lead to unintended overrides.