### PR TITLE
Remove Console.Read(); to prevent the host process from terminating when an error occurs.

### DIFF
--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -72,7 +72,6 @@ namespace GeneXus.Application
 			{
 				Console.Error.WriteLine("ERROR:");
 				Console.Error.WriteLine("Web Host terminated unexpectedly: {0}", e.Message);
-				Console.Read();
 			}			
 		}
 


### PR DESCRIPTION
Containerized processes do not require user input.