### PR TITLE
Ensure REST query parameters of type string are bound as empty strings instead of null

### DIFF
--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -268,9 +268,13 @@ namespace GeneXus.Application
 		private void RegisterControllerAssemblies(IMvcBuilder mvcBuilder)
 		{
 			
-			if (RestAPIHelpers.ServiceAsController() && !string.IsNullOrEmpty(VirtualPath))
+			if (RestAPIHelpers.ServiceAsController())
 			{
-				mvcBuilder.AddMvcOptions(options =>	options.Conventions.Add(new SetRoutePrefix(new RouteAttribute(VirtualPath))));
+				mvcBuilder.AddMvcOptions(options => options.ModelBinderProviders.Insert(0, new QueryStringModelBinderProvider()));
+				if (!string.IsNullOrEmpty(VirtualPath))
+				{
+					mvcBuilder.AddMvcOptions(options => options.Conventions.Add(new SetRoutePrefix(new RouteAttribute(VirtualPath))));
+				}
 			}
 
 			if (RestAPIHelpers.JsonSerializerCaseSensitive())


### PR DESCRIPTION
Add custom ModelBinder to ensure query parameters of type string are bound as empty strings instead of null
Issue:203155