### PR TITLE
Bump version to 1.34

### DIFF
--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<AssemblyVersion>11.0.0.0</AssemblyVersion>
 		<MajorFileVersion>1</MajorFileVersion>
-		<MinorFileVersion>33</MinorFileVersion>
+		<MinorFileVersion>34</MinorFileVersion>
 		<PatchFileVersion Condition="'$(COMMIT_NUMBER)'!=''">$(COMMIT_NUMBER)</PatchFileVersion>
 		<PatchFileVersion Condition="'$(COMMIT_NUMBER)'==''">0</PatchFileVersion>
 		<FileVersion>$(MajorFileVersion).$(MinorFileVersion).$(PatchFileVersion)</FileVersion>


### PR DESCRIPTION
Due to the incorrect creation of a branch, we have lost version 1.32. The last release is generating packages with version 1.33, so we need to increment the version for the next release.