### PR TITLE
Add defensive programming to Smtp ValidateConnection method

### DIFF
--- a/dotnet/src/dotnetframework/GxMail/SMTP/SmtpHelper.cs
+++ b/dotnet/src/dotnetframework/GxMail/SMTP/SmtpHelper.cs
@@ -49,6 +49,10 @@ namespace GeneXus.Mail.Smtp
 				{
 					throw new GXMailException(inner.Message, GXInternetConstants.MAIL_CantLogin);
 				}
+				else if (inner is ArgumentException)
+				{
+					GXLogging.Error(log, "SMTPConnection check method failed", e);
+				}
 				else
 				{
 					throw new GXMailException(inner.Message, GXInternetConstants.MAIL_AuthenticationError);


### PR DESCRIPTION
To handle variations in the signature of System.Net.Mail.MailCommand.Send across different .NET SDK versions.