### PR TITLE
Fix invalid url for multimedia attributes on private amazon S3 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GXFileIO.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GXFileIO.cs
@@ -444,8 +444,8 @@ public class GxExternalFileInfo : IGxFileInfo
 			string folderName = ((ExternalProviderBase)provider).Folder;
 			if (!string.IsNullOrEmpty(folderName) && fileType.HasFlag(GxFileType.Attribute) && !_name.StartsWith(folderName))
 			{
-				_url = $"{provider.GetBaseURL()}{_name}";
 				_name = $"{folderName}{StorageUtils.DELIMITER}{_name}";
+				_url = provider.GetUrl(_name, fileType, 0);
 			}
 		}
 	}


### PR DESCRIPTION
If private external storage is enabled, reading a multimedia attribute from the database (stored in DB) created a temporary file in external storage with an invalid _url. This issue occurred because the presigned URL's private segment was not properly considered.

Issue:202453