### PR TITLE
fix: Packages must start with `GeneXus` prefix.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -122,6 +122,36 @@ jobs:
     - name: Pack
       run: dotnet pack $Env:SolutionFile --no-restore --no-build --configuration $Env:Configuration /p:Version=$Env:NUGET_PACKAGE_VERSION
 
+    - name: Validate package names
+      run: |
+        Write-Output "Validating package names for NuGet.org publication..."
+        Write-Output "All packages must start with 'GeneXus.' prefix as this namespace is reserved for GeneXus on NuGet.org"
+        Write-Output ""
+        
+        $invalidPackages = @()
+        Get-ChildItem ".\dotnet\*.nupkg" -Recurse | ForEach-Object {
+          $packageName = [System.IO.Path]::GetFileNameWithoutExtension($_.Name)
+          # Remove version suffix to get the actual package name
+          $actualPackageName = $packageName -replace '\.\d+\.\d+\.\d+.*$', ''
+          
+          if (-not $actualPackageName.StartsWith("GeneXus.")) {
+            $invalidPackages += $_.Name
+            Write-Warning "Package '$($_.Name)' does not start with 'GeneXus.'"
+          } else {
+            Write-Output "✓ Package '$($_.Name)' correctly starts with 'GeneXus.'"
+          }
+        }
+        
+        if ($invalidPackages.Count -gt 0) {
+          Write-Output ""
+          Write-Error "Validation failed: The following packages do not start with 'GeneXus.': $($invalidPackages -join ', ')"
+          Write-Error "This validation is required for publishing to NuGet.org where the 'GeneXus' prefix is reserved."
+          exit 1
+        }
+        
+        Write-Output ""
+        Write-Output "✅ All packages correctly start with 'GeneXus.' prefix - ready for NuGet.org publication"
+
     - name: Sign packages
       if: github.repository_owner == 'GeneXusLabs' && steps.buildVariables.outputs.SHOULD_DEPLOY == 'true'
       env:

--- a/dotnet/src/extensions/gam/src/DotNet/GamSaml20Net/GamSaml20Net.csproj
+++ b/dotnet/src/extensions/gam/src/DotNet/GamSaml20Net/GamSaml20Net.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>GamSaml20NetImpl</AssemblyName>
 		<Version>17.4.0</Version>
 		<NoWarn>CA1031, CA1801, SYSLIB0027</NoWarn>
-		<PackageId>Gam.Saml20.Net</PackageId>
+		<PackageId>GeneXus.AccessManager.Saml20.Net</PackageId>
 	</PropertyGroup>
 		<PropertyGroup>
 		<DefineConstants>NETCORE</DefineConstants>

--- a/dotnet/src/extensions/gam/src/DotNet/GamTotpNet/GamTotpNet.csproj
+++ b/dotnet/src/extensions/gam/src/DotNet/GamTotpNet/GamTotpNet.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>GamTotpNetImpl</AssemblyName>
 		<Version>17.4.0</Version>
 		<NoWarn>CA1031, CA1801, SYSLIB0027</NoWarn>
-		<PackageId>Gam.Totp.Net</PackageId>
+		<PackageId>GeneXus.AccessManager.Totp.Net</PackageId>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/dotnet/src/extensions/gam/src/DotNet/GamUtilsNet/GamUtilsNet.csproj
+++ b/dotnet/src/extensions/gam/src/DotNet/GamUtilsNet/GamUtilsNet.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>GamUtilsNetImpl</AssemblyName>
 		<Version>17.4.0</Version>
 		<NoWarn>CA1031, CA1801, SYSLIB0027</NoWarn>
-		<PackageId>Gam.Utils.Net</PackageId>
+		<PackageId>GeneXus.AccessManager.Utils.Net</PackageId>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/dotnet/src/extensions/gam/src/DotNetFramework/GamSaml20/GamSaml20.csproj
+++ b/dotnet/src/extensions/gam/src/DotNetFramework/GamSaml20/GamSaml20.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>GamSaml20</RootNamespace>
     <AssemblyName>GamSaml20Impl</AssemblyName>
     <NoWarn>CA1031, CA1801, CA1724</NoWarn>
-    <PackageId>Gam.Saml20</PackageId>
+    <PackageId>GeneXus.AccessManager.Saml20</PackageId>
   </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />

--- a/dotnet/src/extensions/gam/src/DotNetFramework/GamTotp/GamTotp.csproj
+++ b/dotnet/src/extensions/gam/src/DotNetFramework/GamTotp/GamTotp.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>net462</TargetFramework>
 		<AssemblyName>GamTotpImpl</AssemblyName>
 		<NoWarn>CA1031, CA1801</NoWarn>
-		<PackageId>Gam.Totp</PackageId>
+		<PackageId>GeneXus.AccessManager.Totp</PackageId>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 	  <Optimize>True</Optimize>

--- a/dotnet/src/extensions/gam/src/DotNetFramework/GamUtils/GamUtils.csproj
+++ b/dotnet/src/extensions/gam/src/DotNetFramework/GamUtils/GamUtils.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>net462</TargetFramework>
 		<AssemblyName>GamUtilsImpl</AssemblyName>
 		<NoWarn>CA1031, CA1801</NoWarn>
-		<PackageId>Gam.Utils</PackageId>
+		<PackageId>GeneXus.AccessManager.Utils</PackageId>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 	  <Optimize>True</Optimize>


### PR DESCRIPTION
Rename packages that starts with "Gam" as "GeneXus.AccessManager"

Issue: 206451