### PR TITLE
Fix RestAPIClient decimal parsing in non-invariant cultures

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Helpers/GXRestAPIClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/GXRestAPIClient.cs
@@ -1,34 +1,33 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 using GeneXus.Utils;
 using GeneXus.Http.Client;
-
 using System.Web;
-
 using GeneXus.Mime;
-
 using System.Globalization;
+using GeneXus.Http;
+using System.Threading;
+
+
+
 
 #if NETCORE
 using System.Text.Json;
 using System.Text.Json.Serialization;
 #endif
-using System.IO;
 
 namespace GeneXus.Application
 {
 	public class GXRestAPIClient
 	{
+		static readonly IGXLogger log = GXLoggerFactory.GetLogger<GXRestAPIClient>();
+
 		private const string DATE_EMPTY = "0000-00-00";
 		private const string DATETIME_EMPTY = "0000-00-00T00:00:00";
 		private const string DATE_FORMAT = "yyyy-MM-dd";
 		private const string DATETIME_FORMAT = "yyyy-MM-ddTHH:mm:ss";
 		private const string DATETIME_MS_FORMAT = "yyyy-MM-ddTHH:mm:ss.fff";
-		
+
 		public GXRestAPIClient()
 		{
 			Location = new GxLocation();
@@ -38,7 +37,7 @@ namespace GeneXus.Application
 #if NETCORE
 			Location.Port = 8082;
 #else
-			Location.Port = 80;
+                        Location.Port = 80;
 #endif
 		}
 
@@ -50,7 +49,7 @@ namespace GeneXus.Application
 		public string ErrorMessage { get; set; }
 
 		public int StatusCode { get; set; }
-		public string StatusMessage { get ; set; }
+		public string StatusMessage { get; set; }
 		public int ResponseCode { get => responseCode; set => responseCode = value; }
 		public string ResponseMessage { get => responseMessage; set => responseMessage = value; }
 		public string HttpMethod { get => httpMethod; set => httpMethod = value; }
@@ -63,70 +62,74 @@ namespace GeneXus.Application
 		private Dictionary<string, string> _headerVars = new Dictionary<string, string>();
 		private Dictionary<string, string> _bodyVars = new Dictionary<string, string>();
 		//private Dictionary<string, string> _pathVars = new Dictionary<string, string>();
-		private Dictionary<string,object> _responseData = new Dictionary<string, object>();
+		private Dictionary<string, object> _responseData = new Dictionary<string, object>();
+
+		// Internal properties for testing purposes
+		internal Dictionary<string, string> BodyVars => _bodyVars;
+		internal Dictionary<string, object> ResponseData { get => _responseData; set => _responseData = value; }
 
 		private string _contentType = "application/json; charset=utf-8";
-		private string _queryString = String.Empty;
-		private string _bodyString = String.Empty;
+		private string _queryString = string.Empty;
+		private string _bodyString = string.Empty;
 
 		private int responseCode = 0;
-		private string responseMessage = String.Empty;
+		private string responseMessage = string.Empty;
 
 
 		#region "Header Vars"
 
-		public void AddHeaderVar(String varName, String varValue)
+		public void AddHeaderVar(string varName, string varValue)
 		{
 			_headerVars[varName] = GXUtil.UrlEncode(varValue);
 		}
-		public void AddHeaderVar(String varName, int varValue)
+		public void AddHeaderVar(string varName, int varValue)
 		{
 			_headerVars[varName] = varValue.ToString();
 		}
-		public void AddHeaderVar(String varName, long varValue)
+		public void AddHeaderVar(string varName, long varValue)
 		{
 			_headerVars[varName] = varValue.ToString();
 		}
 
-		public void AddHeaderVar(String varName, short varValue)
+		public void AddHeaderVar(string varName, short varValue)
 		{
 			_headerVars[varName] = varValue.ToString();
 		}
-		public void AddHeaderVar(String varName, Decimal varValue)
+		public void AddHeaderVar(string varName, decimal varValue)
 		{
-			_headerVars[varName] = varValue.ToString(System.Globalization.CultureInfo.InvariantCulture);
+			_headerVars[varName] = varValue.ToString(CultureInfo.InvariantCulture);
 		}
-		public void AddHeaderVar(String varName, DateTime varValue)
+		public void AddHeaderVar(string varName, DateTime varValue)
 		{
 			_headerVars[varName] = varValue.ToString(DATE_FORMAT);
 		}
-		public void AddHeaderVar(String varName, DateTime varValue, bool hasMilliseconds)
+		public void AddHeaderVar(string varName, DateTime varValue, bool hasMilliseconds)
 		{
 			string fmt = DATETIME_FORMAT;
 			if (hasMilliseconds)
 				fmt = DATETIME_MS_FORMAT;
 			_headerVars[varName] = varValue.ToString(fmt);
 		}
-		public void AddHeaderVar(String varName, Guid varValue)
+		public void AddHeaderVar(string varName, Guid varValue)
 		{
 			_headerVars[varName] = varValue.ToString();
 		}
-		public void AddHeaderVar(String varName, Geospatial varValue)
+		public void AddHeaderVar(string varName, Geospatial varValue)
 		{
 			_headerVars[varName] = GXUtil.UrlEncode(varValue.ToString());
 		}
-		public void AddHeaderVar(String varName, bool varValue)
+		public void AddHeaderVar(string varName, bool varValue)
 		{
 			_headerVars[varName] = StringUtil.BoolToStr(varValue);
 		}
-		public void AddHeaderVar(String varName, GxUserType varValue)
+		public void AddHeaderVar(string varName, GxUserType varValue)
 		{
 			if (varValue != null)
 			{
 				_headerVars[varName] = varValue.ToJSonString();
 			}
 		}
-		public void AddHeaderVar(String varName, IGxCollection varValue)
+		public void AddHeaderVar(string varName, IGxCollection varValue)
 		{
 			if (varValue != null)
 			{
@@ -136,66 +139,66 @@ namespace GeneXus.Application
 		#endregion
 
 		#region "Query Vars"
-		public void AddQueryVar(String varName, String varValue)
+		public void AddQueryVar(string varName, string varValue)
 		{
 			_queryVars[varName] = GXUtil.UrlEncode(varValue);
 		}
 
-		public void AddQueryVar(String varName, int varValue)
+		public void AddQueryVar(string varName, int varValue)
 		{
 			_queryVars[varName] = varValue.ToString();
 		}
-		public void AddQueryVar(String varName, long varValue)
-		{
-			_queryVars[varName] = varValue.ToString();
-		}
-
-		public void AddQueryVar(String varName, short varValue)
+		public void AddQueryVar(string varName, long varValue)
 		{
 			_queryVars[varName] = varValue.ToString();
 		}
 
-		public void AddQueryVar(String varName, Decimal varValue)
+		public void AddQueryVar(string varName, short varValue)
 		{
-			_queryVars[varName] = varValue.ToString(System.Globalization.CultureInfo.InvariantCulture);
+			_queryVars[varName] = varValue.ToString();
 		}
 
-		public void AddQueryVar(String varName, DateTime varValue)
+		public void AddQueryVar(string varName, decimal varValue)
+		{
+			_queryVars[varName] = varValue.ToString(CultureInfo.InvariantCulture);
+		}
+
+		public void AddQueryVar(string varName, DateTime varValue)
 		{
 			_queryVars[varName] = varValue.ToString(DATE_FORMAT);
 		}
 
-		public void AddQueryVar(String varName, DateTime varValue, bool hasMilliseconds)
+		public void AddQueryVar(string varName, DateTime varValue, bool hasMilliseconds)
 		{
 			string fmt = DATETIME_FORMAT;
 			if (hasMilliseconds)
 				fmt = DATETIME_MS_FORMAT;
 			_queryVars[varName] = varValue.ToString(fmt);
 		}
-		public void AddQueryVar(String varName, Guid varValue)
+		public void AddQueryVar(string varName, Guid varValue)
 		{
 			_queryVars[varName] = varValue.ToString();
 		}
 
-		public void AddQueryVar(String varName, Geospatial varValue)
+		public void AddQueryVar(string varName, Geospatial varValue)
 		{
 			_queryVars[varName] = GXUtil.UrlEncode(varValue.ToString());
 		}
 
-		public void AddQueryVar(String varName, bool varValue)
+		public void AddQueryVar(string varName, bool varValue)
 		{
 			_queryVars[varName] = StringUtil.BoolToStr(varValue);
 		}
 
-		public void AddQueryVar(String varName, GxUserType varValue)
+		public void AddQueryVar(string varName, GxUserType varValue)
 		{
 			if (varValue != null)
 			{
 				_bodyVars[varName] = varValue.ToJSonString();
-			}			
+			}
 		}
 
-		public void AddQueryVar(String varName, IGxCollection varValue)
+		public void AddQueryVar(string varName, IGxCollection varValue)
 		{
 			if (varValue != null)
 			{
@@ -206,12 +209,12 @@ namespace GeneXus.Application
 
 		#region "Body Vars"
 
-		public void AddBodyVar(String varName, DateTime varValue)
+		public void AddBodyVar(string varName, DateTime varValue)
 		{
-			_bodyVars[varName] = "\"" +  varValue.ToString(DATE_FORMAT) + "\"";
+			_bodyVars[varName] = "\"" + varValue.ToString(DATE_FORMAT) + "\"";
 		}
 
-		public void AddBodyVar(String varName, DateTime varValue, bool hasMilliseconds)
+		public void AddBodyVar(string varName, DateTime varValue, bool hasMilliseconds)
 		{
 			string fmt = DATETIME_FORMAT;
 			if (hasMilliseconds)
@@ -219,42 +222,42 @@ namespace GeneXus.Application
 			_bodyVars[varName] = "\"" + varValue.ToString(fmt) + "\"";
 		}
 
-		public void AddBodyVar(String varName, Decimal varValue)
+		public void AddBodyVar(string varName, decimal varValue)
 		{
-			_bodyVars[varName] = varValue.ToString(System.Globalization.CultureInfo.InvariantCulture);
+			_bodyVars[varName] = varValue.ToString(CultureInfo.InvariantCulture);
 		}
 
-		public void AddBodyVar(String varName, string varValue)
+		public void AddBodyVar(string varName, string varValue)
 		{
-			_bodyVars[varName] = "\"" + varValue + "\"" ;
+			_bodyVars[varName] = "\"" + varValue + "\"";
 		}
-		public void AddBodyVar(String varName, int varValue)
-		{
-			_bodyVars[varName] = varValue.ToString();
-		}
-		public void AddBodyVar(String varName, short varValue)
+		public void AddBodyVar(string varName, int varValue)
 		{
 			_bodyVars[varName] = varValue.ToString();
 		}
-		public void AddBodyVar(String varName, long varValue)
+		public void AddBodyVar(string varName, short varValue)
 		{
 			_bodyVars[varName] = varValue.ToString();
 		}
-		public void AddBodyVar(String varName, bool varValue)
+		public void AddBodyVar(string varName, long varValue)
+		{
+			_bodyVars[varName] = varValue.ToString();
+		}
+		public void AddBodyVar(string varName, bool varValue)
 		{
 			_bodyVars[varName] = StringUtil.BoolToStr(varValue);
 		}
-		public void AddBodyVar(String varName, Guid varValue)
+		public void AddBodyVar(string varName, Guid varValue)
 		{
 			_bodyVars[varName] = "\"" + varValue.ToString() + "\"";
 		}
 
-		public void AddBodyVar(String varName, Geospatial varValue)
+		public void AddBodyVar(string varName, Geospatial varValue)
 		{
 			_bodyVars[varName] = "\"" + varValue.ToString() + "\"";
 		}
 
-		public void AddBodyVar(String varName, GxUserType varValue)
+		public void AddBodyVar(string varName, GxUserType varValue)
 		{
 			if (varValue != null)
 			{
@@ -262,7 +265,7 @@ namespace GeneXus.Application
 			}
 		}
 
-		public void AddBodyVar(String varName, IGxCollection varValue)
+		public void AddBodyVar(string varName, IGxCollection varValue)
 		{
 			if (varValue != null)
 			{
@@ -283,7 +286,7 @@ namespace GeneXus.Application
 			string val = GetHeaderString(varName);
 			if (val.StartsWith(DATE_EMPTY))
 				return DateTimeUtil.NullDate();
-			return DateTime.ParseExact(val, DATE_FORMAT, System.Globalization.CultureInfo.InvariantCulture);
+			return DateTime.ParseExact(val, DATE_FORMAT, CultureInfo.InvariantCulture);
 		}
 
 		public DateTime GetHeaderDateTime(string varName, bool hasMilliseconds)
@@ -294,7 +297,7 @@ namespace GeneXus.Application
 			string fmt = DATETIME_FORMAT;
 			if (hasMilliseconds)
 				fmt = DATETIME_MS_FORMAT;
-			return DateTime.ParseExact(val, fmt, System.Globalization.CultureInfo.InvariantCulture);
+			return DateTime.ParseExact(val, fmt, CultureInfo.InvariantCulture);
 		}
 
 		public bool GetHeaderBool(string varName)
@@ -307,9 +310,9 @@ namespace GeneXus.Application
 			return Guid.Parse(GetHeaderString(varName));
 		}
 
-		public Decimal GetHeaderNum(string varName)
+		public decimal GetHeaderNum(string varName)
 		{
-			httpClient.GetHeader(varName, out Decimal val);
+			httpClient.GetHeader(varName, out decimal val);
 			return val;
 		}
 		public long GetHeaderLong(string varName)
@@ -345,7 +348,7 @@ namespace GeneXus.Application
 
 		public string GetBodyString(string varName)
 		{
-			return  GetJsonStr(varName);			
+			return GetJsonStr(varName);
 		}
 
 		public DateTime GetBodyDate(string varName)
@@ -353,7 +356,7 @@ namespace GeneXus.Application
 			string val = GetJsonStr(varName);
 			if (val.StartsWith(DATE_EMPTY))
 				return DateTimeUtil.NullDate();
-			return DateTime.ParseExact(val, DATE_FORMAT, System.Globalization.CultureInfo.InvariantCulture);
+			return DateTime.ParseExact(val, DATE_FORMAT, CultureInfo.InvariantCulture);
 		}
 
 		public DateTime GetBodyDateTime(string varName, bool hasMilliseconds)
@@ -364,47 +367,202 @@ namespace GeneXus.Application
 			string fmt = DATETIME_FORMAT;
 			if (hasMilliseconds)
 				fmt = DATETIME_MS_FORMAT;
-			return DateTime.ParseExact(val, fmt,System.Globalization.CultureInfo.InvariantCulture);
+			return DateTime.ParseExact(val, fmt, CultureInfo.InvariantCulture);
 		}
 
 		public bool GetBodyBool(string varName)
-		{			
-			return  Boolean.Parse(GetJsonStr(varName));
+		{
+			return Boolean.Parse(GetJsonStr(varName));
 		}
 		public Guid GetBodyGuid(string varName)
-		{			
+		{
 			return Guid.Parse(GetJsonStr(varName));
 		}
 
-		public Decimal GetBodyNum(string varName)
+		internal object GetBodyValue(string varName)
 		{
-            	try
+			try
 			{
-				return Decimal.Parse(GetJsonStr(varName), NumberStyles.Float, CultureInfo.InvariantCulture);
+				if (_responseData.TryGetValue(varName.ToLower(), out object value))
+				{
+					return value;
+				}
+				else if (_responseData.Count == 1 && _responseData.ContainsKey(String.Empty))
+				{
+					return _responseData[String.Empty];
+				}
+
+				return null;
 			}
-			catch (FormatException)
+			catch (Exception ex)
 			{
-				Console.WriteLine("Failed to parse number due to format exception.");
+				GXLogging.Warn(log, "Failed to get value from response:" + varName, ex);
+				return null;
 			}
-			catch (OverflowException)
+		}
+
+		public decimal GetBodyNum(string varName)
+		{
+			object value;
+			try
 			{
-				Console.WriteLine("Failed to parse number due to overflow exception.");
+				value = GetBodyValue(varName);
+
+				if (value != null)
+				{
+					if (value is decimal decimalValue)
+						return decimalValue;
+
+					if (value is double doubleValue)
+						return (decimal)doubleValue;
+
+					if (value is int intValue)
+						return intValue;
+
+					if (value is long longValue)
+						return longValue;
+
+					if (value is short shortValue)
+						return shortValue;
+
+					if (value is float floatValue)
+						return (decimal)floatValue;
+
+				}
+
+				return decimal.Parse(GetJsonStr(varName), NumberStyles.Float, CultureInfo.InvariantCulture);
 			}
-			// Return a empty value in case of an exception
+			catch (Exception ex)
+			{
+				GXLogging.Error(log, "Failed to get number value:", GetJsonStr(varName), ex);
+			}
 			return 0m;
 		}
 		public long GetBodyLong(string varName)
 		{
-			return long.Parse(GetJsonStr(varName));
+			try
+			{
+				object value = GetBodyValue(varName);
+
+				if (value != null)
+				{
+					if (value is long longValue)
+						return longValue;
+
+					if (value is int intValue)
+						return intValue;
+
+					if (value is short shortValue)
+						return shortValue;
+
+					if (value is decimal decimalValue)
+						return (long)decimalValue;
+
+					if (value is double doubleValue)
+						return (long)doubleValue;
+
+				}
+
+				return long.Parse(GetJsonStr(varName));
+			}
+			catch (Exception ex)
+			{
+				GXLogging.Error(log, "Failed to get long value:", GetJsonStr(varName), ex);
+				return 0L;
+			}
 		}
+
 		public int GetBodyInt(string varName)
 		{
-			return Int32.Parse(GetJsonStr(varName));
+			try
+			{
+				object value = GetBodyValue(varName);
+
+				if (value != null)
+				{
+					if (value is int intValue)
+						return intValue;
+
+					if (value is short shortValue)
+						return shortValue;
+
+					if (value is long longValue)
+					{
+						if (longValue >= int.MinValue && longValue <= int.MaxValue)
+							return (int)longValue;
+						else
+							throw new OverflowException("Long value is outside the range of Int32");
+					}
+
+					if (value is decimal decimalValue)
+						return (int)decimalValue;
+
+					if (value is double doubleValue)
+						return (int)doubleValue;
+
+				}
+
+				return int.Parse(GetJsonStr(varName));
+			}
+			catch (Exception ex)
+			{
+				GXLogging.Error(log, "Failed to get int value:", GetJsonStr(varName), ex);
+				return 0;
+			}
 		}
 
 		public short GetBodyShort(string varName)
-		{			
-			return (short)Int16.Parse(GetJsonStr(varName));
+		{
+			try
+			{
+				object value = GetBodyValue(varName);
+
+				if (value != null)
+				{
+					if (value is short shortValue)
+						return shortValue;
+
+					if (value is int intValue)
+					{
+						if (intValue >= short.MinValue && intValue <= short.MaxValue)
+							return (short)intValue;
+						else
+							throw new OverflowException("Int value is outside the range of Int16");
+					}
+
+					if (value is long longValue)
+					{
+						if (longValue >= short.MinValue && longValue <= short.MaxValue)
+							return (short)longValue;
+						else
+							throw new OverflowException("Long value is outside the range of Int16");
+					}
+
+					if (value is decimal decimalValue)
+					{
+						if (decimalValue >= short.MinValue && decimalValue <= short.MaxValue)
+							return (short)decimalValue;
+						else
+							throw new OverflowException("decimal value is outside the range of Int16");
+					}
+
+					if (value is double doubleValue)
+					{
+						if (doubleValue >= short.MinValue && doubleValue <= short.MaxValue)
+							return (short)doubleValue;
+						else
+							throw new OverflowException("Double value is outside the range of Int16");
+					}
+
+				}
+
+				return short.Parse(GetJsonStr(varName));
+			}
+			catch (Exception ex)
+			{
+				GXLogging.Error(log, "Failed to get short value:", GetJsonStr(varName), ex);
+				return 0;
+			}
 		}
 
 		public Geospatial GetBodyGeospatial(string varName)
@@ -419,29 +577,24 @@ namespace GeneXus.Application
 
 		public string GetJsonStr(string varName)
 		{
-			string s = String.Empty;
-			if (_responseData.ContainsKey(varName.ToLower()))
-			{
-				s = _responseData[varName.ToLower()].ToString();
-			}
-			else if (_responseData.Count == 1 && _responseData.ContainsKey(String.Empty))
-			{
-				s = _responseData[String.Empty].ToString();
-			}
-			return s;	
+			string s = string.Empty;
+			object value = GetBodyValue(varName);
+			if (value != null)
+				s = value.ToString();
+			return s;
 		}
-		
-		public T GetBodySdt<T>(string varName) where T:GxUserType, new()
+
+		public T GetBodySdt<T>(string varName) where T : GxUserType, new()
 		{
 			T sdt = new T();
 			if (_responseData.ContainsKey(varName.ToLower()) && _responseData.Count == 1) //wrapped sdt
 			{
 				sdt.FromJSonString(_responseData[varName.ToLower()].ToString(), null);
 			}
-			else if (_responseData.Count == 1 && _responseData.ContainsKey(String.Empty)) // unwrapped 
+			else if (_responseData.Count == 1 && _responseData.ContainsKey(string.Empty)) // unwrapped 
 			{
-				sdt.FromJSonString(_responseData[String.Empty].ToString(), null);
-			}			
+				sdt.FromJSonString(_responseData[string.Empty].ToString(), null);
+			}
 			else if (_responseData.Count >= 1) // can contain the same key (recursive unwrapped)
 			{
 
@@ -452,40 +605,40 @@ namespace GeneXus.Application
 				else
 					sdt.FromJSonString("{" + varName + ":" + rData + "}", null);
 #else
-				string rData = JSONHelper.Serialize(_responseData);
-				if (sdt.FromJSonString(rData, null))
-					return sdt;
-				else
-					sdt.FromJSonString("{" + varName + ":" + rData + "}", null);
+                                string rData = JSONHelper.Serialize(_responseData);
+                                if (sdt.FromJSonString(rData, null))
+                                        return sdt;
+                                else
+                                        sdt.FromJSonString("{" + varName + ":" + rData + "}", null);
 #endif
 			}
 			return sdt;
 		}
 
-		public GXBaseCollection<T> GetBodySdtCollection<T>(string varName) where T:GxUserType , new()
-		{			
+		public GXBaseCollection<T> GetBodySdtCollection<T>(string varName) where T : GxUserType, new()
+		{
 			GXBaseCollection<T> collection = new GXBaseCollection<T>();
 			if (_responseData.ContainsKey(varName.ToLower()))
-			{				
+			{
 				collection.FromJSonString(_responseData[varName.ToLower()].ToString(), null);
 			}
-			else if (_responseData.Count == 1 && _responseData.ContainsKey(String.Empty))
+			else if (_responseData.Count == 1 && _responseData.ContainsKey(string.Empty))
 			{
-				collection.FromJSonString(_responseData[String.Empty].ToString(), null);
+				collection.FromJSonString(_responseData[string.Empty].ToString(), null);
 			}
 			return collection;
 		}
 
-		public GxSimpleCollection<T> GetBodySimpleCollection<T>(string varName) 
-		{			
-			GxSimpleCollection<T> collection = new GxSimpleCollection<T>();			
+		public GxSimpleCollection<T> GetBodySimpleCollection<T>(string varName)
+		{
+			GxSimpleCollection<T> collection = new GxSimpleCollection<T>();
 			if (_responseData.ContainsKey(varName.ToLower()))
 			{
 				collection.FromJSonString(_responseData[varName.ToLower()].ToString(), null);
 			}
-			else if (_responseData.Count == 1 && _responseData.ContainsKey(String.Empty))
+			else if (_responseData.Count == 1 && _responseData.ContainsKey(string.Empty))
 			{
-				collection.FromJSonString(_responseData[String.Empty].ToString(), null);
+				collection.FromJSonString(_responseData[string.Empty].ToString(), null);
 			}
 			return collection;
 		}
@@ -501,7 +654,7 @@ namespace GeneXus.Application
 		public void RestExecute()
 		{
 			this.ErrorCode = 0;
-      this.ErrorMessage = "";
+			this.ErrorMessage = "";
 			this.StatusCode = 0;
 			this.StatusMessage = "";
 
@@ -512,7 +665,7 @@ namespace GeneXus.Application
 					httpClient.AddHeader(key, _headerVars[key]);
 				}
 			}
-			_queryString = String.Empty;
+			_queryString = string.Empty;
 			if (_queryVars.Count > 0)
 			{
 				string separator = "?";
@@ -522,13 +675,13 @@ namespace GeneXus.Application
 					separator = "&";
 				}
 			}
-			_bodyString = String.Empty;
+			_bodyString = string.Empty;
 			if (_bodyVars.Count > 0)
 			{
-				string separator = String.Empty;
+				string separator = string.Empty;
 				foreach (string key in _bodyVars.Keys)
 				{
-					_bodyString +=  separator + "\"" + key + "\":" + _bodyVars[key];
+					_bodyString += separator + "\"" + key + "\":" + _bodyVars[key];
 					separator = ",";
 				}
 			}
@@ -547,15 +700,15 @@ namespace GeneXus.Application
 					httpClient.AddHeader("Content-Type", _contentType);
 				}
 			}
-			if (this.Location.AuthenticationMethod == 4 && !String.IsNullOrEmpty(this.Location.AccessToken))
+			if (this.Location.AuthenticationMethod == 4 && !string.IsNullOrEmpty(this.Location.AccessToken))
 			{
 				httpClient.AddHeader("Authorization", this.Location.AccessToken);
 			}
 			string serviceuri = ((this.Location.Secure > 0) ? "https" : "http") + "://" + this.Location.Host;
-			serviceuri += (this.Location.Port != 80) ? ":" + this.Location.Port.ToString() : String.Empty;
+			serviceuri += (this.Location.Port != 80) ? ":" + this.Location.Port.ToString() : string.Empty;
 			serviceuri += "/" + this.Location.BaseUrl.TrimEnd('/').TrimStart('/') + "/" + this.Location.ResourceName;
-			serviceuri += _queryString;			
-			httpClient.HttpClientExecute( this.HttpMethod, serviceuri);
+			serviceuri += _queryString;
+			httpClient.HttpClientExecute(this.HttpMethod, serviceuri);
 			this.ErrorCode = httpClient.ErrCode;
 			this.ErrorMessage = httpClient.ErrDescription;
 			this.StatusCode = httpClient.StatusCode;

--- a/dotnet/test/DotNetCoreUnitTest/Helpers/GXRestAPIClientTest.cs
+++ b/dotnet/test/DotNetCoreUnitTest/Helpers/GXRestAPIClientTest.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using GeneXus.Application;
+using Xunit;
+
+namespace DotNetCoreUnitTest.Helpers
+{
+	public class GXRestAPIClientTest
+	{
+		[Fact]
+		public void TestAddBodyVarWithDecimalUsesCultureInvariant()
+		{
+			// Save the current culture
+			CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
+			CultureInfo originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+			try
+			{
+				// Set culture to Spanish (which uses comma as decimal separator)
+				CultureInfo spanishCulture = new CultureInfo("es-ES");
+				Thread.CurrentThread.CurrentCulture = spanishCulture;
+				Thread.CurrentThread.CurrentUICulture = spanishCulture;
+
+				// Verify that current culture actually uses comma as decimal separator
+				decimal testValue = 1.23m;
+				string formattedWithCurrentCulture = testValue.ToString();
+				Assert.Contains(",", formattedWithCurrentCulture, StringComparison.OrdinalIgnoreCase); // Confirms comma is used in current culture
+
+				GXRestAPIClient client = new GXRestAPIClient();
+				client.AddBodyVar("testDecimal", testValue);
+
+				// Verify that the value in the body uses dot as decimal separator (invariant culture)
+				string storedValue = client.BodyVars["testDecimal"];
+				Assert.Contains(".", storedValue, StringComparison.OrdinalIgnoreCase);
+				Assert.DoesNotContain(",", storedValue, StringComparison.OrdinalIgnoreCase);
+				Assert.Equal("1.23", storedValue); // Should be exactly "1.23"
+			}
+			finally
+			{
+				// Restore original culture
+				Thread.CurrentThread.CurrentCulture = originalCulture;
+				Thread.CurrentThread.CurrentUICulture = originalUICulture;
+			}
+		}
+
+		[Fact]
+		public void TestGetBodyNumReadsDecimalCorrectlyFromResponseData()
+		{
+			// Save the current culture
+			CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
+			CultureInfo originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+			try
+			{
+				// Set culture to Spanish (which uses comma as decimal separator)
+				CultureInfo spanishCulture = new CultureInfo("es-ES");
+				Thread.CurrentThread.CurrentCulture = spanishCulture;
+				Thread.CurrentThread.CurrentUICulture = spanishCulture;
+
+				// Sample JSON with numeric values
+				string jsonResponse = @"{
+                                ""Num4DigitOut"":32767,
+                                ""Num5con1decOut"":155.12346,
+                                ""Num8DigitOut"":""42949672"",
+                                ""Num10con2decOut"":""1551234.56"",
+                                ""Num18DigitOut"":""184467440737095599""
+                        }";
+
+				GXRestAPIClient client = new GXRestAPIClient();
+				client.ResponseData = GeneXus.Utils.RestAPIHelpers.ReadRestParameters(jsonResponse);
+
+				// Verify that GetBodyNum correctly reads the decimal value
+				decimal decimalValue = client.GetBodyNum("Num5con1decOut");
+
+				// Verify the correct value was obtained
+				Assert.Equal(155.12346m, decimalValue);
+
+				// Verify that output format uses invariant culture (decimal point)
+				string formattedValue = decimalValue.ToString(CultureInfo.InvariantCulture);
+				Assert.Contains(".", formattedValue, StringComparison.OrdinalIgnoreCase);
+				Assert.DoesNotContain(",", formattedValue, StringComparison.OrdinalIgnoreCase);
+
+				// Also verify that formatting with current culture uses comma
+				string formattedWithCurrentCulture = decimalValue.ToString();
+				Assert.Contains(",", formattedWithCurrentCulture, StringComparison.OrdinalIgnoreCase);
+			}
+			finally
+			{
+				// Restore original culture
+				Thread.CurrentThread.CurrentCulture = originalCulture;
+				Thread.CurrentThread.CurrentUICulture = originalUICulture;
+			}
+		}
+
+		[Fact]
+		public void TestOptimizedGetBodyNumDirectlyUsesNumericTypes()
+		{
+			// Test that the optimized version of GetBodyNum directly uses numeric values
+
+			// Create a dictionary with different numeric data types
+			var responseData = new Dictionary<string, object>
+				{
+						{ "decimalvalue", 123.45m },           // Decimal value
+                        { "doublevalue", 678.90 },             // Double value
+                        { "intvalue", 12345 },                 // Integer value
+                        { "longvalue", 9876543210L },          // Long value
+                        { "shortvalue", (short)42 },           // Short value
+                        { "floatvalue", 3.14159f },            // Float value
+                        { "stringvalue", "987.654" }           // String value
+                };
+
+			// Create instance and assign data
+			GXRestAPIClient client = new GXRestAPIClient();
+			client.ResponseData = responseData;
+
+			// Verify that each type is processed correctly without unnecessary conversions
+			Assert.Equal(123.45m, client.GetBodyNum("decimalValue"));
+			Assert.Equal(678.90m, client.GetBodyNum("doubleValue"));
+			Assert.Equal(12345m, client.GetBodyNum("intValue"));
+			Assert.Equal(9876543210m, client.GetBodyNum("longValue"));
+			Assert.Equal(42m, client.GetBodyNum("shortValue"));
+			Assert.Equal(3.14159m, client.GetBodyNum("floatValue"));
+			Assert.Equal(987.654m, client.GetBodyNum("stringValue"));
+		}
+	}
+}


### PR DESCRIPTION
Improved GXRestAPIClient with optimized numeric handling and invariant culture support

- Added centralized `GetBodyValue` method to extract values directly from response data
- Optimized numeric parsing to avoid unnecessary string conversions when working with various numeric types
- Added trace error handling 

 ## Unit Tests:
- Added unit tests to verify invariant culture handling with decimal values
- Included culture-specific tests that verify correct behavior when system is using non-invariant cultures

Issue:204865