### PR TITLE
Fix error when adding certificates to HttpClient 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -238,8 +238,20 @@ namespace GeneXus.Http.Client
 			{
 				handler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
 			}
-			foreach (X509Certificate2 cert in certificateCollection)
-				handler.SslOptions.ClientCertificates.Add(cert);
+			if (certificateCollection.Count > 0)
+			{
+				if (handler.SslOptions.ClientCertificates == null)
+				{
+					handler.SslOptions.ClientCertificates = new X509CertificateCollection(certificateCollection);
+				}
+				else
+				{
+					foreach (X509Certificate2 cert in certificateCollection)
+					{
+						handler.SslOptions.ClientCertificates.Add(cert);
+					}
+				}
+			}
 
 			WebProxy proxy = getProxy(proxyHost, proxyPort, authProxyCollection);
 			if (proxy != null)


### PR DESCRIPTION
Due to uninitialized handler.SslOptions.ClientCertificates.