### PR TITLE
Avoid appending URL separator if HttpClient.BaseURL is already final

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -1460,7 +1460,9 @@ namespace GeneXus.Http.Client
 				}
 				else
 				{
-					if (!string.IsNullOrEmpty(name) && name.IndexOf('/') == 0)
+					if (string.IsNullOrEmpty(name))
+						return _url;
+					else if (name.IndexOf('/') == 0)
 						return _url + name;
 					else
 						return _url + "/" + name;


### PR DESCRIPTION
Issue:206517