### PR TITLE
Fix issue #105929. Error with API object that return basic type collection

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GxRestWrapper.cs
@@ -880,29 +880,40 @@ namespace GeneXus.Application
 			if (vType.IsConstructedGenericType && typeof(IGxCollection).IsAssignableFrom(vType)) 
 			{				
 				bool isWrapped = (isApiObject)?false:true;				
+				bool isEmpty = false;
 				object collectionObject = null;
 				string wrappedStatus = "";
 				Type restItemType=null;
 				itemType = collectionValue.GetType().GetGenericArguments()[0];
-				if ((typeof(IGXBCCollection).IsAssignableFrom(vType)) && !isApiObject)//Collection<BCType> convert to GxGenericCollection<BCType_RESTLInterface>
+				if (vType.GetGenericTypeDefinition() == typeof(GxSimpleCollection<>) && isApiObject)
 				{
-					restItemType = ClassLoader.FindType(Config.CommonAssemblyName, itemType.FullName + "_RESTLInterface", null);
+					restItemType = itemType;
+					isEmpty = true;
+					isWrapped = false;
+					collectionObject = collectionValue;
 				}
-				if (restItemType == null)//Collection<SDTType> convert to GxGenericCollection<SDTType_RESTInterface>
+				else
 				{
-					restItemType = ClassLoader.FindType(Config.CommonAssemblyName, itemType.FullName + "_RESTInterface", null);
+					if ((typeof(IGXBCCollection).IsAssignableFrom(vType)) && !isApiObject)//Collection<BCType> convert to GxGenericCollection<BCType_RESTLInterface>
+					{
+						restItemType = ClassLoader.FindType(Config.CommonAssemblyName, itemType.FullName + "_RESTLInterface", null);
+					}
+					if (restItemType == null)//Collection<SDTType> convert to GxGenericCollection<SDTType_RESTInterface>
+					{
+						restItemType = ClassLoader.FindType(Config.CommonAssemblyName, itemType.FullName + "_RESTInterface", null);
+					}
+					object[] attributes = restItemType.GetCustomAttributes(typeof(GxJsonSerialization),  false);
+					IEnumerable<object>  serializationAttributes = attributes.Where(a => a.GetType() == typeof(GxJsonSerialization));
+					if (serializationAttributes != null && serializationAttributes.Any<object>())
+					{
+						GxJsonSerialization attFmt = (GxJsonSerialization)serializationAttributes.FirstOrDefault();
+						wrappedStatus = attFmt.JsonUnwrapped;
+						isWrapped = (isApiObject)? ((wrappedStatus == "wrapped")? true: false): ((wrappedStatus == "unwrapped") ? false : true);
+					}
+					isEmpty = !restItemType.IsDefined(typeof(GxOmitEmptyCollection), false);
+					Type genericListItemType = typeof(GxGenericCollection<>).MakeGenericType(restItemType);
+					collectionObject = Activator.CreateInstance(genericListItemType, new object[] { collectionValue, isWrapped , wrappedStatus});
 				}
-				object[] attributes = restItemType.GetCustomAttributes(typeof(GxJsonSerialization),  false);
-				IEnumerable<object>  serializationAttributes = attributes.Where(a => a.GetType() == typeof(GxJsonSerialization));
-				if (serializationAttributes != null && serializationAttributes.Any<object>())
-				{
-					GxJsonSerialization attFmt = (GxJsonSerialization)serializationAttributes.FirstOrDefault();
-					wrappedStatus = attFmt.JsonUnwrapped;
-					isWrapped = (isApiObject)? ((wrappedStatus == "wrapped")? true: false): ((wrappedStatus == "unwrapped") ? false : true);
-				}
-				bool isEmpty = !restItemType.IsDefined(typeof(GxOmitEmptyCollection), false);
-				Type genericListItemType = typeof(GxGenericCollection<>).MakeGenericType(restItemType);
-				collectionObject = Activator.CreateInstance(genericListItemType, new object[] { collectionValue, isWrapped , wrappedStatus});
 				// Empty collection serialized w/ noproperty
 				if (collectionObject is IList restList)
 				{


### PR DESCRIPTION
Fixed issue with Deserialization In API Objects ( NET core)
When a methods of an API objets has only 1 return parameter and it's a collection of a basic type the service fails with error 500
Added a special case for this since no underlying custom _RestInterface is generated
Issue# 105929