### PR TITLE
Null value in the static HttpContext.Current property when used from a thread worker

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -2281,6 +2281,9 @@ namespace GeneXus.Http
 		private void webExecuteWorker(object target)
 		{
 			HttpContext httpContext = (HttpContext)target;
+#if !NETCORE
+			HttpContext.Current = httpContext;
+#endif
 			try
 			{
 				webExecuteEx(httpContext);


### PR DESCRIPTION
The static HttpContext.Current property returns null when the calling-thread is not the same thread that was associated with the current HTTP request/response, because HttpContext.Current uses thread-local storage.
To address this, a workaround is added specifically for calls from objects with UseBigStack enabled. Which resolves the wrong value returned by the GxHttpContext.IsHttpContext method. 
Issue:106662