### PR TITLE
Add IntegratedSecurity property (based on IntegratedSecuritySupport)

### DIFF
--- a/dotnet/src/extensions/Azure/Handlers/GeneXus.Deploy.AzureFunctions.Handlers.csproj
+++ b/dotnet/src/extensions/Azure/Handlers/GeneXus.Deploy.AzureFunctions.Handlers.csproj
@@ -21,6 +21,10 @@
 		<IntegratedSecuritySupport>true</IntegratedSecuritySupport>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<IntegratedSecurity Condition="'$(IntegratedSecuritySupport)'=='true'">true</IntegratedSecurity>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
 	  <DebugType>portable</DebugType>
 	</PropertyGroup>


### PR DESCRIPTION
To set the expected property during deployment for copying GAM dependencies.

Issue:203968