### PR TITLE
Fix DynamicCall setters

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Helpers/GxDynamicCall.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/GxDynamicCall.cs
@@ -26,7 +26,7 @@ namespace GeneXus.DynamicCall
 			get => _properties;
 			set
 			{
-				_properties = Properties;
+				_properties = value;
 			}
 		}
 
@@ -35,7 +35,7 @@ namespace GeneXus.DynamicCall
 			get => _extendedProperties;
 			set
 			{
-				_extendedProperties = ExtendedProperties;
+				_extendedProperties = value;
 			}
 		}
 		public GxDynamicCall()


### PR DESCRIPTION
In the Property set, Properties was being assigned instead of value, which generates an infinite recursive call and eventually a StackOverflowException.