### PR TITLE
Fixed URL resolution ambiguity on Linux.

### DIFF
--- a/dotnet/test/DotNetCoreUnitTest/DotNetCoreUnitTest.csproj
+++ b/dotnet/test/DotNetCoreUnitTest/DotNetCoreUnitTest.csproj
@@ -20,6 +20,7 @@
 	    <Compile Include="..\DotNetUnitTest\Domain\ShellTest.cs" Link="Domain\ShellTest.cs" />		
 	    <Compile Include="..\DotNetUnitTest\Domain\TimeZoneTest.cs" Link="Domain\TimeZoneTest.cs" />		
 	    <Compile Include="..\DotNetUnitTest\FileIO\DfrgFunctions.cs" Link="FileIO\DfrgFunctions.cs" />
+	    <Compile Include="..\DotNetUnitTest\FileIO\FileIOTests.cs" Link="FileIO\FileIOTests.cs" />
 		<Compile Include="..\DotNetUnitTest\FileIO\FileSystemTest.cs" Link="FileIO\FileSystemTest.cs" />
 		<Compile Include="..\DotNetUnitTest\FileIO\Xslt.cs" Link="FileIO\Xslt.cs" />
 		<Compile Include="..\DotNetUnitTest\ExternalProvider\ExternalProviderS3Test.cs" Link="ExternalProvider\ExternalProviderS3Test.cs" />		

--- a/dotnet/test/DotNetUnitTest/FileIO/FileIOTests.cs
+++ b/dotnet/test/DotNetUnitTest/FileIO/FileIOTests.cs
@@ -61,7 +61,7 @@ namespace UnitTesting
 			PathUtil.AbsoluteUri(path, out uri);
 			Assert.True(uri.Scheme == Uri.UriSchemeFile);
 			Assert.True(uri.IsAbsoluteUri);
-			//Assert.True(new FileInfo(uri.LocalPath).FullName == new FileInfo("PublicTempStorage/multimedia/myimg_8e1604b16eda43e59694f9aeb0b33e77.jpg").FullName);
+			Assert.True(new FileInfo(uri.LocalPath).FullName == new FileInfo("PublicTempStorage/multimedia/myimg_8e1604b16eda43e59694f9aeb0b33e77.jpg").FullName);
 
 			path = "https://localhost/ImageType.NetEnvironment/PublicTempStorage/multimedia/myimg_8e1604b16eda43e59694f9aeb0b33e77.jpg";
 			PathUtil.AbsoluteUri(path, out uri);

--- a/dotnet/test/DotNetUnitTest/FileIO/FileIOTests.cs
+++ b/dotnet/test/DotNetUnitTest/FileIO/FileIOTests.cs
@@ -62,6 +62,17 @@ namespace UnitTesting
 			Assert.True(uri.Scheme == Uri.UriSchemeFile);
 			Assert.True(uri.IsAbsoluteUri);
 			//Assert.True(new FileInfo(uri.LocalPath).FullName == new FileInfo("PublicTempStorage/multimedia/myimg_8e1604b16eda43e59694f9aeb0b33e77.jpg").FullName);
+
+			path = "https://localhost/ImageType.NetEnvironment/PublicTempStorage/multimedia/myimg_8e1604b16eda43e59694f9aeb0b33e77.jpg";
+			PathUtil.AbsoluteUri(path, out uri);
+			Assert.True(uri.Scheme == Uri.UriSchemeHttps);
+			Assert.True(uri.IsAbsoluteUri);
+
+			path = "file:///app/test/files/xml/error.xml";
+			PathUtil.AbsoluteUri(path, out uri);
+			Assert.True(uri.Scheme == Uri.UriSchemeFile);
+			Assert.True(uri.IsAbsoluteUri);
+
 		}
 		[Fact]
 		public void GXDBFilePathTest()

--- a/dotnet/test/DotNetUnitTest/FileIO/FileIOTests.cs
+++ b/dotnet/test/DotNetUnitTest/FileIO/FileIOTests.cs
@@ -11,7 +11,9 @@ namespace UnitTesting
 	{
 		public FileIOTests()
 		{
+#if !NETCORE
 			Config.ConfigFileName = Path.Combine(BaseDir, "client.exe.config");
+#endif
 		}
 		[Fact]
 		public void FileSharedToCopy()


### PR DESCRIPTION
Previously, URLs like /KB.NET/PublicTempStorage/multimedia/beach_2e47be657a0e4e35aa6cdfdd4089a90c.jpg were resolved as absolute URIs. Updated the logic to first check if the URL can be resolved as relative to the local app path. If not, it is treated as an absolute URL
Issue:202755