### PR TITLE
Fix: Skip empty request content

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -892,8 +892,13 @@ namespace GeneXus.Http.Client
 					EndMultipartBoundary(reqStream);
 					GXLogging.Debug(log, "End SendStream.Read: stream " + reqStream.ToString());
 					reqStream.Seek(0, SeekOrigin.Begin);
-					request.Content = new ByteArrayContent(reqStream.ToArray());
-					setContentHeaders(request, contentType);
+					if (reqStream.Length > 0)
+					{
+						request.Content = new ByteArrayContent(reqStream.ToArray());
+						setContentHeaders(request, contentType);
+					}
+					else
+						GXLogging.Debug(log, "No content to send, skipping request.Content assignment.");
 #if NETCORE
 					response = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult();
 					response.ExtractCookies(cookies);
@@ -950,8 +955,15 @@ namespace GeneXus.Http.Client
 					EndMultipartBoundary(reqStream);
 					GXLogging.Debug(log, "End SendStream.Read: stream " + reqStream.ToString());
 					reqStream.Seek(0, SeekOrigin.Begin);
-					request.Content = new ByteArrayContent(reqStream.ToArray());
-					setContentHeaders(request, contentType);
+
+					if (reqStream.Length > 0)
+					{
+						request.Content = new ByteArrayContent(reqStream.ToArray());
+						setContentHeaders(request, contentType);
+					}
+					else
+						GXLogging.Debug(log, "No content to send, skipping request.Content assignment.");
+
 					response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 					response.ExtractCookies(cookies);
 				}


### PR DESCRIPTION
Added check to avoid sending empty request content when no data is present in the stream, preventing potential errors with services that reject Content-Length: 0
Issue:203510