### PR TITLE
Multi-tenant Redis session support

### DIFF
--- a/dotnet/src/dotnetcore/GxClasses/Services/Session/GXSessionFactory.cs
+++ b/dotnet/src/dotnetcore/GxClasses/Services/Session/GXSessionFactory.cs
@@ -12,11 +12,13 @@ namespace GeneXus.Services
 	{
 		private static readonly IGXLogger log = GXLoggerFactory.GetLogger<GXSessionServiceFactory>();
 
+		static ISessionService sessionService;
 		static string REDIS = "REDIS";
 		static string DATABASE = "DATABASE";
 		public static ISessionService GetProvider()
 		{
-			ISessionService sessionService = null;
+			if (sessionService != null)
+				return sessionService;
 			GXService providerService = GXServices.Instance?.Get(GXServices.SESSION_SERVICE);
 			if (providerService != null)
 			{
@@ -63,6 +65,7 @@ namespace GeneXus.Services
 		internal static string SESSION_INSTANCE = "SESSION_PROVIDER_INSTANCE_NAME";
 		internal static string SESSION_PASSWORD = "SESSION_PROVIDER_PASSWORD";
 		static string SESSION_TIMEOUT = "SESSION_PROVIDER_SESSION_TIMEOUT";
+		const string SUBDOMAIN = "%SUBDOMAIN%";
 		public GxRedisSession(GXService serviceProvider)
 		{
 			string password = serviceProvider.Properties.Get(SESSION_PASSWORD);
@@ -99,6 +102,10 @@ namespace GeneXus.Services
 			SessionTimeout = sessionTimeout;
 			GXLogging.Debug(log, "Redis Host:", host, ", InstanceName:", instanceName);
 			GXLogging.Debug(log, "Redis sessionTimeoutMinutes:", sessionTimeout.ToString());
+		}
+		internal bool IsMultitenant
+		{
+			get { return InstanceName == SUBDOMAIN; }
 		}
 		public string ConnectionString { get; }
 		public string InstanceName { get; }

--- a/dotnet/src/dotnetcore/GxNetCoreStartup/SessionHelper.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/SessionHelper.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+using GeneXus.Services;
+using System.Linq;
+
+namespace GeneXus.Application
+{
+	public class TenantRedisCache : IDistributedCache
+	{
+		private readonly IHttpContextAccessor _httpContextAccessor;
+		private readonly IServiceProvider _serviceProvider;
+		private readonly ConcurrentDictionary<string, RedisCache> _redisCaches = new();
+
+		public TenantRedisCache(IHttpContextAccessor httpContextAccessor, IServiceProvider serviceProvider)
+		{
+			_httpContextAccessor = httpContextAccessor;
+			_serviceProvider = serviceProvider;
+		}
+
+		private IDistributedCache GetTenantCache()
+		{
+			string tenantId = _httpContextAccessor.HttpContext?.Items[TenantMiddleware.TENANT_ID]?.ToString() ?? "default";
+
+			return _redisCaches.GetOrAdd(tenantId, id =>
+			{
+				ISessionService sessionService = GXSessionServiceFactory.GetProvider();
+				var options = new RedisCacheOptions
+				{
+					Configuration = sessionService.ConnectionString,
+					InstanceName = $"{id}:"
+				};
+				return new RedisCache(options);
+			});
+		}
+
+		public byte[] Get(string key) => GetTenantCache().Get(key);
+		public Task<byte[]> GetAsync(string key, CancellationToken token = default) => GetTenantCache().GetAsync(key, token);
+		public void Refresh(string key) => GetTenantCache().Refresh(key);
+		public Task RefreshAsync(string key, CancellationToken token = default) => GetTenantCache().RefreshAsync(key, token);
+		public void Remove(string key) => GetTenantCache().Remove(key);
+		public Task RemoveAsync(string key, CancellationToken token = default) => GetTenantCache().RemoveAsync(key, token);
+		public void Set(string key, byte[] value, DistributedCacheEntryOptions options) => GetTenantCache().Set(key, value, options);
+		public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default) => GetTenantCache().SetAsync(key, value, options, token);
+	}
+
+
+	public class TenantMiddleware
+	{
+		internal const string TENANT_ID = "TenantId";
+		private readonly RequestDelegate _next;
+
+		public TenantMiddleware(RequestDelegate next)
+		{
+			_next = next;
+		}
+
+		public async Task Invoke(HttpContext context)
+		{
+			string host = context.Request.Host.Host;
+			string subdomain = host.Split('.').FirstOrDefault();
+			context.Items[TENANT_ID] = subdomain; 
+
+			await _next(context);
+		}
+	}
+}

--- a/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/Startup.cs
@@ -28,6 +28,7 @@ using Microsoft.AspNetCore.Rewrite;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -436,15 +437,27 @@ namespace GeneXus.Application
 
 		private void ConfigureSessionService(IServiceCollection services, ISessionService sessionService)
 		{
+			
 			if (sessionService is GxRedisSession)
 			{
-				services.AddStackExchangeRedisCache(options =>
+				GxRedisSession gxRedisSession = (GxRedisSession)sessionService;
+				if (gxRedisSession.IsMultitenant)
 				{
-					GXLogging.Info(log, $"Using Redis for Distributed session, ConnectionString:{sessionService.ConnectionString}, InstanceName: {sessionService.InstanceName}");
-					options.Configuration = sessionService.ConnectionString;
-					options.InstanceName = sessionService.InstanceName;
-				});
-				services.AddDataProtection().PersistKeysToStackExchangeRedis(ConnectionMultiplexer.Connect(sessionService.ConnectionString), DATA_PROTECTION_KEYS).SetApplicationName(sessionService.InstanceName);
+					GXLogging.Info(log, $"Using multi-tenant Redis for Distributed session, ConnectionString:{sessionService.ConnectionString}, InstanceName: {sessionService.InstanceName}");
+
+					services.AddSingleton<IDistributedCache, TenantRedisCache>();
+					services.AddDataProtection().PersistKeysToStackExchangeRedis(ConnectionMultiplexer.Connect(sessionService.ConnectionString), DATA_PROTECTION_KEYS).SetApplicationName("default");
+				}
+				else
+				{
+					services.AddStackExchangeRedisCache(options =>
+					{
+						GXLogging.Info(log, $"Using Redis for Distributed session, ConnectionString:{sessionService.ConnectionString}, InstanceName: {sessionService.InstanceName}");
+						options.Configuration = sessionService.ConnectionString;
+						options.InstanceName = sessionService.InstanceName;
+					});
+					services.AddDataProtection().PersistKeysToStackExchangeRedis(ConnectionMultiplexer.Connect(sessionService.ConnectionString), DATA_PROTECTION_KEYS).SetApplicationName(sessionService.InstanceName);
+				}
 			}
 			else if (sessionService is GxDatabaseSession)
 			{
@@ -491,6 +504,14 @@ namespace GeneXus.Application
 			app.UseCookiePolicy();
 			app.UseSession();
 			app.UseStaticFiles();
+
+			ISessionService sessionService = GXSessionServiceFactory.GetProvider();
+			GxRedisSession gxRedisSession = sessionService as GxRedisSession;
+			if (gxRedisSession != null && gxRedisSession.IsMultitenant)
+			{
+				app.UseMiddleware<TenantMiddleware>();
+			}
+
 			ConfigureCors(app);
 			ConfigureSwaggerUI(app, baseVirtualPath);
 


### PR DESCRIPTION
Updated Redis session configuration to use subdomain as instance name, ensuring tenant-specific session isolation in a multi-tenant environment
Issue:204332