### PR TITLE
Apply Timeout to HttpClient instances created with authentication

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Domain/GxHttpClient.cs
@@ -199,6 +199,10 @@ namespace GeneXus.Http.Client
 			{
 				disposableInstance = true;
 				client = new HttpClient(GetHandler(URI, authCollection, authProxyCollection, certificateCollection, proxyHost, proxyPort));
+				if (timeout != 0)
+				{
+					client.Timeout = TimeSpan.FromMilliseconds(timeout);
+				}
 			}
 			if (!string.IsNullOrEmpty(Preferences.HttpClientUserAgent))
 				client.DefaultRequestHeaders.UserAgent.ParseAdd(Preferences.HttpClientUserAgent);


### PR DESCRIPTION
When AddAuthentication() is called, GxHttpClient passes a non-empty authCollection to GetHttpClientInstance, so CacheableInstance returns false and the non-cached branch builds a fresh HttpClient. That branch never set client.Timeout, leaving the default 100s and silently ignoring the user-configured Timeout property.
Issue:208609