### PR TITLE
Fix error with deserialization of property data types containing null values

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
@@ -2400,7 +2400,8 @@ namespace GeneXus.Utils
 				{
 					lock (syncObj)
 					{
-						this.Set(item.Key.ToString(), item.Value.ToString());
+						if (item.Key != null && item.Value != null)
+							this.Set(item.Key.ToString(), item.Value.ToString());
 					}
 				}
 			}


### PR DESCRIPTION
Issue:200791
It was a side effect of #208 given that item.Value can be null instead of JNull.