### PR TITLE
Prevent NullReferenceException when validating key

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Model/URLRouter.cs
@@ -20,7 +20,7 @@ namespace GeneXus.Application
 		internal static string GetURLRoute(string key, object[] objectParms, string[] parmsName, string scriptPath)
 		{
 			string[] parms = objectParms.Select(p => StringizeParm(p)).ToArray();
-			if (PathUtil.IsAbsoluteUrl(key) || key.StartsWith("/") || string.IsNullOrEmpty(key) || scheme.IsMatch(key))
+			if (string.IsNullOrEmpty(key) || PathUtil.IsAbsoluteUrl(key) || key.StartsWith("/")  || scheme.IsMatch(key))
 			{
 				if (parms.Length > 0)
 				{


### PR DESCRIPTION
Avoid NullReferenceException by checking for null or empty key first