### PR TITLE
Upgrade log4net 3.3.1

### DIFF
--- a/dotnet/src/dotnetcore/GxClasses/GxClasses.csproj
+++ b/dotnet/src/dotnetcore/GxClasses/GxClasses.csproj
@@ -133,7 +133,7 @@
   </ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Experimental.System.Messaging.Signed" Version="1.0.0" />
-		<PackageReference Include="log4net" Version="3.3.0" />
+		<PackageReference Include="log4net" Version="3.3.1" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.6" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="3.0.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">

--- a/dotnet/src/dotnetcore/GxPdfReportsCS.Itext4/GxPdfReportsCS.Itext4.csproj
+++ b/dotnet/src/dotnetcore/GxPdfReportsCS.Itext4/GxPdfReportsCS.Itext4.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.0" />
+    <PackageReference Include="log4net" Version="3.3.1" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Core/gxconfig.cs
@@ -457,7 +457,7 @@ namespace GeneXus.Configuration
 #if NETCORE
 		public static IConfiguration ConfigRoot { get ; set; }
 		const string Log4NetShortName = "log4net";
-		static Version Log4NetVersion = new Version(3, 3, 0, 0);
+		static Version Log4NetVersion = new Version(3, 3, 1, 0);
 
 		const string ConfigurationManagerBak = "System.Configuration.ConfigurationManager, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51";
 		const string ConfigurationManagerFileName = "System.Configuration.ConfigurationManager.dll";
@@ -504,7 +504,7 @@ namespace GeneXus.Configuration
 #else
 		static Dictionary<string, Version> AssemblyRedirect = new Dictionary<string, Version>
 		{
-			{"log4net", new Version(3, 3, 0, 0) },
+			{"log4net", new Version(3, 3, 1, 0) },
 			{ "System.Threading.Tasks.Extensions", new Version(4, 2, 0, 1) },
 			{ "System.Runtime.CompilerServices.Unsafe", new Version(4, 0, 4, 1) },
 			{ "System.Buffers", new Version(4, 0, 5, 0)},

--- a/dotnet/src/dotnetframework/GxClasses/GxClasses.csproj
+++ b/dotnet/src/dotnetframework/GxClasses/GxClasses.csproj
@@ -20,7 +20,7 @@
 		<PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
 		<PackageReference Include="Nustache" Version="1.16.0.10" />
 		<PackageReference Include="SecurityCodeScan" PrivateAssets="all" Version="3.3.0" />
-		<PackageReference Include="log4net" Version="3.3.0" />
+		<PackageReference Include="log4net" Version="3.3.1" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Net.Http.WinHttpHandler" Version="5.0.0" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />


### PR DESCRIPTION
- Bump `log4net` package reference from `3.3.0` to `3.3.1` (latest stable) in the three csprojs that ship it: `GxClasses` (.NET Framework),  `GxClasses` (.NET Core) and `GxPdfReportsCS.Itext4`.
- Bump the hard-coded log4net assembly version in `gxconfig.cs`'s `AssemblyResolve` helpers from `3.3.0.0` to `3.3.1.0` in both the NETCORE and !NETCORE branches, so the runtime redirect matches the new package version.
Issue:208361