### PR TITLE
ci: sign nupkgs against Azure Key Vault using NuGetKeyVaultSignTool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,12 +2,6 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "azuresigntool": {
-      "version": "6.0.0",
-      "commands": [
-        "AzureSignTool"
-      ]
-    },
     "nugetkeyvaultsigntool": {
       "version": "3.2.3",
       "commands": [

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,6 +2,12 @@
   "version": 1,
   "isRoot": true,
   "tools": {
+    "azuresigntool": {
+      "version": "6.0.0",
+      "commands": [
+        "AzureSignTool"
+      ]
+    },
     "nugetkeyvaultsigntool": {
       "version": "3.2.3",
       "commands": [

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nugetkeyvaultsigntool": {
+      "version": "3.2.3",
+      "commands": [
+        "NuGetKeyVaultSignTool"
+      ]
+    }
+  }
+}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -160,16 +160,38 @@ jobs:
     - name: Sign packages
       if: github.repository_owner == 'GeneXusLabs' && steps.buildVariables.outputs.SHOULD_DEPLOY == 'true'
       env:
-        TIMESTAMPER_URL: ${{ secrets.CODE_SIGN_CERTIFICATE_TIMESTAMPER_URL }}
-        PFX_BASE64: ${{ secrets.CODE_SIGN_CERTIFICATE_BASE64 }}
-        PFX_PASS: ${{ secrets.CODE_SIGN_CERTIFICATE_PASSWORD }}
+        VAULT_URL:          ${{ vars.AZURE_CODE_SIGNING_VAULT_URL }}
+        CERT_NAME:          ${{ vars.AZURE_CODE_SIGNING_CERT_NAME }}
+        TIMESTAMPER_URL:    ${{ vars.AZURE_CODE_SIGNING_TIMESTAMP_SERVER }}
+        AZURE_TENANT:       ${{ vars.AZURE_CODE_SIGNING_TENANT }}
+        AZURE_APP_ID:       ${{ vars.AZURE_CODE_SIGNING_APP_ID }}
+        AZURE_APP_PASSWORD: ${{ secrets.AZURE_CODE_SIGNING_APP_PASSWORD }}
       run: |
-        $codesign_pfx = "code_sign_cert.pfx"
-        $bytes = [Convert]::FromBase64String($Env:PFX_BASE64)
-        [IO.File]::WriteAllBytes($codesign_pfx, $bytes)
+        # Restore the local tool manifest (.config/dotnet-tools.json) which pins NuGetKeyVaultSignTool.
+        dotnet tool restore
 
+        # Acquire an Azure Key Vault access token via client_credentials grant.
+        $body = @{
+          grant_type    = 'client_credentials'
+          client_id     = $Env:AZURE_APP_ID
+          client_secret = $Env:AZURE_APP_PASSWORD
+          scope         = 'https://vault.azure.net/.default'
+        }
+        $token = (Invoke-RestMethod -Method Post `
+            -Uri "https://login.microsoftonline.com/$Env:AZURE_TENANT/oauth2/v2.0/token" `
+            -Body $body).access_token
+        Write-Host "::add-mask::$token"
+
+        # Sign every produced .nupkg against the certificate stored in the vault.
         Get-ChildItem ".\dotnet\*.nupkg" -Recurse | ForEach-Object {
-          dotnet nuget sign $_.FullName --certificate-path $codesign_pfx --certificate-password $Env:PFX_PASS --timestamper $Env:TIMESTAMPER_URL
+          dotnet tool run NuGetKeyVaultSignTool sign $_.FullName `
+            -kvu $Env:VAULT_URL `
+            -kvc $Env:CERT_NAME `
+            -kva $token `
+            -tr  $Env:TIMESTAMPER_URL `
+            -td  sha256 `
+            -fd  sha256
+          if ($LASTEXITCODE -ne 0) { throw "NuGetKeyVaultSignTool failed for $($_.Name)" }
         }
 
     - name: Configure Azure Artifacts feed

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -160,11 +160,11 @@ jobs:
     - name: Sign packages
       if: github.repository_owner == 'GeneXusLabs' && steps.buildVariables.outputs.SHOULD_DEPLOY == 'true'
       env:
-        VAULT_URL:          ${{ vars.AZURE_CODE_SIGNING_VAULT_URL }}
+        VAULT_URL:          ${{ secrets.AZURE_CODE_SIGNING_VAULT_URL }}
         CERT_NAME:          ${{ vars.AZURE_CODE_SIGNING_CERT_NAME }}
         TIMESTAMPER_URL:    ${{ vars.AZURE_CODE_SIGNING_TIMESTAMP_SERVER }}
-        AZURE_TENANT:       ${{ vars.AZURE_CODE_SIGNING_TENANT }}
-        AZURE_APP_ID:       ${{ vars.AZURE_CODE_SIGNING_APP_ID }}
+        AZURE_TENANT:       ${{ secrets.AZURE_CODE_SIGNING_TENANT }}
+        AZURE_APP_ID:       ${{ secrets.AZURE_CODE_SIGNING_APP_ID }}
         AZURE_APP_PASSWORD: ${{ secrets.AZURE_CODE_SIGNING_APP_PASSWORD }}
       run: |
         # Restore the local tool manifest (.config/dotnet-tools.json) which pins NuGetKeyVaultSignTool.

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -124,6 +124,62 @@ jobs:
     - name: Test
       run: dotnet test $Env:SolutionFile --no-restore --no-build --configuration $Env:Configuration
 
+    # TODO: restore the SHOULD_DEPLOY gate before merging this PR.
+    - name: Sign assemblies
+      if: github.repository_owner == 'GeneXusLabs'
+      env:
+        VAULT_URL:          ${{ secrets.AZURE_CODE_SIGNING_VAULT_URL }}
+        CERT_NAME:          ${{ vars.AZURE_CODE_SIGNING_CERT_NAME }}
+        TIMESTAMPER_URL:    ${{ vars.AZURE_CODE_SIGNING_TIMESTAMP_SERVER }}
+        AZURE_TENANT:       ${{ secrets.AZURE_CODE_SIGNING_TENANT }}
+        AZURE_APP_ID:       ${{ secrets.AZURE_CODE_SIGNING_APP_ID }}
+        AZURE_APP_PASSWORD: ${{ secrets.AZURE_CODE_SIGNING_APP_PASSWORD }}
+      run: |
+        dotnet tool restore
+
+        # Acquire an Azure Key Vault access token via client_credentials grant.
+        $body = @{
+          grant_type    = 'client_credentials'
+          client_id     = $Env:AZURE_APP_ID
+          client_secret = $Env:AZURE_APP_PASSWORD
+          scope         = 'https://vault.azure.net/.default'
+        }
+        $token = (Invoke-RestMethod -Method Post `
+            -Uri "https://login.microsoftonline.com/$Env:AZURE_TENANT/oauth2/v2.0/token" `
+            -Body $body).access_token
+        Write-Host "::add-mask::$token"
+
+        # Discover dlls produced by projects in dotnet/src/ (filename matches a .csproj
+        # under that tree). This avoids re-signing third-party dlls that NuGet copied
+        # into bin/, whose original signatures we must not overwrite.
+        $projectAssemblyNames = Get-ChildItem dotnet/src -Filter *.csproj -Recurse |
+            ForEach-Object { $_.BaseName } |
+            Sort-Object -Unique
+
+        $dllsToSign = Get-ChildItem dotnet/src -Filter *.dll -Recurse |
+            Where-Object {
+              $projectAssemblyNames -contains $_.BaseName -and
+              $_.FullName -match "\\bin\\$Env:Configuration\\"
+            } |
+            Select-Object -ExpandProperty FullName -Unique
+
+        if ($dllsToSign.Count -eq 0) {
+          throw "Sign assemblies: no dlls matched a project in dotnet/src/. Check the build output."
+        }
+
+        Write-Host "Signing $($dllsToSign.Count) assemblies via $Env:VAULT_URL ($Env:CERT_NAME)..."
+        $toolArgs = @(
+          'sign'
+          '-kvu', $Env:VAULT_URL
+          '-kvc', $Env:CERT_NAME
+          '-kva', $token
+          '-tr',  $Env:TIMESTAMPER_URL
+          '-td',  'sha256'
+          '-fd',  'sha256'
+        ) + $dllsToSign
+        dotnet tool run AzureSignTool @toolArgs
+        if ($LASTEXITCODE -ne 0) { throw "AzureSignTool failed (exit $LASTEXITCODE)" }
+
     - name: Pack
       run: dotnet pack $Env:SolutionFile --no-restore --no-build --configuration $Env:Configuration /p:Version=$Env:NUGET_PACKAGE_VERSION
 
@@ -157,8 +213,9 @@ jobs:
         Write-Output ""
         Write-Output "✅ All packages correctly start with 'GeneXus.' prefix - ready for NuGet.org publication"
 
+    # TODO: restore the SHOULD_DEPLOY gate before merging this PR.
     - name: Sign packages
-      if: github.repository_owner == 'GeneXusLabs' && steps.buildVariables.outputs.SHOULD_DEPLOY == 'true'
+      if: github.repository_owner == 'GeneXusLabs'
       env:
         VAULT_URL:          ${{ secrets.AZURE_CODE_SIGNING_VAULT_URL }}
         CERT_NAME:          ${{ vars.AZURE_CODE_SIGNING_CERT_NAME }}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -124,63 +124,6 @@ jobs:
     - name: Test
       run: dotnet test $Env:SolutionFile --no-restore --no-build --configuration $Env:Configuration
 
-    # TODO: restore the SHOULD_DEPLOY gate before merging this PR.
-    - name: Sign assemblies
-      if: github.repository_owner == 'GeneXusLabs'
-      env:
-        VAULT_URL:          ${{ secrets.AZURE_CODE_SIGNING_VAULT_URL }}
-        CERT_NAME:          ${{ vars.AZURE_CODE_SIGNING_CERT_NAME }}
-        TIMESTAMPER_URL:    ${{ vars.AZURE_CODE_SIGNING_TIMESTAMP_SERVER }}
-        AZURE_TENANT:       ${{ secrets.AZURE_CODE_SIGNING_TENANT }}
-        AZURE_APP_ID:       ${{ secrets.AZURE_CODE_SIGNING_APP_ID }}
-        AZURE_APP_PASSWORD: ${{ secrets.AZURE_CODE_SIGNING_APP_PASSWORD }}
-      run: |
-        dotnet tool restore
-
-        # Acquire an Azure Key Vault access token via client_credentials grant.
-        $body = @{
-          grant_type    = 'client_credentials'
-          client_id     = $Env:AZURE_APP_ID
-          client_secret = $Env:AZURE_APP_PASSWORD
-          scope         = 'https://vault.azure.net/.default'
-        }
-        $token = (Invoke-RestMethod -Method Post `
-            -Uri "https://login.microsoftonline.com/$Env:AZURE_TENANT/oauth2/v2.0/token" `
-            -Body $body).access_token
-        Write-Host "::add-mask::$token"
-
-        # Discover dlls produced by projects in dotnet/src/. For each csproj we look ONLY
-        # inside its own bin/$Configuration/ tree, matching <ProjectName>.dll across all
-        # target frameworks. This avoids signing copies of the same dll that get duplicated
-        # into other projects' bins via project references, and keeps third-party dlls
-        # (their authors' signatures must not be overwritten) out of the list.
-        $dllsToSign = Get-ChildItem dotnet/src -Filter *.csproj -Recurse | ForEach-Object {
-            $projectBin = Join-Path $_.Directory.FullName "bin/$Env:Configuration"
-            if (Test-Path $projectBin) {
-              Get-ChildItem -Path $projectBin -Filter "$($_.BaseName).dll" -Recurse -File -ErrorAction SilentlyContinue
-            }
-        } | Select-Object -ExpandProperty FullName -Unique
-
-        if ($dllsToSign.Count -eq 0) {
-          throw "Sign assemblies: no dlls matched a project in dotnet/src/. Check the build output."
-        }
-
-        # AzureSignTool reads the file list from -ifl <path>, avoiding the Windows
-        # command-line length limit (~32k chars) that 800+ paths blow through.
-        $listFile = Join-Path $Env:RUNNER_TEMP "files-to-sign.txt"
-        $dllsToSign | Set-Content -Path $listFile -Encoding utf8
-
-        Write-Host "Signing $($dllsToSign.Count) assemblies via $Env:VAULT_URL ($Env:CERT_NAME)..."
-        dotnet tool run AzureSignTool sign `
-          -kvu $Env:VAULT_URL `
-          -kvc $Env:CERT_NAME `
-          -kva $token `
-          -tr  $Env:TIMESTAMPER_URL `
-          -td  sha256 `
-          -fd  sha256 `
-          -ifl $listFile
-        if ($LASTEXITCODE -ne 0) { throw "AzureSignTool failed (exit $LASTEXITCODE)" }
-
     - name: Pack
       run: dotnet pack $Env:SolutionFile --no-restore --no-build --configuration $Env:Configuration /p:Version=$Env:NUGET_PACKAGE_VERSION
 
@@ -214,9 +157,8 @@ jobs:
         Write-Output ""
         Write-Output "✅ All packages correctly start with 'GeneXus.' prefix - ready for NuGet.org publication"
 
-    # TODO: restore the SHOULD_DEPLOY gate before merging this PR.
     - name: Sign packages
-      if: github.repository_owner == 'GeneXusLabs'
+      if: github.repository_owner == 'GeneXusLabs' && steps.buildVariables.outputs.SHOULD_DEPLOY == 'true'
       env:
         VAULT_URL:          ${{ secrets.AZURE_CODE_SIGNING_VAULT_URL }}
         CERT_NAME:          ${{ vars.AZURE_CODE_SIGNING_CERT_NAME }}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -149,35 +149,36 @@ jobs:
             -Body $body).access_token
         Write-Host "::add-mask::$token"
 
-        # Discover dlls produced by projects in dotnet/src/ (filename matches a .csproj
-        # under that tree). This avoids re-signing third-party dlls that NuGet copied
-        # into bin/, whose original signatures we must not overwrite.
-        $projectAssemblyNames = Get-ChildItem dotnet/src -Filter *.csproj -Recurse |
-            ForEach-Object { $_.BaseName } |
-            Sort-Object -Unique
-
-        $dllsToSign = Get-ChildItem dotnet/src -Filter *.dll -Recurse |
-            Where-Object {
-              $projectAssemblyNames -contains $_.BaseName -and
-              $_.FullName -match "\\bin\\$Env:Configuration\\"
-            } |
-            Select-Object -ExpandProperty FullName -Unique
+        # Discover dlls produced by projects in dotnet/src/. For each csproj we look ONLY
+        # inside its own bin/$Configuration/ tree, matching <ProjectName>.dll across all
+        # target frameworks. This avoids signing copies of the same dll that get duplicated
+        # into other projects' bins via project references, and keeps third-party dlls
+        # (their authors' signatures must not be overwritten) out of the list.
+        $dllsToSign = Get-ChildItem dotnet/src -Filter *.csproj -Recurse | ForEach-Object {
+            $projectBin = Join-Path $_.Directory.FullName "bin/$Env:Configuration"
+            if (Test-Path $projectBin) {
+              Get-ChildItem -Path $projectBin -Filter "$($_.BaseName).dll" -Recurse -File -ErrorAction SilentlyContinue
+            }
+        } | Select-Object -ExpandProperty FullName -Unique
 
         if ($dllsToSign.Count -eq 0) {
           throw "Sign assemblies: no dlls matched a project in dotnet/src/. Check the build output."
         }
 
+        # AzureSignTool reads the file list from -ifl <path>, avoiding the Windows
+        # command-line length limit (~32k chars) that 800+ paths blow through.
+        $listFile = Join-Path $Env:RUNNER_TEMP "files-to-sign.txt"
+        $dllsToSign | Set-Content -Path $listFile -Encoding utf8
+
         Write-Host "Signing $($dllsToSign.Count) assemblies via $Env:VAULT_URL ($Env:CERT_NAME)..."
-        $toolArgs = @(
-          'sign'
-          '-kvu', $Env:VAULT_URL
-          '-kvc', $Env:CERT_NAME
-          '-kva', $token
-          '-tr',  $Env:TIMESTAMPER_URL
-          '-td',  'sha256'
-          '-fd',  'sha256'
-        ) + $dllsToSign
-        dotnet tool run AzureSignTool @toolArgs
+        dotnet tool run AzureSignTool sign `
+          -kvu $Env:VAULT_URL `
+          -kvc $Env:CERT_NAME `
+          -kva $token `
+          -tr  $Env:TIMESTAMPER_URL `
+          -td  sha256 `
+          -fd  sha256 `
+          -ifl $listFile
         if ($LASTEXITCODE -ne 0) { throw "AzureSignTool failed (exit $LASTEXITCODE)" }
 
     - name: Pack


### PR DESCRIPTION
Code signing requirements now mandate HSM-compatible certificate storage: local PFX files are no longer viable. The certificate has moved to an Azure Key Vault, so the workflow needs a tool that can sign nupkgs using a remote key — `dotnet nuget sign` only supports local PFX paths.

Replace the PFX-based `dotnet nuget sign` step with NuGetKeyVaultSignTool 3.2.3, pinned via a new .config/dotnet-tools.json manifest. The workflow restores the tool, acquires an access token for https://vault.azure.net through a client_credentials grant against Entra ID, and signs every produced nupkg using the remote certificate.

Required GitHub configuration:
- vars.AZURE_CODE_SIGNING_VAULT_URL
- vars.AZURE_CODE_SIGNING_CERT_NAME
- vars.AZURE_CODE_SIGNING_TIMESTAMP_SERVER
- vars.AZURE_CODE_SIGNING_TENANT
- vars.AZURE_CODE_SIGNING_APP_ID
- secrets.AZURE_CODE_SIGNING_APP_PASSWORD

Once validated, the legacy secrets can be removed:
- secrets.CODE_SIGN_CERTIFICATE_BASE64
- secrets.CODE_SIGN_CERTIFICATE_PASSWORD
- secrets.CODE_SIGN_CERTIFICATE_TIMESTAMPER_URL

Issue:208489