### PR TITLE
Fix 403 Forbidden errors when handling large tokens 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Security/WebSecurity.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Security/WebSecurity.cs
@@ -129,6 +129,10 @@ namespace GeneXus.Web.Security
 			using (var hmac = new System.Security.Cryptography.HMACSHA256(bSecretKey))
 			{
 				var handler = new JwtSecurityTokenHandler();
+				if (signedToken.Length >= handler.MaximumTokenSizeInBytes)
+				{
+					handler.MaximumTokenSizeInBytes = signedToken.Length + 1;
+				}
 				var validationParameters = new TokenValidationParameters
 				{
 					ClockSkew = TimeSpan.FromMinutes(1),


### PR DESCRIPTION
Adjusted the maximum token size dynamically based on the token length to prevent 403 Forbidden errors when handling large tokens originated from structure data types.
Issue:107110