### PR TITLE
Restore ServicePointManager SSL callback bridge for .NET 10

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -207,11 +207,9 @@ namespace GeneXus.Http.Client
 
 		private static string HttpClientInstanceIdentifier(string proxyHost, int proxyPort, List<string> fileCertificateCollection, int timeout)
 		{
-#if !NET10_0_OR_GREATER
+#pragma warning disable SYSLIB0014
 			bool defaultSslOptions = ServicePointManager.ServerCertificateValidationCallback == null;
-#else
-			bool defaultSslOptions = true;
-#endif
+#pragma warning restore SYSLIB0014
 			if (string.IsNullOrEmpty(proxyHost) && CollectionUtils.IsNullOrEmpty(fileCertificateCollection) && timeout== DEFAULT_TIMEOUT && defaultSslOptions)
 			{
 				return string.Empty;
@@ -281,7 +279,7 @@ namespace GeneXus.Http.Client
 
 		private static void SetSslOptions(SocketsHttpHandler handler)
 		{
-#if !NET10_0_OR_GREATER
+#pragma warning disable SYSLIB0014
 			if (ServicePointManager.ServerCertificateValidationCallback != null)
 			{
 				handler.SslOptions = new SslClientAuthenticationOptions
@@ -289,7 +287,7 @@ namespace GeneXus.Http.Client
 					RemoteCertificateValidationCallback = ServicePointManager.ServerCertificateValidationCallback
 				};
 			}
-#endif
+#pragma warning restore SYSLIB0014
 		}
 #else
 		[SecuritySafeCritical]

--- a/dotnet/src/dotnetframework/GxMail/Exchange/CertificateCallback.cs
+++ b/dotnet/src/dotnetframework/GxMail/Exchange/CertificateCallback.cs
@@ -5,12 +5,12 @@ namespace GeneXus.Mail.Exchange
 {
     public static class CertificateCallback
     {
-#if !NET10_0_OR_GREATER
+#pragma warning disable SYSLIB0014
 		static CertificateCallback()
         {
             ServicePointManager.ServerCertificateValidationCallback = CertificateValidationCallBack;
         }
-#endif
+#pragma warning restore SYSLIB0014
 
 		public static void Initialize()
         {


### PR DESCRIPTION
Replace #if !NET10_0_OR_GREATER guards with #pragma warning disable SYSLIB0014 so that ServicePointManager.ServerCertificateValidationCallback is read and applied to SocketsHttpHandler.SslOptions in all target frameworks, including .NET 10. Without this bridge, apps relying on that callback to handle self-signed or name-mismatched certificates would fail SSL handshake after migrating to .NET 10.
Issue:208453