### PR TITLE
The formatlink function was not applying the correct rewrite pattern

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
@@ -131,7 +131,12 @@ namespace GeneXus.Application
 						string objectName = map[0];
 						string url = map[1];
 						url = url.Replace(@"\=", "=").Replace(@"\\", @"\");
-						routerList[$"{NormalizedUrlObjectName(objectName)}.aspx"] = url;
+#if NETCORE
+						routerList[$"{NormalizedUrlObjectName(objectName)}"] = url;
+						routerList[$"{NormalizedUrlObjectName(objectName)}{HttpHelper.ASPX}"] = url;
+#else
+						routerList[$"{NormalizedUrlObjectName(objectName)}{HttpHelper.ASPX}"] = url;
+#endif
 					}
 				}
 			}


### PR DESCRIPTION
It was incorrectly adding the .aspx extension for .NETCORE.

To maintain compatibility, the .aspx extension is preserved when loading rewrite patterns, ensuring proper handling for link function with hardcoded argument.
Issue:203762