### PR TITLE
Fix/issue202777

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/gxproc.cs
@@ -109,8 +109,12 @@ namespace GeneXus.Procedure
 		}
 		private void exitApplication(bool flushBatchCursor)
 		{
+			bool inMainExit = false;
 			if (!(GxContext.IsHttpContext || GxContext.IsRestService) && IsMain && GxApplication.MainContext==context)
+			{
 				ThreadUtil.WaitForEnd();
+				inMainExit = true;
+			}
 
 			if (flushBatchCursor)
 			{
@@ -118,8 +122,9 @@ namespace GeneXus.Procedure
 					ds.Connection.FlushBatchCursors(this);
 			}
 
-			if (IsMain)
+			if (inMainExit)
 				dbgInfo?.OnExit();
+
 			if (disconnectUserAtCleanup)
 			{
 				try


### PR DESCRIPTION
- There are some scenarios where a single process executes GeneXus objects which end up with IsMain being true
For example, some GXTest/GXFlow code instantiates procedures without passing them a GxContext.
This was making the coverage trace file to try a premature cleanup and the need to start another coverage session
- Add a specific Id for .NET code coverage sessions (Id=3)
- Add a public static OnExit entry to allow for third party code which instantiates objects that end up being marked as Main in the same process to do a proper cleanup before exiting the last object.
- Update OnExit/1 to be more resilient by ensuring every DbgItem with ticks not set to have a valid tick count
- Add (conditionally compiled) code to generate a verbose log file of the trace being written. To enable this trace you have to build GxClasses.dll with  _LOG_WRITER symbol defined

Issue: 202777