### PR TITLE
The cookie header was not parsed correctly

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -584,7 +584,12 @@ namespace GeneXus.Http.Client
 						{
 							if (cookie.Contains("="))
 							{
-								cookies.Add(new Uri(request.RequestUri.Host), new Cookie(cookie.Split('=')[0], cookie.Split('=')[1]) { Domain = request.RequestUri.Host });
+								UriBuilder uriBuilder = new UriBuilder(request.RequestUri.Scheme, request.RequestUri.Host);
+								Cookie pCookie = ParseCookie(cookie, request.RequestUri.Host);
+								if (pCookie != null)
+								{
+									cookies.Add(uriBuilder.Uri, pCookie);
+								}
 							}
 						}
 						break;
@@ -607,6 +612,16 @@ namespace GeneXus.Http.Client
 					headers.ConnectionClose = false;
 			}
 			InferContentType(contentType, request);
+		}
+		Cookie ParseCookie(string cookie, string domain)
+		{
+			string[] values = cookie.TrimEnd(';').Split('=');
+			if (values.Length >= 2) {
+				string cookieName = values[0].Trim();
+				string cookieValue = values[1];
+				return new Cookie(cookieName, cookieValue) { Domain = domain };
+			}
+			return null;
 		}
 		void AddHeader(HttpRequestHeaders headers, string headerName, string headerValue)
 		{

--- a/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
@@ -27,7 +27,6 @@ namespace xUnitTesting
 				httpclient.Execute("GET", string.Empty);
 				Assert.NotEqual(((int)HttpStatusCode.InternalServerError), httpclient.StatusCode);
 			}
-
 		}
 
 		[Fact]

--- a/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
@@ -45,6 +45,32 @@ namespace xUnitTesting
 				Assert.NotEqual(((int)HttpStatusCode.InternalServerError), httpclient.StatusCode);
 			}
 		}
+
+		[Fact]
+		public void HttpClientCookieHeader()
+		{
+			string headerValue = "CognitoIdentityServiceProvider.3tgmin25m9bkg6vgi7vpavu7a9.M00000936.refreshToken=eyJjdHkiOiJKV1QiLCJlbmMiSkRCAmMpYqndvORnWLTfHw; CognitoIdentityServiceProvider.3tgmin25m9bkg6vgi7vpavu7a9.LastAuthUser=M00000936";
+			string headerName = "Cookie";
+			using (GxHttpClient httpclient = new GxHttpClient())
+			{
+				httpclient.AddHeader(headerName, headerValue);
+				httpclient.Host = "localhost";
+				httpclient.Port = 80;
+				httpclient.BaseURL = @"NotFound/NotFound.php";
+				httpclient.HttpClientExecute("GET", string.Empty);
+				Assert.NotEqual(((int)HttpStatusCode.InternalServerError), httpclient.StatusCode);
+			}
+			using (GxHttpClient oldHttpclient = new GxHttpClient())
+			{
+				oldHttpclient.AddHeader(headerName, headerValue);
+				oldHttpclient.Host = "localhost";
+				oldHttpclient.Port = 80;
+				oldHttpclient.BaseURL = @"NotFound/NotFound.php";
+				oldHttpclient.Execute("GET", string.Empty);
+				Assert.NotEqual(((int)HttpStatusCode.InternalServerError), oldHttpclient.StatusCode);
+			}
+
+		}
 #if !NETCORE
 		[Fact]
 		public void NoStoreHeader()


### PR DESCRIPTION
It failed when the value had a blank space before the cookie name.
Issue:106515