### PR TITLE
Ensure Newtonsoft.Json 13.0.1 compatibility with GAM

### DIFF
--- a/dotnet/src/dotnetcore/GxExcel/GxExcel.csproj
+++ b/dotnet/src/dotnetcore/GxExcel/GxExcel.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
 	<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="EPPlus" Version="4.5.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Add an explicit primary reference to Newtonsoft.Json to avoid version conflicts when using GAM assemblies that depend on 13.0.1.
Issue:205021