### PR TITLE
Add support to change SignatureVersion property of AmazonS3Config class.

### DIFF
--- a/dotnet/src/dotnetframework/Providers/Storage/GXAmazonS3/ExternalProviderS3.cs
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXAmazonS3/ExternalProviderS3.cs
@@ -25,7 +25,7 @@ namespace GeneXus.Storage.GXAmazonS3
 		const string BUCKET = "BUCKET_NAME";
 		const string REGION = "REGION";
 		const string STORAGE_CUSTOM_ENDPOINT_VALUE = "custom";
-
+		const string SIGNATURE_VERSION = "SIGNATURE_VERSION";
 		const string DEFAULT_ENDPOINT = "s3.amazonaws.com";
 		const string DEFAULT_REGION = "us-east-1";
 		
@@ -78,6 +78,7 @@ namespace GeneXus.Storage.GXAmazonS3
 		private void Initialize() { 
 			string keyId = GetEncryptedPropertyValue(ACCESS_KEY, ACCESS_KEY_ID_DEPRECATED);
 			string keySecret = GetEncryptedPropertyValue(SECRET_ACCESS_KEY, SECRET_ACCESS_KEY_DEPRECATED);
+			string signatureVersion = GetPropertyValue(SIGNATURE_VERSION, SIGNATURE_VERSION, "");
 			AWSCredentials credentials = null;
 			if (!string.IsNullOrEmpty(keyId) && !string.IsNullOrEmpty(keySecret))
 			{
@@ -99,6 +100,10 @@ namespace GeneXus.Storage.GXAmazonS3
 				config.ForcePathStyle = forcePathStyle;
 				config.ServiceURL = Endpoint;
 				customEndpoint = true;
+				if (!string.IsNullOrEmpty(signatureVersion))
+				{
+					config.SignatureVersion = signatureVersion;
+				}
 			}
 			else
 			{


### PR DESCRIPTION
- Add possibility to change SignatureVersion property, to address a issue related to Content-SHA256 when using Dell S3 custom storage.

Changing to SignatureVersion=2 works.
Using default SignatureVersion=4 only works with Dell S3 custom storage when setting a random value to ChecksumSHA256 property of the PutObjectRequest class. In the tests, the checksum does not need to match the file content.

2025-06-05 13:06:51,337 [7] ERROR GxFile - GXFile General Error
Amazon.S3.AmazonS3Exception: The Content-SHA256 you specified did not match what we received
 ---> Amazon.Runtime.Internal.HttpErrorResponseException: Exception of type 'Amazon.Runtime.Internal.HttpErrorResponseException' was thrown.
   at Amazon.Runtime.HttpWebRequestMessage.ProcessHttpResponseMessage(HttpResponseMessage responseMessage)
   at Amazon.Runtime.HttpWebRequestMessage.GetResponseAsync(CancellationToken cancellationToken)
   at Amazon.Runtime.Internal.HttpHandler`1.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.RedirectHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.Unmarshaller.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.S3.Internal.AmazonS3ResponseHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.ErrorHandler.InvokeAsync[T](IExecutionContext executionContext)
   --- End of inner exception stack trace ---
