### PR TITLE
Ensure unique filenames when downloading email attachments with duplicate names

### DIFF
--- a/dotnet/src/dotnetcore/GxMail/GxMail.csproj
+++ b/dotnet/src/dotnetcore/GxMail/GxMail.csproj
@@ -25,6 +25,7 @@
     <Compile Include="..\..\dotnetframework\GxMail\Exchange\UserData.cs" Link="Exchange\UserData.cs" />
     <Compile Include="..\..\dotnetframework\GxMail\GXInternetConstants.cs" Link="GXInternetConstants.cs" />
     <Compile Include="..\..\dotnetframework\GxMail\GXMailException.cs" Link="GXMailException.cs" />
+    <Compile Include="..\..\dotnetframework\GxMail\GXMailHelper.cs" Link="GXMailHelper.cs" />
     <Compile Include="..\..\dotnetframework\GxMail\GXMailMessage.cs" Link="GXMailMessage.cs" />
     <Compile Include="..\..\dotnetframework\GxMail\GXMailRecipient.cs" Link="GXMailRecipient.cs" />
     <Compile Include="..\..\dotnetframework\GxMail\GXMailRecipientCollection.cs" Link="GXMailRecipientCollection.cs" />

--- a/dotnet/src/dotnetframework/GxMail/Exchange/ExchangeSession.cs
+++ b/dotnet/src/dotnetframework/GxMail/Exchange/ExchangeSession.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net;
+using GeneXus.Mail.Util;
 using Microsoft.Exchange.WebServices.Data;
 using Microsoft.Identity.Client;
 
@@ -383,8 +384,8 @@ namespace GeneXus.Mail.Exchange
 						if (attach is FileAttachment)
 						{
 							FileAttachment fileAttachment = attach as FileAttachment;
-							string attachFileName = fileAttachment.Name;
-							string filePath = System.IO.Path.Combine(_attachDir, attachFileName);
+							string attachFileName = GXMailHelper.FixAndEnsureUniqueFileName(_attachDir, fileAttachment.Name);
+							string filePath = Path.Combine(_attachDir, attachFileName);
 							fileAttachment.Load(filePath);
 							gxmessage.Attachments.addNew(attachFileName);
 						}

--- a/dotnet/src/dotnetframework/GxMail/GXMailHelper.cs
+++ b/dotnet/src/dotnetframework/GxMail/GXMailHelper.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using GeneXus.Utils;
+
+namespace GeneXus.Mail.Util
+{
+	internal class GXMailHelper
+	{
+		internal static string FixAndEnsureUniqueFileName(string attachDir, string name)
+		{
+			if (string.IsNullOrEmpty(name))
+			{
+				name = Path.GetRandomFileName();
+			}
+			int idx = 1;
+			string nameOri = Path.GetFileNameWithoutExtension(name);
+			while (File.Exists(Path.Combine(attachDir, name)))
+			{
+				name = $"{nameOri} ({idx}).{Path.GetExtension(name)}";
+				idx = idx + 1;
+			}
+
+			if (Path.Combine(attachDir, name).Length > 200)
+			{
+				name = Path.GetRandomFileName().Replace(".", "") + "." + Path.GetExtension(name);
+			}
+			return FileUtil.FixFileName(name, attachDir);
+		}
+
+	}
+}

--- a/dotnet/src/dotnetframework/GxMail/MailMessage.cs
+++ b/dotnet/src/dotnetframework/GxMail/MailMessage.cs
@@ -6,7 +6,9 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using GeneXus.Mail.Util;
 using GeneXus.Utils;
+using Org.Mentalis.Security.Certificates;
 
 namespace GeneXus.Mail.Internals.Pop3
 {
@@ -142,19 +144,6 @@ namespace GeneXus.Mail.Internals.Pop3
 			}
 		}
 
-		private string FixFileName(string AttachDir, string name)
-		{
-			if (string.IsNullOrEmpty(name))
-			{
-				name = Path.GetRandomFileName();
-			}
-			if (Path.Combine(AttachDir, name).Length > 200)
-			{
-				name = Path.GetRandomFileName().Replace(".", "") + "." + Path.GetExtension(name);
-			}
-			Regex validChars = new Regex(@"[\\\/\*\?\|:<>]");
-			return validChars.Replace(name, "_");
-		}
 
 		private static void FillMonthList()
 		{
@@ -319,15 +308,7 @@ namespace GeneXus.Mail.Internals.Pop3
 				extension = "." + ExtensionFromContentType(contentType);
 			}
 
-			int idx = 1;
-			string nameOri = "" + name;
-			while(File.Exists(path + name + extension))
-			{
-				name = nameOri + " (" + idx + ")";
-				idx = idx + 1;
-			}
-
-			return FixFileName(path, name + extension);
+			return GXMailHelper.FixAndEnsureUniqueFileName(path, name + extension);
 		}
 
 		private static string ExtensionFromContentType(string contentType)

--- a/dotnet/src/dotnetframework/GxMail/POP3SessionOpenPop.cs
+++ b/dotnet/src/dotnetframework/GxMail/POP3SessionOpenPop.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Mail;
 using System.Reflection;
+using GeneXus.Mail.Util;
 using GeneXus.Utils;
 using OpenPop.Mime;
 using OpenPop.Pop3;
@@ -180,7 +181,7 @@ namespace GeneXus.Mail
 				
 				foreach (var attach in attachs)
                 {
-                    string attachName = FixFileName(AttachDir, attach.FileName);
+                    string attachName = GXMailHelper.FixAndEnsureUniqueFileName(AttachDir, attach.FileName);
                     if (!string.IsNullOrEmpty(attach.ContentId) && attach.ContentDisposition != null && attach.ContentDisposition.Inline)
                     {
                         string cid = "cid:" + attach.ContentId;

--- a/dotnet/src/dotnetframework/GxMail/Pop3MailKit.cs
+++ b/dotnet/src/dotnetframework/GxMail/Pop3MailKit.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Authentication;
+using GeneXus.Mail.Util;
 using GeneXus.Utils;
 using MailKit;
 using MailKit.Net.Pop3;
@@ -206,14 +207,14 @@ namespace GeneXus.Mail
 
 				foreach (MimeEntity attach in attachs)
 				{
-					string attachName = FixFileName(AttachDir, attach is MessagePart ? attach.ContentDisposition?.FileName : ((MimePart)attach).FileName);
+					string attachName = GXMailHelper.FixAndEnsureUniqueFileName(AttachDir, attach is MessagePart ? attach.ContentDisposition?.FileName : ((MimePart)attach).FileName);
 					ProcessMailAttachment(gxmessage, attach, attachName);
 				}
 				foreach (MimeEntity attach in msg.BodyParts)
 				{
 					if (IsEmbeddedImage(attach, msg))
 					{
-						string attachName = FixFileName(AttachDir, attach.ContentDisposition!=null ? attach.ContentDisposition?.FileName : ((MimePart)attach).FileName);
+						string attachName = GXMailHelper.FixAndEnsureUniqueFileName(AttachDir, attach.ContentDisposition!=null ? attach.ContentDisposition?.FileName : ((MimePart)attach).FileName);
 						ProcessMailAttachment(gxmessage, attach, attachName);
 					}
 				}

--- a/dotnet/src/dotnetframework/GxMail/Pop3SessionBase.cs
+++ b/dotnet/src/dotnetframework/GxMail/Pop3SessionBase.cs
@@ -103,18 +103,6 @@ namespace GeneXus.Mail
 			}
 		}
 
-		protected string FixFileName(string attachDir, string name)
-		{
-			if (string.IsNullOrEmpty(name))
-			{
-				name = Path.GetRandomFileName();
-			}
-			if (Path.Combine(AttachDir, name).Length > 200)
-			{
-				name = Path.GetRandomFileName().Replace(".", "") + "." + Path.GetExtension(name);
-			}
-			Regex validChars = new Regex(@"[\\\/\*\?\|:<>]");
-			return validChars.Replace(name, "_");
-		}
+
 	}
 }


### PR DESCRIPTION
Fixed issue where email attachments with the same name were overwritten. Now, duplicate filenames are saved as "file (1).ext", "file (2).ext", etc

Issue:203465