### PR TITLE
Fix URL separator issue in relative image paths when running in HTTP context

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -3764,6 +3764,7 @@ namespace GeneXus.Application
 		static Hashtable m_images = new Hashtable();
 
 		const string IMAGES_TXT = "Images.txt";
+		const string URL_SEPARATOR = "/";
 		Hashtable Images
 		{
 			get
@@ -3840,7 +3841,12 @@ namespace GeneXus.Application
 												string imagePath = parts[4];
 												string intExt = parts[3];
 												if (intExt[0] != 'E' && intExt[0] != 'e' && !Path.IsPathRooted(imagePath) && !imagePath.ToLower().StartsWith("http:"))
-													imagePath = Path.Combine(imgDir, KBPrefix + "Resources", imagePath);
+												{
+													if (!string.IsNullOrEmpty(imgDir))
+														imagePath = Path.Combine(imgDir, KBPrefix + "Resources", imagePath);
+													else
+														imagePath = KBPrefix + "Resources" + URL_SEPARATOR + imagePath;  
+												}
 												string parts12 = '_' + parts[1] + '_' + parts[2];
 
 												m_images[KBPrefix + parts[0] + parts12] = imagePath;

--- a/dotnet/test/DotNetUnitTest/PDF/PDFTests.cs
+++ b/dotnet/test/DotNetUnitTest/PDF/PDFTests.cs
@@ -48,9 +48,8 @@ namespace UnitTesting
 			catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
 			{
-				Console.WriteLine(ex.ToString());	
+				Assert.True(false, $"Unexpected error in TestIText5: {ex.Message}");
 			}
-			Assert.True(File.Exists(report));
 		}
 		[Fact]
 		public void TestIText4LGPLIsUsed()


### PR DESCRIPTION
This change fixes a side effect introduced in #1072