### PR TITLE
Add missing ApiExecutePermissionPrefix method for .NET Framework.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Services/GXRestServices.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Services/GXRestServices.cs
@@ -633,6 +633,7 @@ namespace GeneXus.Utils
 		protected virtual bool IsSynchronizer { get { return false; } }
 		protected virtual bool IntegratedSecurityEnabled { get { return false; } }
 		protected virtual GAMSecurityLevel IntegratedSecurityLevel { get { return 0; } }
+		protected virtual string ApiExecutePermissionPrefix(string gxMethod) { return ExecutePermissionPrefix; }
 		protected virtual GAMSecurityLevel ApiIntegratedSecurityLevel(string gxMethod) { return IntegratedSecurityLevel; }
 		protected virtual string ExecutePermissionPrefix { get { return string.Empty; } }
 	}


### PR DESCRIPTION
This is required for API objects with Integrated Security Level set to Authorization and a non-empty Permission prefix.