### PR TITLE
Resolve issue with dynamic reports when used alongside file upload functionality

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
@@ -835,6 +835,7 @@ namespace GeneXus.Configuration
 		static int oldSTR = -1;
 		static int instrumented = -1;
 		static string mediaPath;
+		static string layoutMetadataPath;
 		static string pdfLib;
 		static string blobPath;
 		static string blobPathFolderName;
@@ -1234,30 +1235,30 @@ namespace GeneXus.Configuration
 		}
 		public static string getPRINT_LAYOUT_METADATA_DIR()
 		{
-			if (mediaPath == null)
+			if (layoutMetadataPath == null)
 			{
 				lock (syncRoot)
 				{
-					if (mediaPath == null)
+					if (layoutMetadataPath == null)
 					{
-						if (Config.GetValueOf("PRINT_LAYOUT_METADATA_DIR", out mediaPath))
+						if (Config.GetValueOf("PRINT_LAYOUT_METADATA_DIR", out layoutMetadataPath))
 						{
-							mediaPath = mediaPath.Trim();
+							layoutMetadataPath = layoutMetadataPath.Trim();
 
-							if (!String.IsNullOrEmpty(mediaPath) && !mediaPath.EndsWith("\\") && !mediaPath.EndsWith("/"))
+							if (!String.IsNullOrEmpty(layoutMetadataPath) && !layoutMetadataPath.EndsWith("\\") && !layoutMetadataPath.EndsWith("/"))
 							{
-								mediaPath += Path.DirectorySeparatorChar;
+								layoutMetadataPath += Path.DirectorySeparatorChar;
 							}
 						}
 						else
 						{
-							mediaPath = "";
+							layoutMetadataPath = string.Empty;
 						}
-						GXLogging.Debug(log, "PRINT_LAYOUT_METADATA_DIR:", mediaPath);
+						GXLogging.Debug(log, "PRINT_LAYOUT_METADATA_DIR:", layoutMetadataPath);
 					}
 				}
 			}
-			return mediaPath;
+			return layoutMetadataPath;
 		}
 		internal static string PdfReportLibrary()
 		{


### PR DESCRIPTION
Fix getPRINT_LAYOUT_METADATA_DIR method to use the appropriate internal variable, as it was previously referencing mediaPath from the TMP_MEDIA_PATH setting
Issue:[202188](https://issues.genexus.dev/viewissue.aspx?202188)