### PR TITLE
Single message processing of Service bus Azure functions and changes to Blob functions

### DIFF
--- a/dotnet/src/extensions/Azure/Handlers/ServiceBusHandler/ServiceBusTriggerHandler.cs
+++ b/dotnet/src/extensions/Azure/Handlers/ServiceBusHandler/ServiceBusTriggerHandler.cs
@@ -41,6 +41,25 @@ namespace GeneXus.Deploy.AzureFunctions.ServiceBusHandler
 				throw;
 			}
 		}
+
+		public async Task RunSingle(ServiceBusReceivedMessage myQueueItem, FunctionContext context)
+		{
+			var log = context.GetLogger("ServiceBusTriggerHandler");
+			string functionName = context.FunctionDefinition.Name;
+
+			log.LogInformation($"GeneXus Service Bus trigger handler. Function processed: {functionName}.");
+
+			try
+			{
+				ServiceBusReceivedMessage[] queueItems = new ServiceBusReceivedMessage[] { myQueueItem };
+				await ProcessMessages(context, log, queueItems);
+			}
+			catch (Exception ex) //Catch System exception and retry
+			{
+				log.LogError(ex.ToString());
+				throw;
+			}
+		}
 		private Task ProcessMessages(FunctionContext context, ILogger log, ServiceBusReceivedMessage[] messages)
 		{
 			string envVar = $"GX_AZURE_{context.FunctionDefinition.Name.ToUpper()}_CLASS";


### PR DESCRIPTION
Issue:202978
- Azure Functions triggered by Service Bus messages can manage batch messages or just a single message.
Depending on several factors, it may be advisable to process only one message (not batch).
- Breaking change in Azure functions triggered by Blob. Now we follow the recommendation of using event grid source. This means changes at infra for the user.