### PR TITLE
Fix error An address incompatible with the requested protocol was used

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxFtp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxFtp.cs
@@ -680,7 +680,7 @@ namespace GeneXus.Utils
 		private IPAddress GetIpAddress(string host)
 		{
 			IPHostEntry serverHostEntry = Dns.GetHostEntry(host);
-			IPAddress ipAddresses = serverHostEntry.AddressList.FirstOrDefault();
+			IPAddress ipAddresses = serverHostEntry.AddressList.FirstOrDefault(a => (a.AddressFamily == _DataSocket.AddressFamily));
 			GXLogging.Debug(log, $"GetHostEntry({host}) AddressList length: ", serverHostEntry.AddressList.Length.ToString());
 			if (ipAddresses == null)
 			{


### PR DESCRIPTION
At OpenDataConnection.
Issue:202076
On #948 the filter a => (a.AddressFamily == _DataSocket.AddressFamily) was accidentally lost.