### PR TITLE
Fix: Ensure Basic Authentication adds the Authorization header correctly

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -488,6 +488,10 @@ namespace GeneXus.Http.Client
 		{
 			if (scheme >= _Basic && scheme <= _Kerberos)
 				_authCollection.Add(new GxAuthScheme(scheme, realm, user, password));
+			if (scheme == _Basic) {
+				string authHeader = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{user}:{password}"));
+				AddHeader(HttpHeader.AUTHORIZATION, new AuthenticationHeaderValue("Basic", authHeader).ToString());
+			}
 		}
 
 		public void AddProxyAuthentication(int scheme, string realm, string user, string password)
@@ -727,7 +731,7 @@ namespace GeneXus.Http.Client
 			}
 			InferContentType(contentType, request);
 		}
-		void setHeaders(HttpRequestMessage request, CookieContainer cookies, out string contentType)
+		internal void SetHeaders(HttpRequestMessage request, CookieContainer cookies, out string contentType)
 		{
 			HttpRequestHeaders headers = request.Headers;
 			contentType = null;
@@ -864,7 +868,7 @@ namespace GeneXus.Http.Client
 				RequestUri = new Uri(requestUrl),
 				Method = new HttpMethod(method),
 			};
-			setHeaders(request, cookies, out string contentType);
+			SetHeaders(request, cookies, out string contentType);
 			SetHttpVersion(request);
 			bool disposableInstance = true;
 			try
@@ -926,7 +930,7 @@ namespace GeneXus.Http.Client
 				RequestUri = new Uri(requestUrl),
 				Method = new HttpMethod(method),
 			};
-			setHeaders(request, cookies, out string contentType);
+			SetHeaders(request, cookies, out string contentType);
 			SetHttpVersion(request);
 			bool disposableInstance = true;
 			try
@@ -1581,6 +1585,8 @@ namespace GeneXus.Http.Client
 					}
 					else
 					{
+						//return new NetworkCredential(auth.User, auth.Password);
+
 						if (cc == null)
 						{
 							cc = new CredentialCache();

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/HttpHelper.cs
@@ -52,6 +52,7 @@ namespace GeneXus.Http
 		internal static string TRANSFER_ENCODING = "Transfer-Encoding";
 		internal static string X_CSRF_TOKEN_HEADER = "X-XSRF-TOKEN";
 		internal static string X_CSRF_TOKEN_COOKIE = "XSRF-TOKEN";
+		internal static string AUTHORIZATION = "Authorization";
 	}
 	internal class HttpHeaderValue
 	{

--- a/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/GxHttpClientTest.cs
@@ -4,10 +4,14 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using GeneXus.Application;
 using GeneXus.Http.Client;
 using Xunit;
+
+
+
 #if !NETCORE
 using System.Web.SessionState;
 using System.Web;
@@ -18,8 +22,10 @@ namespace xUnitTesting
 
 	public class GxHttpClientTest
 	{
-		const int MAX_CONNECTIONS= 5;
-		public GxHttpClientTest() {
+		const int MAX_CONNECTIONS = 5;
+
+		public GxHttpClientTest()
+		{
 			Environment.SetEnvironmentVariable("GX_HTTPCLIENT_MAX_PER_ROUTE", MAX_CONNECTIONS.ToString(), EnvironmentVariableTarget.Process);
 		}
 		[Fact]
@@ -203,5 +209,31 @@ namespace xUnitTesting
 			Assert.Equal(0, result);
 		}
 #endif
+
+#if NETCORE
+		[Fact]
+		public void BasicAuthenticationIncludesHeader()
+		{
+			GxContext context = new GxContext();
+			using (GxHttpClient httpclient = new GxHttpClient(context))
+			{
+				string url= "https://www.google.com/";
+				string username = "user";
+				string password = "pass";
+				string credentialsBase64 = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}"));
+				httpclient.AddAuthentication(0, string.Empty, username, password);
+
+				HttpRequestMessage request = new HttpRequestMessage()
+				{
+					RequestUri = new Uri(url),
+					Method = HttpMethod.Post,
+				};
+				httpclient.SetHeaders(request, null, out string contentType);
+				string headerValue = request.Headers.GetValues("Authorization").FirstOrDefault();
+				Assert.Equal(headerValue, $"Basic {credentialsBase64}");
+			}
+		}
+#endif
 	}
+
 }


### PR DESCRIPTION
ServerCredentials property is designed for server-based authentication schemes such as NTLM, Kerberos, or Digest, where the credentials are automatically negotiated by the handler.
For Basic Authentication, is must set the Authorization header with the necessary credentials encoded in Base64.
Issue:201305