### PR TITLE
- Fix numeric format in Json Serialization for locales where the comma is the decimal separator.

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
@@ -3161,18 +3161,20 @@ namespace GeneXus.Utils
 			writer.WriteBooleanValue(value);
 		}
 	}
+	
 	public class StringConverter : JsonConverter<string>
 	{
 		public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 		{
 			if (reader.TokenType == JsonTokenType.Number)
 			{
+				var numberFmt = CultureInfo.InvariantCulture.NumberFormat;
+
 				if (reader.TryGetInt32(out int l))
-					return l.ToString();
-				else if (reader.TryGetDecimal(out decimal d))
-					return d.ToString();
-				else
-					return reader.GetDouble().ToString();
+					return l.ToString(numberFmt);
+				if (reader.TryGetDecimal(out decimal d))
+					return d.ToString(numberFmt);
+				return reader.GetDouble().ToString(numberFmt);
 			}
 			return reader.GetString();
 		}


### PR DESCRIPTION
 Fix : Numeric format in Json Serialization lost decimals when  locales ( such as spanish) has a decimal separator different to the point (".") 
