### PR TITLE
Upgrade StackExchange.Redis to 2.9.17 

### DIFF
--- a/dotnet/src/dotnetcore/Providers/Cache/GxRedis/GxRedis.csproj
+++ b/dotnet/src/dotnetcore/Providers/Cache/GxRedis/GxRedis.csproj
@@ -18,7 +18,7 @@
     <Compile Include="..\..\..\..\dotnetframework\Providers\Cache\GxRedis\GxRedis.cs" Link="GxRedis.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
+    <PackageReference Include="StackExchange.Redis" Version="2.9.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/extensions/Azure/Handlers/GeneXus.Deploy.AzureFunctions.Handlers.csproj
+++ b/dotnet/src/extensions/Azure/Handlers/GeneXus.Deploy.AzureFunctions.Handlers.csproj
@@ -78,7 +78,7 @@
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" OutputItemType="Analyzer" />
 		<PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
-		<PackageReference Include="StackExchange.Redis" Version="2.6.122" />
+		<PackageReference Include="StackExchange.Redis" Version="2.9.17" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 	

--- a/dotnet/src/extensions/Azure/Libraries/GeneXus.Deploy.AzureFunctionsLibraries.csproj
+++ b/dotnet/src/extensions/Azure/Libraries/GeneXus.Deploy.AzureFunctionsLibraries.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-	<PackageReference Include="StackExchange.Redis" Version="2.6.122" />
+	<PackageReference Include="StackExchange.Redis" Version="2.9.17" />
 	<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
 	<PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" OutputItemType="Analyzer" />
 	<PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />


### PR DESCRIPTION
Upgrade StackExchange.Redis from 2.6.122 to 2.9.17. This includes improvements in timeout handling, reduced lock contention under load, configurable heartbeat interval, and various bug fixes. 
Issue:206131