### PR TITLE
Upgrade MimeKit from version 3.1.1 to 4.7.1 to address vulnerability issue.

### DIFF
--- a/dotnet/src/dotnetcore/GxMail/GxMail.csproj
+++ b/dotnet/src/dotnetcore/GxMail/GxMail.csproj
@@ -67,9 +67,9 @@
 
   <ItemGroup>
 	<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="MailKit" Version="3.1.1" />
+    <PackageReference Include="MailKit" Version="4.7.1" />
     <PackageReference Include="Microsoft.Exchange.WebServices" Version="2.2.0" />
-    <PackageReference Include="MimeKit" Version="3.1.1" />
+    <PackageReference Include="MimeKit" Version="4.7.1" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.60.3" />
     <PackageReference Include="OpenPop" Version="2.0.6.2" />
 	<PackageReference Include="Org.Mentalis.Security" Version="1.0.0" />

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/GeneXusCryptographyNetCore/GeneXusCryptographyNetCore.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/GeneXusCryptographyNetCore/GeneXusCryptographyNetCore.csproj
@@ -68,7 +68,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/GeneXusJWTNetCore/GeneXusJWTNetCore.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/GeneXusJWTNetCore/GeneXusJWTNetCore.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.35.0" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="6.35.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.35.0" />

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/GeneXusXmlSignatureNetCore/GeneXusXmlSignatureNetCore.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/GeneXusXmlSignatureNetCore/GeneXusXmlSignatureNetCore.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
   </ItemGroup>
 

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/SecurityAPICommonsNetCore/SecurityAPICommonsNetCore.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetcore/SecurityAPICommonsNetCore/SecurityAPICommonsNetCore.csproj
@@ -10,41 +10,41 @@
 
 	<PropertyGroup>
 		<DefineConstants>NETCORE</DefineConstants>
-</PropertyGroup>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Commons\Certificate.cs" Link="Commons\Certificate.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Commons\Error.cs" Link="Commons\Error.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Commons\Key.cs" Link="Commons\Key.cs" />
+	<ItemGroup>
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Commons\Certificate.cs" Link="Commons\Certificate.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Commons\Error.cs" Link="Commons\Error.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Commons\Key.cs" Link="Commons\Key.cs" />
 		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Commons\PublicKey.cs" Link="Commons\PublicKey.cs" />
 		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Commons\PrivateKey.cs" Link="Commons\PrivateKey.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Commons\SecurityAPIObject.cs" Link="Commons\SecurityAPIObject.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Config\AvailableEncoding.cs" Link="Config\AvailableEncoding.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Config\EncodingUtil.cs" Link="Config\EncodingUtil.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Config\SecurityApiGlobal.cs" Link="Config\Global.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Encoders\Base64Encoder.cs" Link="Encoders\Base64Encoder.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Commons\SecurityAPIObject.cs" Link="Commons\SecurityAPIObject.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Config\AvailableEncoding.cs" Link="Config\AvailableEncoding.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Config\EncodingUtil.cs" Link="Config\EncodingUtil.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Config\SecurityApiGlobal.cs" Link="Config\Global.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Encoders\Base64Encoder.cs" Link="Encoders\Base64Encoder.cs" />
 		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Encoders\Base64UrlEncoder.cs" Link="Encoders\Base64UrlEncoder.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Encoders\HexaEncoder.cs" Link="Encoders\HexaEncoder.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Keys\CertificateX509.cs" Link="Keys\CertificateX509.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Keys\PrivateKeyManager.cs" Link="Keys\PrivateKeyManager.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Keys\SymmetricKeyGenerator.cs" Link="Keys\SymmetricKeyGenerator.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Keys\SymmetricKeyType.cs" Link="Keys\SymmetricKeyType.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Utils\ExtensionsWhiteList.cs" Link="Utils\ExtensionsWhiteList.cs" />
-    <Compile Include="..\..\dotnetframework\SecurityAPICommons\Utils\SecurityUtils.cs" Link="Utils\SecurityUtils.cs" />
-  </ItemGroup>
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Encoders\HexaEncoder.cs" Link="Encoders\HexaEncoder.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Keys\CertificateX509.cs" Link="Keys\CertificateX509.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Keys\PrivateKeyManager.cs" Link="Keys\PrivateKeyManager.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Keys\SymmetricKeyGenerator.cs" Link="Keys\SymmetricKeyGenerator.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Keys\SymmetricKeyType.cs" Link="Keys\SymmetricKeyType.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Utils\ExtensionsWhiteList.cs" Link="Utils\ExtensionsWhiteList.cs" />
+		<Compile Include="..\..\dotnetframework\SecurityAPICommons\Utils\SecurityUtils.cs" Link="Utils\SecurityUtils.cs" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
-    <PackageReference Include="jose-jwt" Version="5.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
+		<PackageReference Include="jose-jwt" Version="5.0.0" />
+		<PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
+		<PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Config\" />
-    <Folder Include="Encoders\" />
-    <Folder Include="Keys\" />
-    <Folder Include="Utils\" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="Config\" />
+		<Folder Include="Encoders\" />
+		<Folder Include="Keys\" />
+		<Folder Include="Utils\" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
As a consequence, update BouncyCastle.Cryptography from version 2.3.1 to 2.4.0.
Vulnerability issue was reported at #1045