### PR TITLE
Set .NET version to 8.0 to ensure compatibility

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,8 @@
 {
   "sdk": {
+    "version":"8.0.0",
+    "rollForward": "latestMinor",
     "allowPrerelease": true
+	
   }
 }


### PR DESCRIPTION
Avoiding GitHub Actions running on the latest unsupported version (9.0).
Resolve MSB3030 error: Unable to copy "extensions.json" due to it not being found in the expected path during the build process.