### PR TITLE
Treat low and moderate vulnerabilities as warnings

### DIFF
--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -29,6 +29,8 @@
 		<NoWarn>NU5105;CS0618;CS8032;CS0618;SYSLIB0021;SYSLIB0023</NoWarn>
 		<IsPackable>true</IsPackable>
 		<DisableImplicitNamespaceImports>True</DisableImplicitNamespaceImports>
+		<!--keep low and moderate vulnerabilities (NU1901;NU1902;NU1903;NU1904) as warnings but treat high and critical vulnerabilities (NU1903 and NU1904) as errors-->
+		<WarningsNotAsErrors>NU1900;NU1901;NU1902;</WarningsNotAsErrors>
 	</PropertyGroup>
 
 	<Target Name="GetFileVersionForPackage">


### PR DESCRIPTION
Keep high and critical vulnerabilities as errors.
