### PR TITLE
CodeQL: Sanitize log entries created from user input

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -3716,7 +3716,7 @@ namespace GeneXus.Application
 				if (String.IsNullOrEmpty(sTZ))
 				{
 					sTZ = (string)GetCookie(GX_REQUEST_TIMEZONE);
-					GXLogging.Debug(Logger, "ClientTimeZone GX_REQUEST_TIMEZONE cookie:", sTZ);
+					GXLogging.DebugSanitized(Logger, "ClientTimeZone GX_REQUEST_TIMEZONE cookie:", sTZ);
 				}
 				if (!DateTimeUtil.ValidTimeZone(sTZ))
 				{

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
@@ -935,7 +935,7 @@ namespace GeneXus.Data
 										return binary;
 									}
 								}
-								GXLogging.Debug(log, "GxCommand. An error occurred while getting data from file path ", uri.AbsolutePath, e);
+								GXLogging.DebugSanitized(log, e, "GxCommand. An error occurred while getting data from file path ", uri.AbsolutePath);
 								throw e;
 							}
 							break;

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataPostgreSQL.cs
@@ -343,9 +343,9 @@ namespace GeneXus.Data
 		}
 		public override void SetParameter(IDbDataParameter parameter, object value)
 		{
-			if (value is Guid)
+			if (value is Guid guid)
 			{
-				value = value.ToString();
+				value = guid.ToString();
 			}
 #if NETCORE
 			else if (value is GxEmbedding embedding)

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/GXLogging.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/GXLogging.cs
@@ -832,6 +832,18 @@ namespace GeneXus
 				}
 			}
 		}
+		internal static void WarnSanitized(IGXLogger log, string msg, params string[] list)
+		{
+			if (log.IsDebugEnabled)
+			{
+				StringBuilder strBuilder = new StringBuilder(msg);
+				foreach (string parm in list)
+				{
+					strBuilder.Append(Utils.StringUtil.Sanitize(parm, Utils.StringUtil.LogUserEntryWhiteList));
+				}
+				log.LogWarning(strBuilder.ToString());
+			}
+		}
 		public static void Warn(IGXLogger logger, string msg, params string[] list)
 		{
 			if (logger != null)

--- a/dotnet/src/dotnetframework/GxClasses/Helpers/GXMetadata.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Helpers/GXMetadata.cs
@@ -111,7 +111,7 @@ namespace GeneXus.Metadata
 				}
 				catch(FileNotFoundException)
 				{
-					GXLogging.Warn(log, "Assembly: ", defaultAssemblyName, "not found");
+					GXLogging.WarnSanitized(log, "Assembly: ", defaultAssemblyName, "not found");
 				}
 				catch(Exception ex)
 				{

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpServices.cs
@@ -225,7 +225,7 @@ namespace GeneXus.Http
 				}
 				if (code != 0)
 				{
-					GXLogging.Error(log, "Error executing ", commandType);
+					GXLogging.WarnSanitized(log, "Error executing " + commandType);
 					context.HttpContext.Response.Write(ERROR_LINE);
 				}
 			}


### PR DESCRIPTION
Issue:206598
Try to fix the security issues reported by CodeQL. One of them (https://github.com/genexuslabs/DotNetClasses/security/code-scanning/665) appears to be a false positive related to the Path handling, so an explicit cast to Guid was added to prevent the false-positive call stack to Logging reported by CodeQL.
