### PR TITLE
Fix NullReferenceException at FtpService.GetIpAddress 

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxFtp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxFtp.cs
@@ -96,6 +96,12 @@ namespace GeneXus.Utils
 			{
 				if (! sUrl.StartsWith( "//"))
 					sUrl = "//" + sUrl;
+
+				if (Uri.CheckHostName(sUrl.TrimStart('/')) == UriHostNameType.IPv6)
+				{
+					sUrl = "//[" + sUrl.TrimStart('/') + "]";
+				}
+
 				sUrl = "ftp:" + sUrl;
 			}
 			Uri Url= new Uri( sUrl);

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxFtp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxFtp.cs
@@ -685,7 +685,11 @@ namespace GeneXus.Utils
 			{
 				ipAddresses = serverHostEntry.AddressList.FirstOrDefault(a => a != null && a.AddressFamily == _DataSocket.AddressFamily);
 			}
-			else
+			else if (_ControlSocket != null)
+			{
+				ipAddresses = serverHostEntry.AddressList.FirstOrDefault(a => a != null && a.AddressFamily == _ControlSocket.AddressFamily);
+			}
+			else 
 			{
 				ipAddresses = serverHostEntry.AddressList.FirstOrDefault();
 			}

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxFtp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxFtp.cs
@@ -680,7 +680,7 @@ namespace GeneXus.Utils
 		private IPAddress GetIpAddress(string host)
 		{
 			IPHostEntry serverHostEntry = Dns.GetHostEntry(host);
-			IPAddress ipAddresses = serverHostEntry.AddressList.FirstOrDefault(a => (a.AddressFamily == _DataSocket.AddressFamily));
+			IPAddress ipAddresses = serverHostEntry.AddressList.FirstOrDefault(a => a!=null && a.AddressFamily == _DataSocket.AddressFamily);
 			GXLogging.Debug(log, $"GetHostEntry({host}) AddressList length: ", serverHostEntry.AddressList.Length.ToString());
 			if (ipAddresses == null)
 			{

--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxFtp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxFtp.cs
@@ -680,7 +680,15 @@ namespace GeneXus.Utils
 		private IPAddress GetIpAddress(string host)
 		{
 			IPHostEntry serverHostEntry = Dns.GetHostEntry(host);
-			IPAddress ipAddresses = serverHostEntry.AddressList.FirstOrDefault(a => a!=null && a.AddressFamily == _DataSocket.AddressFamily);
+			IPAddress ipAddresses;
+			if (_DataSocket != null)
+			{
+				ipAddresses = serverHostEntry.AddressList.FirstOrDefault(a => a != null && a.AddressFamily == _DataSocket.AddressFamily);
+			}
+			else
+			{
+				ipAddresses = serverHostEntry.AddressList.FirstOrDefault();
+			}
 			GXLogging.Debug(log, $"GetHostEntry({host}) AddressList length: ", serverHostEntry.AddressList.Length.ToString());
 			if (ipAddresses == null)
 			{

--- a/dotnet/test/DotNetUnitTest/Domain/GxFtpTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/GxFtpTest.cs
@@ -9,6 +9,7 @@ namespace xUnitTesting
 	{
 		[Theory]
 		[InlineData("127.0.0.1", AddressFamily.InterNetwork)] // IPv4
+		[InlineData("::1", AddressFamily.InterNetworkV6)]     // IPv6
 		[InlineData("localhost", AddressFamily.InterNetwork)] // Hostname resolving to IPv4
 		public void FtpAddressFamilyTest(string host, AddressFamily addressFamily)
 		{
@@ -22,6 +23,6 @@ namespace xUnitTesting
 			context.FtpInstance.GetStatusText(out msg);
 			Assert.Equal("Login Failed.", msg);
 		}
-	
+		
 	}
 }

--- a/dotnet/test/DotNetUnitTest/Domain/GxFtpTest.cs
+++ b/dotnet/test/DotNetUnitTest/Domain/GxFtpTest.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Net.Sockets;
+using GeneXus.Application;
+using Xunit;
+
+namespace xUnitTesting
+{
+	public class GxFtpTest
+	{
+		[Theory]
+		[InlineData("127.0.0.1", AddressFamily.InterNetwork)] // IPv4
+		[InlineData("localhost", AddressFamily.InterNetwork)] // Hostname resolving to IPv4
+		public void FtpAddressFamilyTest(string host, AddressFamily addressFamily)
+		{
+			GxContext context = new GxContext();
+			int code;
+			string msg;
+			Console.WriteLine("Testing AddressFamily for host: " + host + " with address family: " + addressFamily);
+			context.FtpInstance.Connect(host, "admin", "P@ssw0rd");
+			context.FtpInstance.GetErrorCode(out code);
+			Assert.Equal(1, code);
+			context.FtpInstance.GetStatusText(out msg);
+			Assert.Equal("Login Failed.", msg);
+		}
+	
+	}
+}


### PR DESCRIPTION
Added null check for IPAddress in FirstOrDefault to prevent NullReferenceException in GetIpAddress method
Issue:204637