### PR TITLE
Improve ajax deserialization performance at BeforeInvoke.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/Web/HttpAjaxContext.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/Web/HttpAjaxContext.cs
@@ -85,7 +85,7 @@ namespace GeneXus.Http
 
 		public bool isInputParm(string key)
 		{
-			return inParmsMetadataHash.Contains(key);
+			return (inParmsMetadataHash!=null && inParmsMetadataHash.Contains(key));
 		}
 
 		public void Clear()
@@ -105,7 +105,7 @@ namespace GeneXus.Http
 			IGxJSONSerializable jsonValue = value as IGxJSONSerializable;
 			if (jsonValue!=null)
 			{
-				if (!inParmsHashValue.ContainsKey(fieldName))
+				if (inParmsHashValue!=null && !inParmsHashValue.ContainsKey(fieldName))
 					return true;
 				return GXUtil.GetHash(jsonValue.ToJSonString()) != inParmsHashValue[fieldName];
 			}

--- a/dotnet/src/dotnetframework/GxClasses/Core/Web/HttpAjaxContext.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/Web/HttpAjaxContext.cs
@@ -346,7 +346,7 @@ namespace GeneXus.Http
 					try
 					{
 						JObject obj = GetGxObject(AttValues, CmpContext, IsMasterPage);
-						if (obj != null && (DynAjaxEventContext.isParmModified(AttName, SdtObj) || !isUndefinedOutParam( AttName, SdtObj)))
+						if (obj != null && (!isUndefinedOutParam(AttName, SdtObj) || DynAjaxEventContext.isParmModified(AttName, SdtObj)))
 						{
 							IGxJSONAble SdtObjJson = SdtObj as IGxJSONAble;
 							if (SdtObjJson != null)

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
@@ -1045,7 +1045,7 @@ namespace GeneXus.Utils
 	public class GxUserType : IGxXMLSerializable, ICloneable, IGxJSONAble, IGxJSONSerializable, IGXAssigned
 	{
 		static readonly IGXLogger log = GXLoggerFactory.GetLogger<GxUserType>();
-		protected GXProperties dirties = new GXProperties();
+		protected ConcurrentDictionary<string,byte> dirties = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
 		private const string PROPERTY_PREFIX = "gxtpr_";
 		static object setupChannelObject = null;
 		static bool setupChannelInitialized;
@@ -1104,11 +1104,11 @@ namespace GeneXus.Utils
 
 	public virtual void SetDirty(string fieldName)
 		{
-			dirties[fieldName.ToLower()] = "true";
+			dirties[fieldName] = 1;
 		}
 		public virtual bool IsDirty(string fieldName)
 		{
-			if (dirties.ContainsKey(fieldName.ToLower()))
+			if (dirties.ContainsKey(fieldName))
 				return true;
 			return false;
 		}
@@ -1906,15 +1906,15 @@ namespace GeneXus.Utils
 		}
 		private bool IsGxUploadAttribute(PropertyInfo propertyInfo)
 		{
-			return GxUploadAttrs.ContainsKey(propertyInfo.Name.ToLower());
+			return GxUploadAttrs.ContainsKey(propertyInfo.Name);
 		}
 		private string JsonNameToInternalName(string jsonPropertyName)
 		{
 			string map = JsonMap(jsonPropertyName);
 			if (!string.IsNullOrEmpty(map))
-				return $"{PROPERTY_PREFIX}{map.ToLower()}";
+				return $"{PROPERTY_PREFIX}{map}";
 			else
-				return $"{PROPERTY_PREFIX}{jsonPropertyName.ToLower()}";
+				return $"{PROPERTY_PREFIX}{jsonPropertyName}";
 		}
 		protected virtual GXTypeInfo TypeInfo { get { return _compatibilityGxuploadAttrs; } set { _compatibilityGxuploadAttrs = value; } }
 		private ConcurrentDictionary<string, byte> GxUploadAttrs
@@ -1925,7 +1925,7 @@ namespace GeneXus.Utils
 				{
 					TypeInfo = new GXTypeInfo();
 
-					TypeInfo.UploadAttrs = new ConcurrentDictionary<string, byte>();
+					TypeInfo.UploadAttrs = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
 					foreach (PropertyInfo property in this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
 					{
 						if (property.Name.StartsWith(PROPERTY_PREFIX, StringComparison.OrdinalIgnoreCase))
@@ -1933,7 +1933,7 @@ namespace GeneXus.Utils
 							bool hasAtt = property.IsDefined(typeof(GxUpload), false);
 							if (hasAtt)
 							{
-								TypeInfo.UploadAttrs.TryAdd(property.Name.ToLower(), 1);
+								TypeInfo.UploadAttrs.TryAdd(property.Name, 1);
 							}
 						}
 					}
@@ -2025,13 +2025,8 @@ namespace GeneXus.Utils
 			GetType().GetProperty($"gxTpr_{propertyName}").SetValue(this, propertyValue);
 		}
 	}
-	internal class GXCompatibilityTypeInfo : GXTypeInfo
-	{
-
-	}
 	public class GXTypeInfo
 	{
-		public ConcurrentDictionary<string, PropertyInfo> TypeProps { get; set; }
 		public ConcurrentDictionary<string, byte> UploadAttrs { get; set; }
 	}
 	public interface IGxJSONAble

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
@@ -19,6 +19,7 @@ namespace GeneXus.Utils
 	using System.Xml.Serialization;
 	using GeneXus.Application;
 	using GeneXus.Configuration;
+	using GeneXus.Data;
 	using GeneXus.Http;
 	using GeneXus.Metadata;
 	using GeneXus.XML;
@@ -1045,7 +1046,7 @@ namespace GeneXus.Utils
 	{
 		static readonly IGXLogger log = GXLoggerFactory.GetLogger<GxUserType>();
 		protected GXProperties dirties = new GXProperties();
-
+		private const string PROPERTY_PREFIX = "gxtpr_";
 		static object setupChannelObject = null;
 		static bool setupChannelInitialized;
 		[XmlIgnore]
@@ -1605,24 +1606,27 @@ namespace GeneXus.Utils
 
 		private ICollection getFromJSONObjectOrderIterator(ICollection it)
 		{
-			List<string> v = new List<string>();
+			if (GxUploadAttrs.IsEmpty && !typeof(GxSilentTrnSdt).IsAssignableFrom(this.GetType()))
+			{
+				return it;
+			}
+			List<string> _JsonObjectOrderIterator = new List<string>();
+
 			List<string> vAtEnd = new List<string>();
 			foreach (string name in it)
 			{
-				string map = JsonMap(name);
-				PropertyInfo objProperty = GetTypeProperty("gxtpr_" + (!string.IsNullOrEmpty(map) ? map : name).ToLower());
-				if (name.EndsWith("_N") || objProperty != null && IsGxUploadAttribute(objProperty))
+				if (name.EndsWith("_N") || IsGxUploadAttribute(name))
 				{
 					vAtEnd.Add(name);
 				}
 				else
 				{
-					v.Add(name);//keep the order of attributes that do not end with _N.
+					_JsonObjectOrderIterator.Add(name);//keep the order of attributes that do not end with _N.
 				}
 			}
 			if (vAtEnd.Count > 0)
-				v.AddRange(vAtEnd);
-			return v;
+				_JsonObjectOrderIterator.AddRange(vAtEnd);
+			return _JsonObjectOrderIterator;
 		}
 
 		public void FromJSONObject(dynamic obj)
@@ -1635,9 +1639,7 @@ namespace GeneXus.Utils
 			foreach (string name in jsonIterator)
 			{
 				object currObj = jobj[name];
-				string map = JsonMap(name);
-				PropertyInfo objProperty = GetTypeProperty("gxtpr_" + (map != null ? map : name).ToLower());
-
+				PropertyInfo objProperty = GetTypeProperty(JsonNameToInternalName(name));
 				if (objProperty != null)
 				{
 					if (!JSONHelper.IsJsonNull(currObj))
@@ -1897,32 +1899,66 @@ namespace GeneXus.Utils
 			return success;
 		}
 
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("GxFxCopRules", "CR1000:EnforceThreadSafeType")]
-		private Dictionary<string, bool> gxuploadAttrs = new Dictionary<string, bool>();
-		private bool IsGxUploadAttribute(PropertyInfo property)
+		private GXCompatibilityTypeInfo _compatibilityGxuploadAttrs = new GXCompatibilityTypeInfo();
+		private bool IsGxUploadAttribute(string jsonPropertyName)
 		{
-			string key = property.Name;
-			if (!gxuploadAttrs.ContainsKey(key))
-			{
-				bool hasAtt = property.IsDefined(typeof(GxUpload), false);
-				gxuploadAttrs.Add(key, hasAtt);
-			}
-			return gxuploadAttrs[key];
+			return GxUploadAttrs.ContainsKey(JsonNameToInternalName(jsonPropertyName));
 		}
+		private bool IsGxUploadAttribute(PropertyInfo propertyInfo)
+		{
+			return GxUploadAttrs.ContainsKey(propertyInfo.Name.ToLower());
+		}
+		private string JsonNameToInternalName(string jsonPropertyName)
+		{
+			string map = JsonMap(jsonPropertyName);
+			if (!string.IsNullOrEmpty(map))
+				return $"{PROPERTY_PREFIX}{map.ToLower()}";
+			else
+				return $"{PROPERTY_PREFIX}{jsonPropertyName.ToLower()}";
+		}
+		protected virtual GXTypeInfo TypeInfo { get { return _compatibilityGxuploadAttrs; } set { } }
+		private ConcurrentDictionary<string, byte> GxUploadAttrs
+		{
+			get
+			{
+				if (TypeInfo == null)
+				{
+					TypeInfo = new GXTypeInfo();
 
-		private Hashtable props;
-
+					TypeInfo.UploadAttrs = new ConcurrentDictionary<string, byte>();
+					foreach (PropertyInfo property in this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+					{
+						if (property.Name.StartsWith(PROPERTY_PREFIX, StringComparison.OrdinalIgnoreCase))
+						{
+							bool hasAtt = property.IsDefined(typeof(GxUpload), false);
+							if (hasAtt)
+							{
+								TypeInfo.UploadAttrs.TryAdd(property.Name.ToLower(), 1);
+							}
+						}
+					}
+				}
+				else if (TypeInfo is GXCompatibilityTypeInfo)
+				{
+					TypeInfo.UploadAttrs = new ConcurrentDictionary<string, byte>();
+					foreach (PropertyInfo property in this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+					{
+						if (property.Name.StartsWith(PROPERTY_PREFIX, StringComparison.OrdinalIgnoreCase))
+						{
+							bool hasAtt = property.IsDefined(typeof(GxUpload), false);
+							if (hasAtt)
+							{
+								TypeInfo.UploadAttrs.TryAdd(property.Name.ToLower(), 1);
+							}
+						}
+					}
+				}
+				return TypeInfo.UploadAttrs;
+			}
+		}
 		private PropertyInfo GetTypeProperty(string propName)
 		{
-			if (props == null)
-			{
-				props = new Hashtable();
-				foreach (PropertyInfo prop in this.GetType().GetProperties())
-				{
-					props.Add(prop.Name.ToLower(), prop);
-				}
-			}
-			return (PropertyInfo)props[propName];
+			return this.GetType().GetProperty(propName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
 		}
 
 		private Hashtable methods;
@@ -2004,7 +2040,15 @@ namespace GeneXus.Utils
 			GetType().GetProperty($"gxTpr_{propertyName}").SetValue(this, propertyValue);
 		}
 	}
+	internal class GXCompatibilityTypeInfo : GXTypeInfo
+	{
 
+	}
+	public class GXTypeInfo
+	{
+		public ConcurrentDictionary<string, PropertyInfo> TypeProps { get; set; }
+		public ConcurrentDictionary<string, byte> UploadAttrs { get; set; }
+	}
 	public interface IGxJSONAble
 	{
 		void AddObjectProperty(string name, object prop);

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
@@ -1899,7 +1899,7 @@ namespace GeneXus.Utils
 			return success;
 		}
 
-		private GXCompatibilityTypeInfo _compatibilityGxuploadAttrs = new GXCompatibilityTypeInfo();
+		private GXTypeInfo _compatibilityGxuploadAttrs = null;
 		private bool IsGxUploadAttribute(string jsonPropertyName)
 		{
 			return GxUploadAttrs.ContainsKey(JsonNameToInternalName(jsonPropertyName));
@@ -1916,7 +1916,7 @@ namespace GeneXus.Utils
 			else
 				return $"{PROPERTY_PREFIX}{jsonPropertyName.ToLower()}";
 		}
-		protected virtual GXTypeInfo TypeInfo { get { return _compatibilityGxuploadAttrs; } set { } }
+		protected virtual GXTypeInfo TypeInfo { get { return _compatibilityGxuploadAttrs; } set { _compatibilityGxuploadAttrs = value; } }
 		private ConcurrentDictionary<string, byte> GxUploadAttrs
 		{
 			get
@@ -1925,21 +1925,6 @@ namespace GeneXus.Utils
 				{
 					TypeInfo = new GXTypeInfo();
 
-					TypeInfo.UploadAttrs = new ConcurrentDictionary<string, byte>();
-					foreach (PropertyInfo property in this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
-					{
-						if (property.Name.StartsWith(PROPERTY_PREFIX, StringComparison.OrdinalIgnoreCase))
-						{
-							bool hasAtt = property.IsDefined(typeof(GxUpload), false);
-							if (hasAtt)
-							{
-								TypeInfo.UploadAttrs.TryAdd(property.Name.ToLower(), 1);
-							}
-						}
-					}
-				}
-				else if (TypeInfo is GXCompatibilityTypeInfo)
-				{
 					TypeInfo.UploadAttrs = new ConcurrentDictionary<string, byte>();
 					foreach (PropertyInfo property in this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
 					{

--- a/dotnet/test/DotNetCoreUnitTest/StringUtil/JsonUtilTest.cs
+++ b/dotnet/test/DotNetCoreUnitTest/StringUtil/JsonUtilTest.cs
@@ -190,6 +190,19 @@ namespace xUnitTesting
 			JArray array = JSONHelper.ReadJSON<JArray>(json);
 			Assert.Equal(7, array.Count);
 		}
+#if NETCORE
+		[Fact]
+		public void DeserializationTwoLevels()
+		{
+			string json = "{\"Name\":\"MainName\",\"Level\":[{\"LevelName\":\"LevelName1\"}, {\"LevelName\":\"LevelName2\"}]}";
+			GxContext context = new GxContext();
+			SdtSDTTwoLevels sdt = new SdtSDTTwoLevels(context);
+			sdt.FromJSonString(json, null);
+			Assert.Equal("MainName", sdt.gxTpr_Name);
+			Assert.Equal("LevelName1",((SdtSDTTwoLevels_LevelItem)sdt.gxTpr_Level.Item(1)).gxTpr_Levelname);
+			Assert.Equal("LevelName2", ((SdtSDTTwoLevels_LevelItem)sdt.gxTpr_Level.Item(2)).gxTpr_Levelname);
+		}
+#endif
 	}
 
 	[XmlSerializerFormat]

--- a/dotnet/test/DotNetCoreUnitTest/StringUtil/type_SdtSDTTwoLevels.cs
+++ b/dotnet/test/DotNetCoreUnitTest/StringUtil/type_SdtSDTTwoLevels.cs
@@ -1,0 +1,227 @@
+/*
+				   File: type_SdtSDTTwoLevels
+			Description: SDTTwoLevels
+				 Author: Nemo 🐠 for C# (.NET) version 18.0.9.180423
+		   Program type: Callable routine
+			  Main DBMS: 
+*/
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Xml.Serialization;
+using GeneXus.Application;
+using GeneXus.Utils;
+
+
+namespace GeneXus.Programs
+{
+	[XmlRoot(ElementName="SDTTwoLevels")]
+	[XmlType(TypeName="SDTTwoLevels" , Namespace="MassiveSearch" )]
+	[Serializable]
+	public class SdtSDTTwoLevels : GxUserType
+	{
+		public SdtSDTTwoLevels( )
+		{
+			/* Constructor for serialization */
+			gxTv_SdtSDTTwoLevels_Name = "";
+
+		}
+
+		public SdtSDTTwoLevels(IGxContext context)
+		{
+			this.context = context;	
+			initialize();
+		}
+
+		#region Json
+		private static Hashtable mapper;
+		public override string JsonMap(string value)
+		{
+			if (mapper == null)
+			{
+				mapper = new Hashtable();
+			}
+			return (string)mapper[value]; ;
+		}
+
+		public override void ToJSON()
+		{
+			ToJSON(true) ;
+			return;
+		}
+
+		public override void ToJSON(bool includeState)
+		{
+			AddObjectProperty("Name", gxTpr_Name, false);
+
+			if (gxTv_SdtSDTTwoLevels_Level != null)
+			{
+				AddObjectProperty("Level", gxTv_SdtSDTTwoLevels_Level, false);
+			}
+			return;
+		}
+		#endregion
+
+		#region Properties
+
+		[SoapElement(ElementName="Name")]
+		[XmlElement(ElementName="Name")]
+		public string gxTpr_Name
+		{
+			get {
+				return gxTv_SdtSDTTwoLevels_Name; 
+			}
+			set {
+				gxTv_SdtSDTTwoLevels_Name = value;
+				SetDirty("Name");
+			}
+		}
+
+
+
+
+		[SoapElement(ElementName="Level" )]
+		[XmlArray(ElementName="Level"  )]
+		[XmlArrayItemAttribute(ElementName="LevelItem" , IsNullable=false )]
+		public GXBaseCollection<SdtSDTTwoLevels_LevelItem> gxTpr_Level
+		{
+			get {
+				if ( gxTv_SdtSDTTwoLevels_Level == null )
+				{
+					gxTv_SdtSDTTwoLevels_Level = new GXBaseCollection<SdtSDTTwoLevels_LevelItem>( context, "SDTTwoLevels.LevelItem", "");
+				}
+				return gxTv_SdtSDTTwoLevels_Level;
+			}
+			set {
+				gxTv_SdtSDTTwoLevels_Level_N = false;
+				gxTv_SdtSDTTwoLevels_Level = value;
+				SetDirty("Level");
+			}
+		}
+
+		public void gxTv_SdtSDTTwoLevels_Level_SetNull()
+		{
+			gxTv_SdtSDTTwoLevels_Level_N = true;
+			gxTv_SdtSDTTwoLevels_Level = null;
+		}
+
+		public bool gxTv_SdtSDTTwoLevels_Level_IsNull()
+		{
+			return gxTv_SdtSDTTwoLevels_Level == null;
+		}
+		public bool ShouldSerializegxTpr_Level_GxSimpleCollection_Json()
+		{
+			return gxTv_SdtSDTTwoLevels_Level != null && gxTv_SdtSDTTwoLevels_Level.Count > 0;
+
+		}
+
+
+		public override bool ShouldSerializeSdtJson()
+		{
+			return true;
+		}
+
+
+
+		#endregion
+
+		#region Static Type Properties
+		[SoapIgnore]
+		[XmlIgnore]
+		private static GXTypeInfo _typeProps;
+		protected override GXTypeInfo TypeInfo { get { return _typeProps; } set { _typeProps = value; } }
+		#endregion
+
+		#region Initialization
+
+		public void initialize( )
+		{
+			gxTv_SdtSDTTwoLevels_Name = "";
+
+			gxTv_SdtSDTTwoLevels_Level_N = true;
+
+			return  ;
+		}
+
+
+
+		#endregion
+
+		#region Declaration
+
+		protected string gxTv_SdtSDTTwoLevels_Name;
+		 
+		protected bool gxTv_SdtSDTTwoLevels_Level_N;
+		protected GXBaseCollection<SdtSDTTwoLevels_LevelItem> gxTv_SdtSDTTwoLevels_Level = null; 
+
+
+
+		#endregion
+	}
+	#region Rest interface
+	[GxUnWrappedJson()]
+	[DataContract(Name=@"SDTTwoLevels", Namespace="MassiveSearch")]
+	public class SdtSDTTwoLevels_RESTInterface : GxGenericCollectionItem<SdtSDTTwoLevels>, System.Web.SessionState.IRequiresSessionState
+	{
+		public SdtSDTTwoLevels_RESTInterface( ) : base()
+		{	
+		}
+
+		public SdtSDTTwoLevels_RESTInterface( SdtSDTTwoLevels psdt ) : base(psdt)
+		{	
+		}
+
+		#region Rest Properties
+		[DataMember(Name="Name", Order=0)]
+		public  string gxTpr_Name
+		{
+			get { 
+				return StringUtil.RTrim( sdt.gxTpr_Name);
+
+			}
+			set { 
+				 sdt.gxTpr_Name = value;
+			}
+		}
+
+		[DataMember(Name="Level", Order=1, EmitDefaultValue=false)]
+		public GxGenericCollection<SdtSDTTwoLevels_LevelItem_RESTInterface> gxTpr_Level
+		{
+			get {
+				if (sdt.ShouldSerializegxTpr_Level_GxSimpleCollection_Json())
+					return new GxGenericCollection<SdtSDTTwoLevels_LevelItem_RESTInterface>(sdt.gxTpr_Level);
+				else
+					return null;
+
+			}
+			set {
+				value.LoadCollection(sdt.gxTpr_Level);
+			}
+		}
+
+
+		#endregion
+
+		public SdtSDTTwoLevels sdt
+		{
+			get { 
+				return (SdtSDTTwoLevels)Sdt;
+			}
+			set { 
+				Sdt = value;
+			}
+		}
+
+		[OnDeserializing]
+		void checkSdt( StreamingContext ctx )
+		{
+			if ( sdt == null )
+			{
+				sdt = new SdtSDTTwoLevels() ;
+			}
+		}
+	}
+	#endregion
+}

--- a/dotnet/test/DotNetCoreUnitTest/StringUtil/type_SdtSDTTwoLevels_LevelItem.cs
+++ b/dotnet/test/DotNetCoreUnitTest/StringUtil/type_SdtSDTTwoLevels_LevelItem.cs
@@ -1,0 +1,170 @@
+/*
+				   File: type_SdtSDTTwoLevels_LevelItem
+			Description: Level
+				 Author: Nemo 🐠 for C# (.NET) version 18.0.9.180423
+		   Program type: Callable routine
+			  Main DBMS: 
+*/
+using System;
+using System.Collections;
+using GeneXus.Utils;
+using GeneXus.Resources;
+using GeneXus.Application;
+using GeneXus.Metadata;
+using GeneXus.Cryptography;
+using GeneXus.Encryption;
+using GeneXus.Http.Client;
+using GeneXus.Http.Server;
+using System.Reflection;
+using System.Xml.Serialization;
+using System.Runtime.Serialization;
+using System.Collections.Concurrent;
+
+
+namespace GeneXus.Programs
+{
+	[XmlRoot(ElementName="SDTTwoLevels.LevelItem")]
+	[XmlType(TypeName="SDTTwoLevels.LevelItem" , Namespace="MassiveSearch" )]
+	[Serializable]
+	public class SdtSDTTwoLevels_LevelItem : GxUserType
+	{
+		public SdtSDTTwoLevels_LevelItem( )
+		{
+			/* Constructor for serialization */
+			gxTv_SdtSDTTwoLevels_LevelItem_Levelname = "";
+
+		}
+
+		public SdtSDTTwoLevels_LevelItem(IGxContext context)
+		{
+			this.context = context;	
+			initialize();
+		}
+
+		#region Json
+		private static Hashtable mapper;
+		public override string JsonMap(string value)
+		{
+			if (mapper == null)
+			{
+				mapper = new Hashtable();
+			}
+			return (string)mapper[value]; ;
+		}
+
+		public override void ToJSON()
+		{
+			ToJSON(true) ;
+			return;
+		}
+
+		public override void ToJSON(bool includeState)
+		{
+			AddObjectProperty("LevelName", gxTpr_Levelname, false);
+
+			return;
+		}
+		#endregion
+
+		#region Properties
+
+		[SoapElement(ElementName="LevelName")]
+		[XmlElement(ElementName="LevelName")]
+		public string gxTpr_Levelname
+		{
+			get {
+				return gxTv_SdtSDTTwoLevels_LevelItem_Levelname; 
+			}
+			set {
+				gxTv_SdtSDTTwoLevels_LevelItem_Levelname = value;
+				SetDirty("Levelname");
+			}
+		}
+
+
+
+		public override bool ShouldSerializeSdtJson()
+		{
+			return true;
+		}
+
+
+
+		#endregion
+
+		#region Static Type Properties
+		[SoapIgnore]
+		[XmlIgnore]
+		private static GXTypeInfo _typeProps;
+		protected override GXTypeInfo TypeInfo { get { return _typeProps; } set { _typeProps = value; } }
+		#endregion
+
+		#region Initialization
+
+		public void initialize( )
+		{
+			gxTv_SdtSDTTwoLevels_LevelItem_Levelname = "";
+			return  ;
+		}
+
+
+
+		#endregion
+
+		#region Declaration
+
+		protected string gxTv_SdtSDTTwoLevels_LevelItem_Levelname;
+		 
+
+
+		#endregion
+	}
+	#region Rest interface
+	[DataContract(Name=@"SDTTwoLevels.LevelItem", Namespace="MassiveSearch")]
+	public class SdtSDTTwoLevels_LevelItem_RESTInterface : GxGenericCollectionItem<SdtSDTTwoLevels_LevelItem>, System.Web.SessionState.IRequiresSessionState
+	{
+		public SdtSDTTwoLevels_LevelItem_RESTInterface( ) : base()
+		{	
+		}
+
+		public SdtSDTTwoLevels_LevelItem_RESTInterface( SdtSDTTwoLevels_LevelItem psdt ) : base(psdt)
+		{	
+		}
+
+		#region Rest Properties
+		[DataMember(Name="LevelName", Order=0)]
+		public  string gxTpr_Levelname
+		{
+			get { 
+				return StringUtil.RTrim( sdt.gxTpr_Levelname);
+
+			}
+			set { 
+				 sdt.gxTpr_Levelname = value;
+			}
+		}
+
+
+		#endregion
+
+		public SdtSDTTwoLevels_LevelItem sdt
+		{
+			get { 
+				return (SdtSDTTwoLevels_LevelItem)Sdt;
+			}
+			set { 
+				Sdt = value;
+			}
+		}
+
+		[OnDeserializing]
+		void checkSdt( StreamingContext ctx )
+		{
+			if ( sdt == null )
+			{
+				sdt = new SdtSDTTwoLevels_LevelItem() ;
+			}
+		}
+	}
+	#endregion
+}


### PR DESCRIPTION
Issue:106678
Improve the performance of getFromJSONObjectOrderIterator, particularly for SDT collections where it was previously poor. Given that gxuploadAttrs and props were recalculated for each element in the collection.