### PR TITLE
Fixed URL redirection to default site page 

### DIFF
--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -612,7 +612,7 @@ namespace GeneXus.Application
 			string[] defaultFiles = { "default.htm", "default.html", "index.htm", "index.html" };
 			foreach (string file in defaultFiles) {
 				if (System.IO.File.Exists(Path.Combine(Startup.LocalPath, file))){
-					return Redirect(file);
+					return Redirect(Url.Content($"~/{file}"));
 				}
 			}
 			return Redirect(defaultFiles[0]);


### PR DESCRIPTION
Missing trailing slash caused incorrect URL redirection to root instead of the application path.
Issue:201515