### PR TITLE
Downgrade log4net to 2.0.17 for .NET Framework generator

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
@@ -504,7 +504,7 @@ namespace GeneXus.Configuration
 #else
 		static Dictionary<string, Version> AssemblyRedirect = new Dictionary<string, Version>
 		{
-			{"log4net", new Version(3, 3, 0, 0) },
+			{"log4net", new Version(2, 0, 17, 0) },
 			{ "System.Threading.Tasks.Extensions", new Version(4, 2, 0, 1) },
 			{ "System.Runtime.CompilerServices.Unsafe", new Version(4, 0, 4, 1) },
 			{ "System.Buffers", new Version(4, 0, 5, 0)},

--- a/dotnet/src/dotnetframework/GxClasses/GxClasses.csproj
+++ b/dotnet/src/dotnetframework/GxClasses/GxClasses.csproj
@@ -20,7 +20,7 @@
 		<PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
 		<PackageReference Include="Nustache" Version="1.16.0.10" />
 		<PackageReference Include="SecurityCodeScan" PrivateAssets="all" Version="3.3.0" />
-		<PackageReference Include="log4net" Version="3.3.0" />
+		<PackageReference Include="log4net" Version="2.0.17" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Net.Http.WinHttpHandler" Version="5.0.0" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />


### PR DESCRIPTION
log4net 3.x added platform detection in SystemInfo's static constructor (IsAndroidCore) that calls APIs requiring EnvironmentPermission / SecurityPermission. These are not granted under ASP.NET Medium Trust, so the cctor throws SecurityException and any page touching the logger fails at startup.

Keep log4net 3.3.0 on the .NET Core generator (still supported there) and only downgrade the .NET Framework target where Medium Trust KBs exist. The binding-redirect entry in gxconfig.cs (#else branch, active only under NETFRAMEWORK) is updated accordingly.
Issue:208437