### PR TITLE
Basic Authentication user ID was not properly parsed 

### DIFF
--- a/dotnet/test/DotNetCoreWebUnitTest/Middleware/HeadersTest.cs
+++ b/dotnet/test/DotNetCoreWebUnitTest/Middleware/HeadersTest.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using GeneXus.Metadata;
+using GeneXus.Utils;
 using Xunit;
 namespace xUnitTesting
 {
@@ -25,14 +26,18 @@ namespace xUnitTesting
 			const string host = "192.168.1.100";
 			const string scheme = "https";
 			const string remoteUrl = $"{scheme}:\\/\\/{host}";
+			const string passwordWithSpecialCharacters = "mypasswordwithspecialcharacters:!*";
+			const string userId = "myuser";
 			HttpClient client = server.CreateClient();
 			client.DefaultRequestHeaders.Add("X-Forwarded-For", host);
 			client.DefaultRequestHeaders.Add("X-Forwarded-Proto", scheme);
+			client.DefaultRequestHeaders.Add("Authorization", $"Basic {StringUtil.ToBase64(userId+ ":" + passwordWithSpecialCharacters)}");
 
 			HttpResponseMessage response = await client.GetAsync("/rest/apps/httpheaders");
 			response.EnsureSuccessStatusCode();
 			string resp = await response.Content.ReadAsStringAsync();
-			Assert.Contains(remoteUrl, resp, System.StringComparison.OrdinalIgnoreCase);
+			Assert.Contains(remoteUrl, resp, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains(userId, resp, StringComparison.OrdinalIgnoreCase);
 			Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
 		}
 		

--- a/dotnet/test/DotNetCoreWebUnitTest/apps/httpheaders.cs
+++ b/dotnet/test/DotNetCoreWebUnitTest/apps/httpheaders.cs
@@ -1,6 +1,9 @@
+using System;
 using GeneXus.Application;
 using GeneXus.Data.NTier;
+using GeneXus.Data.NTier.ADO;
 using GeneXus.Procedure;
+using GeneXus.Utils;
 
 namespace GeneXus.Programs.apps
 {
@@ -30,7 +33,7 @@ namespace GeneXus.Programs.apps
 		void executePrivate(out string result)
 		{
 			result = (context.GetHttpSecure() == 1 ? "https://" : "http://") + context.GetRemoteAddress();
-
+			result += StringUtil.NewLine() + GXUtil.UserId(string.Empty, context, pr_default);
 			cleanup();
 		}
 
@@ -51,7 +54,37 @@ namespace GeneXus.Programs.apps
 
 		public override void initialize()
 		{
+			pr_default = new DataStoreProvider(context, new httpheaders__default(),
+			new Object[][] {
+			}
+		 );
 		}
+		private IDataStoreProvider pr_default;
 	}
+	public class httpheaders__default : DataStoreHelperBase, IDataStoreHelper
+	{
+		public ICursor[] getCursors()
+		{
+			cursorDefinitions();
+			return new Cursor[] {
+	   };
+		}
 
+		private static CursorDef[] def;
+		private void cursorDefinitions()
+		{
+			if (def == null)
+			{
+				def = new CursorDef[] {
+		  };
+			}
+		}
+
+		public void getResults(int cursor,
+								IFieldGetter rslt,
+								Object[] buf)
+		{
+		}
+
+	}
 }


### PR DESCRIPTION
When the password contained the special separator character ':'.
Issue:107824