### PR TITLE
 Free request-scoped GeneXus resources eagerly to drain the finalizer queue   

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/GXApplication.cs
@@ -358,9 +358,11 @@ namespace GeneXus.Application
 		internal static GxContext MainContext { get; set; }
 	}
 	[Serializable]
-	public class GxContext : IGxContext
+	public class GxContext : IGxContext, IDisposable
 	{
 		private static IGXLogger log = null;
+		[NonSerialized]
+		private bool _disposed;
 		internal static string GX_SPA_REQUEST_HEADER = "X-SPA-REQUEST";
 		internal static string GX_SPA_REDIRECT_URL = "X-SPA-REDIRECT-URL";
 		internal const string GXLanguage = "GXLanguage";
@@ -3441,8 +3443,25 @@ namespace GeneXus.Application
 		}
 		~GxContext()
 		{
+			if (_disposed) return;
 			GxUserInfo.RemoveHandle(_handle);
 			GXFileWatcher.Instance.DeleteTemporaryFiles(_handle);
+		}
+
+		public void Dispose()
+		{
+			if (_disposed) return;
+			_disposed = true;
+
+			if (_httpAjaxContext != null)
+			{
+				try { _httpAjaxContext.Cleanup(); } catch { }
+				_httpAjaxContext = null;
+			}
+
+			GxUserInfo.RemoveHandle(_handle);
+			GXFileWatcher.Instance.DeleteTemporaryFiles(_handle);
+			GC.SuppressFinalize(this);
 		}
 		public void SetProperty(string key, string value)
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Core/Web/HttpAjaxContext.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/Web/HttpAjaxContext.cs
@@ -465,8 +465,24 @@ namespace GeneXus.Http
 		}
 
 		public void ajax_rsp_clear()
-		{ 
+		{
 			_PropValues = new JArray();
+		}
+
+		public void Cleanup()
+		{
+			_AttValues = new JArray();
+			_HiddenValues = new JObject();
+			_PropValues = new JArray();
+			_WebComponents = new JObject();
+			_LoadCommands = new Hashtable();
+			_Messages = new JObject();
+			_Grids = new JArray();
+			DicGrids = new Dictionary<String, int>();
+			_ComponentObjects = new JObject();
+			_StylesheetsToLoad = new JArray();
+			commands = new GXAjaxCommandCollection();
+			cmpContents = new Stack();
 		}
 
 		public void ajax_rsp_assign_prop(String CmpContext, bool IsMasterPage, String Control, String Property, String Value, bool SendAjax = true)

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataADO.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataADO.cs
@@ -707,20 +707,20 @@ namespace GeneXus.Data.ADO
 		
 		public void Close()
 		{
-			if (connection!=null) 
+			if (connection!=null)
 			{
 				GXLogging.Debug(log, "GxConnection.Close Id " + " connection State '" + connection.State + "'" + " handle:" + handle + " datastore:" + DataStore.Id);
 			}
-			if (connection!=null && ((connection.State & ConnectionState.Closed) == 0 )) 
+			try
 			{
-				try
-				{
-					connectionCache.Clear();
-				}
-				catch(Exception e){
-					GXLogging.Warn(log, "GxConnection.Close can't close all prepared cursors" ,e);
-				}
-				
+				if (connectionCache != null) connectionCache.Clear();
+			}
+			catch (Exception e)
+			{
+				GXLogging.Warn(log, "GxConnection.Close can't close all prepared cursors", e);
+			}
+			if (connection!=null && ((connection.State & ConnectionState.Closed) == 0 ))
+			{
 				GXLogging.Debug(log, "UncommitedChanges before Close:" + UncommitedChanges );
                 try
                 {
@@ -764,17 +764,16 @@ namespace GeneXus.Data.ADO
 			{
 				GXLogging.Debug(log, "GxConnection.Close Id " + " connection State '" + connection.State + "'" + " handle:" + handle + " datastore:" + DataStore.Id);
 			}
+			try
+			{
+				if (connectionCache != null) connectionCache.Clear();
+			}
+			catch (Exception e)
+			{
+				GXLogging.Warn(log, "GxConnection.Close can't close all prepared cursors", e);
+			}
 			if (connection != null && ((connection.State & ConnectionState.Closed) == 0))
 			{
-				try
-				{
-					connectionCache.Clear();
-				}
-				catch (Exception e)
-				{
-					GXLogging.Warn(log, "GxConnection.Close can't close all prepared cursors", e);
-				}
-
 				GXLogging.Debug(log, "UncommitedChanges before Close:" + UncommitedChanges);
 				try
 				{

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
@@ -2503,16 +2503,17 @@ namespace GeneXus.Data
 		{	
 			throw (new GxNotImplementedException());
 		}
-		public bool IsClosed 
+		public bool IsClosed
 		{
 			get{return !open;}
 		}
-		public int Depth 
+		public int Depth
 		{
 			get {return 0;}
 		}
 		public void Dispose()
 		{
+			try { Close(); } catch (Exception ex) { GXLogging.Warn(log, "GxDataReader.Dispose error", ex); }
 		}
 		public string GetName(int i)
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Data/GXDataCommon.cs
@@ -837,7 +837,10 @@ namespace GeneXus.Data
 				}
 				else
 				{
-
+					foreach (object oldParam in cmd.Parameters)
+					{
+						if (oldParam is IDisposable disposable) disposable.Dispose();
+					}
 					cmd.Parameters.Clear();
 
 					AddParameters(cmd, parameters);

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -1990,63 +1990,70 @@ namespace GeneXus.Http
 #if NETCORE
 		internal async Task ProcessRequestAsync(HttpContext httpContext)
 		{
-			localHttpContext = httpContext;
-
-			if (IsSpaRequest() && !IsSpaSupported())
-			{
-				this.SendResponseStatus(SPA_NOT_SUPPORTED_STATUS_CODE, "SPA not supported by the object");
-				context.CloseConnections();
-				await Task.CompletedTask;
-			}
-			ControlOutputWriter = new HtmlTextWriter(localHttpContext);
-			LoadParameters(localHttpContext.Request.QueryString.Value);
-			context.httpAjaxContext.GetAjaxEncryptionKey(); //Save encryption key in session
-			InitPrivates();
 			try
 			{
-				SetStreaming();
-				SendHeaders();
-				string clientid = context.ClientID; //Send clientid cookie (before response HasStarted) if necessary, since UseResponseBuffering is not in .netcore3.0
+				localHttpContext = httpContext;
 
-				bool validSession = ValidWebSession();
-				if (validSession && IntegratedSecurityEnabled)
-					validSession = ValidSession();
-				if (validSession)
+				if (IsSpaRequest() && !IsSpaSupported())
 				{
-					if (UseBigStack())
+					this.SendResponseStatus(SPA_NOT_SUPPORTED_STATUS_CODE, "SPA not supported by the object");
+					context.CloseConnections();
+					await Task.CompletedTask;
+				}
+				ControlOutputWriter = new HtmlTextWriter(localHttpContext);
+				LoadParameters(localHttpContext.Request.QueryString.Value);
+				context.httpAjaxContext.GetAjaxEncryptionKey(); //Save encryption key in session
+				InitPrivates();
+				try
+				{
+					SetStreaming();
+					SendHeaders();
+					string clientid = context.ClientID; //Send clientid cookie (before response HasStarted) if necessary, since UseResponseBuffering is not in .netcore3.0
+
+					bool validSession = ValidWebSession();
+					if (validSession && IntegratedSecurityEnabled)
+						validSession = ValidSession();
+					if (validSession)
 					{
-						Thread ts = new Thread(new ParameterizedThreadStart(webExecuteWorker));
-						ts.Start(httpContext);
-						ts.Join();
-						if (workerException != null)
-							throw workerException;
+						if (UseBigStack())
+						{
+							Thread ts = new Thread(new ParameterizedThreadStart(webExecuteWorker));
+							ts.Start(httpContext);
+							ts.Join();
+							if (workerException != null)
+								throw workerException;
+						}
+						else
+						{
+							await WebExecuteExAsync(httpContext);
+						}
 					}
 					else
 					{
-						await WebExecuteExAsync(httpContext);
+						context.CloseConnections();
+						if (IsGxAjaxRequest() || context.isAjaxRequest())
+							context.DispatchAjaxCommands();
+					}
+					SetCompression(httpContext);
+					context.ResponseCommited = true;
+				}
+				catch (Exception e)
+				{
+					try
+					{
+						context.CloseConnections();
+					}
+					catch { }
+					{
+						Exception exceptionToHandle = e.InnerException ?? e;
+						handleException(exceptionToHandle.GetType().FullName, exceptionToHandle.Message, exceptionToHandle.StackTrace);
+						throw new Exception("GXApplication exception", e);
 					}
 				}
-				else
-				{
-					context.CloseConnections();
-					if (IsGxAjaxRequest() || context.isAjaxRequest())
-						context.DispatchAjaxCommands();
-				}
-				SetCompression(httpContext);
-				context.ResponseCommited = true;
 			}
-			catch (Exception e)
+			finally
 			{
-				try
-				{
-					context.CloseConnections();
-				}
-				catch { }
-				{
-					Exception exceptionToHandle = e.InnerException ?? e;
-					handleException(exceptionToHandle.GetType().FullName, exceptionToHandle.Message, exceptionToHandle.StackTrace);
-					throw new Exception("GXApplication exception", e);
-				}
+				try { (context as IDisposable)?.Dispose(); } catch { }
 			}
 		}
 
@@ -2056,90 +2063,97 @@ namespace GeneXus.Http
 #endif
 		public void ProcessRequest(HttpContext httpContext)
 		{
-			localHttpContext = httpContext;
-
-			if (IsSpaRequest() && !IsSpaSupported())
-			{
-				this.SendResponseStatus(SPA_NOT_SUPPORTED_STATUS_CODE, "SPA not supported by the object");
-#if !NETCORE
-				context.HttpContext.Response.TrySkipIisCustomErrors = true;
-#endif
-				context.CloseConnections();
-				return;
-			}
-#if NETCORE
-			ControlOutputWriter = new HtmlTextWriter(localHttpContext);
-			LoadParameters(localHttpContext.Request.QueryString.Value);
-			context.httpAjaxContext.GetAjaxEncryptionKey(); //Save encryption key in session
-#else
-			ControlOutputWriter = new HtmlTextWriter(localHttpContext.Response.Output);
-			LoadParameters(localHttpContext.Request.Url.Query);
-#endif
-			InitPrivates();
 			try
 			{
-				SetStreaming();
-				SendHeaders();
-				string clientid = context.ClientID; //Send clientid cookie (before response HasStarted) if necessary, since UseResponseBuffering is not in .netcore3.0
+				localHttpContext = httpContext;
+
+				if (IsSpaRequest() && !IsSpaSupported())
+				{
+					this.SendResponseStatus(SPA_NOT_SUPPORTED_STATUS_CODE, "SPA not supported by the object");
 #if !NETCORE
-				CSRFHelper.ValidateAntiforgery(httpContext);
+					context.HttpContext.Response.TrySkipIisCustomErrors = true;
+#endif
+					context.CloseConnections();
+					return;
+				}
+#if NETCORE
+				ControlOutputWriter = new HtmlTextWriter(localHttpContext);
+				LoadParameters(localHttpContext.Request.QueryString.Value);
+				context.httpAjaxContext.GetAjaxEncryptionKey(); //Save encryption key in session
+#else
+				ControlOutputWriter = new HtmlTextWriter(localHttpContext.Response.Output);
+				LoadParameters(localHttpContext.Request.Url.Query);
+#endif
+				InitPrivates();
+				try
+				{
+					SetStreaming();
+					SendHeaders();
+					string clientid = context.ClientID; //Send clientid cookie (before response HasStarted) if necessary, since UseResponseBuffering is not in .netcore3.0
+#if !NETCORE
+					CSRFHelper.ValidateAntiforgery(httpContext);
 #endif
 
-				bool validSession = ValidWebSession();
-				if (validSession && IntegratedSecurityEnabled)
-					validSession = ValidSession();
-				if (validSession)
-				{
-					if (UseBigStack())
+					bool validSession = ValidWebSession();
+					if (validSession && IntegratedSecurityEnabled)
+						validSession = ValidSession();
+					if (validSession)
 					{
-#if !NETCORE
-						Thread ts = new Thread(new ParameterizedThreadStart(webExecuteWorker), STACKSIZE);
-						object currentCultureInfo = Thread.CurrentThread.CurrentUICulture.Clone();
-						if (currentCultureInfo != null)
+						if (UseBigStack())
 						{
-							ts.CurrentUICulture = (CultureInfo)currentCultureInfo;
-						}
+#if !NETCORE
+							Thread ts = new Thread(new ParameterizedThreadStart(webExecuteWorker), STACKSIZE);
+							object currentCultureInfo = Thread.CurrentThread.CurrentUICulture.Clone();
+							if (currentCultureInfo != null)
+							{
+								ts.CurrentUICulture = (CultureInfo)currentCultureInfo;
+							}
 #else
-						Thread ts = new Thread(new ParameterizedThreadStart(webExecuteWorker));
+							Thread ts = new Thread(new ParameterizedThreadStart(webExecuteWorker));
 #endif
-						ts.Start(httpContext);
-						ts.Join();
-						if (workerException != null)
-							throw workerException;
+							ts.Start(httpContext);
+							ts.Join();
+							if (workerException != null)
+								throw workerException;
+						}
+						else
+						{
+							webExecuteEx(httpContext);
+						}
 					}
 					else
 					{
-						webExecuteEx(httpContext);
+						context.CloseConnections();
+						if (IsGxAjaxRequest() || context.isAjaxRequest())
+							context.DispatchAjaxCommands();
+					}
+					SetCompression(httpContext);
+					context.ResponseCommited = true;
+				}
+				catch (Exception e)
+				{
+					try
+					{
+						context.CloseConnections();
+					}
+					catch { }
+#if !NETCORE
+					if (CSRFHelper.HandleException(e, httpContext))
+					{
+						GXLogging.Error(log, $"Validation of antiforgery failed", e);
+					}
+					else
+#endif
+					{
+						Exception exceptionToHandle = e.InnerException ?? e;
+						handleException(exceptionToHandle.GetType().FullName, exceptionToHandle.Message, exceptionToHandle.StackTrace);
+						throw new Exception("GXApplication exception", e);
 					}
 				}
-				else
-				{
-					context.CloseConnections();
-					if (IsGxAjaxRequest() || context.isAjaxRequest())
-						context.DispatchAjaxCommands();
-				}
-				SetCompression(httpContext);
-				context.ResponseCommited = true;
 			}
-			catch (Exception e)
+			finally
 			{
-				try
-				{
-					context.CloseConnections();
-				}
-				catch { }
-#if !NETCORE
-				if (CSRFHelper.HandleException(e, httpContext))
-				{
-					GXLogging.Error(log, $"Validation of antiforgery failed", e);
-				}
-				else
-#endif
-				{
-					Exception exceptionToHandle = e.InnerException ?? e;
-					handleException(exceptionToHandle.GetType().FullName, exceptionToHandle.Message, exceptionToHandle.StackTrace);
-					throw new Exception("GXApplication exception", e);
-				}
+				try { (context as IDisposable)?.Dispose(); } catch { }
 			}
 		}
 		protected virtual bool ChunkedStreaming() { return false; }

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttp.cs
@@ -2053,7 +2053,8 @@ namespace GeneXus.Http
 			}
 			finally
 			{
-				try { (context as IDisposable)?.Dispose(); } catch { }
+				try { (context as IDisposable)?.Dispose(); }
+				catch (Exception disposeEx) { GXLogging.Warn(log, "Error disposing GxContext at end of request", disposeEx); }
 			}
 		}
 
@@ -2153,7 +2154,8 @@ namespace GeneXus.Http
 			}
 			finally
 			{
-				try { (context as IDisposable)?.Dispose(); } catch { }
+				try { (context as IDisposable)?.Dispose(); }
+				catch (Exception disposeEx) { GXLogging.Warn(log, "Error disposing GxContext at end of request", disposeEx); }
 			}
 		}
 		protected virtual bool ChunkedStreaming() { return false; }


### PR DESCRIPTION
Heap dumps from a long-running w3wp.exe showed tens of thousands of
  objects pending finalization, dominated by Oracle native handles and
  GxContext instances retaining the AJAX response payload
  (GxContext -> HttpAjaxContext -> JArray -> JObject -> Hashtable).

  * HttpAjaxContext.Cleanup() resets the response collections.
  * GxContext implements IDisposable; Dispose() invokes Cleanup(),
    runs the existing handle/temp-file cleanup, and suppresses the
    finalizer (kept as a safety net).
  * GXHttpHandler.ProcessRequest / ProcessRequestAsync wrap their
    bodies in try/finally and dispose the context at end of request;
    errors are logged via GXLogging.Warn.
  * GxDataReader.Dispose() forwards to Close() instead of being a no-op.
  * GxConnection.Close always clears the prepared-command cache, even
    when the connection was already moved to Closed (sync + async).
  * GetCommand disposes prior IDbDataParameter instances when reusing
    a cached command with a different parameter shape.

  System.Data.OracleClient is deprecated  (https://learn.microsoft.com/en-us/dotnet/api/system.data.oracleclient);
  migrating to ODP.NET Managed eliminates native OCI handles entirely