### PR TITLE
Some Foreach cursors for MySQL and PostgreSQL were not being cached as expected

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
@@ -2225,16 +2225,19 @@ namespace GeneXus.Data
 
 		public void AddToCache(bool hasNext)
 		{
-			if (hasNext)
+			if (!(reader is MemoryDataReader))
 			{
-				object[] values = new object[reader.FieldCount];
-				m_dr.GetValues(reader, ref values);
-				block.Add(values);
-			}
-			else
-			{
-				SqlUtil.AddBlockToCache(key, new CacheItem(block, false, pos, readBytes), con, expiration != null ? (int)expiration.ItemSlidingExpiration.TotalMinutes : 0);
-				Close();
+				if (hasNext)
+				{
+					object[] values = new object[reader.FieldCount];
+					m_dr.GetValues(reader, ref values);
+					block.Add(values);
+				}
+				else
+				{
+					SqlUtil.AddBlockToCache(key, new CacheItem(block, false, pos, readBytes), con, expiration != null ? (int)expiration.ItemSlidingExpiration.TotalMinutes : 0);
+					Close();
+				}
 			}
 		}
 


### PR DESCRIPTION
 Records read by MemoryDataReader can always be cached because the cursor is fully consumed during the read operation.