### PR TITLE
Fix CallAgent tool execution failing due to null ChatHistory instance

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxCollections.cs
@@ -2545,7 +2545,7 @@ namespace GeneXus.Utils
 
 		public GXExternalCollection()
 		{
-
+			instance = new ArrayList();
 		}
 		public GXExternalCollection(IGxContext context, string containedType, string containedTypeNamespace)
 		{


### PR DESCRIPTION
The external GXExternalCollection instance was not being initialized in the default constructor which caused ChatHistory to be null when invoking CallAgent.
Issue:206311