### PR TITLE
Restore local.settings.json for local execution of Azure Functions

### DIFF
--- a/dotnet/src/extensions/Azure/Handlers/GeneXus.Deploy.AzureFunctions.Handlers.csproj
+++ b/dotnet/src/extensions/Azure/Handlers/GeneXus.Deploy.AzureFunctions.Handlers.csproj
@@ -106,7 +106,7 @@
 				<PackagePath>./lib/$(TargetFramework)/</PackagePath>
 				<PackageCopyToOutput>true</PackageCopyToOutput>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(MSBuildProjectName).csproj;.\**\*.cs;host.json;" Exclude=".\obj\**\*.cs;.\bin\**\*">
+			<TfmSpecificPackageFile Include="$(MSBuildProjectName).csproj;.\**\*.cs;host.json;local.settings.json;" Exclude=".\obj\**\*.cs;.\bin\**\*">
 				<PackagePath>./src/</PackagePath>
 				<PackageCopyToOutput>true</PackageCopyToOutput>
 			</TfmSpecificPackageFile>


### PR DESCRIPTION
Re-add local.settings.json to the Azure Functions src package to enable local execution with func start.
Previously removed in #703, it worked fine until v18u11, but from v18u12 onward.
Still pending investigation on why it is now required.


This file is not needed in production, but its presence is ignored when deployed.
Issue: 203323