### PR TITLE
Fix Microsoft.Bcl.AsyncInterfaces version conflict when using Redis

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
@@ -501,7 +501,8 @@ namespace GeneXus.Configuration
 			{ "System.Threading.Tasks.Extensions", new Version(4, 2, 0, 1) },
 			{ "System.Runtime.CompilerServices.Unsafe", new Version(4, 0, 4, 1) },
 			{ "System.Buffers", new Version(4, 0, 3, 0)},
-			{ "System.Memory",new Version(4, 0, 1, 1) }
+			{ "System.Memory",new Version(4, 0, 1, 1) },
+			{ "Microsoft.Bcl.AsyncInterfaces",new Version(8, 0, 0, 0) }//redirection required for StackExchange.Redis
 		};
 
 		static string GeoTypesAssembly = "Microsoft.SqlServer.Types";


### PR DESCRIPTION
Add AssemblyResolve handler to load Microsoft.Bcl.AsyncInterfaces v8.0.0.0
Redirects requests for v5.0.0.0 (as referenced by StackExchange.Redis) to v8.0.0.0, which is used since the System.Text.Json update.
