### PR TITLE
Fix error "System.ArgumentException: Illegal characters in path" when adding an external image to reports

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Printer/GxPrinter.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Printer/GxPrinter.cs
@@ -16,6 +16,7 @@ namespace GeneXus.Printer
 	using System.Threading;
 	using System.Threading.Tasks;
 	using GeneXus.Configuration;
+	using GeneXus.Utils;
 	using GeneXus.XML;
 
 	public interface IPrintHandler
@@ -2162,10 +2163,19 @@ namespace GeneXus.Printer
 	{
 		static public string AddPath(string name, string path)
 		{
-			if (Path.IsPathRooted(name) || name.IndexOf(":") != -1 ||
+			if (name.IndexOf(":") != -1 ||
 				(name.Length >=2 && (name.Substring( 0,2) == "//" || name.Substring( 0,2) == @"\\")) ||
 				(name.StartsWith("http:" ) || name.StartsWith("https:" )))
 				return name;
+#if NETCORE
+			if (Path.IsPathRooted (name))
+				return name;
+#else
+			if (PathUtil.IsValidFilePath(name) && Path.IsPathRooted(name))
+			{
+				return name;
+			}
+#endif
 			return Path.Combine(path, name);
 		}
 	}

--- a/dotnet/test/DotNetUnitTest/FileIO/FileIOTests.cs
+++ b/dotnet/test/DotNetUnitTest/FileIO/FileIOTests.cs
@@ -117,5 +117,15 @@ namespace UnitTesting
 			string fullPath = ReportUtils.AddPath(name, path);
 			Assert.Equal(name, fullPath);
 		}
+		[Fact]
+		public void ReportUtilAddPathWithIllegalCharacters()
+		{
+			string name = "https://chart.googleapis.com/chart?chs=400x400&cht=qr&chl=http://sistemas.gov/nfceweb/consultarNFCe.jsp?p=13231205514674000128650020009504049878593990|2|1|09|1337.07|4558626967746769617A304E4B7A6D34504B4E61524A474F4D32513D|1|14D0A30916C6C7EA709E7E33E330EE3F290FE25D";
+			string path = "C:/Models/Report/NETModel/Web/";
+			string fullPath = ReportUtils.AddPath(name, path);
+
+			Assert.Equal(name, fullPath);
+		}
+
 	}
 }


### PR DESCRIPTION
Path.IsPathRooted validates the path for valid charactersPath (only in .NET Framework)
Issue:106511