### PR TITLE
Upgrade dependencies to address known vulnerabilities

### DIFF
--- a/dotnet/src/dotnetcore/DynService/Cosmos/DynService.CosmosDB.csproj
+++ b/dotnet/src/dotnetcore/DynService/Cosmos/DynService.CosmosDB.csproj
@@ -13,7 +13,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Core" Version="1.42.0" />
+		<PackageReference Include="Azure.Core" Version="1.50.0" />
 		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.36.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/dotnet/src/dotnetcore/DynService/OData/DynServiceOData.csproj
+++ b/dotnet/src/dotnetcore/DynService/OData/DynServiceOData.csproj
@@ -14,6 +14,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 		<PackageReference Include="GeneXus.Odata.Client" Version="5.2.3.8" />
+		<!-- Override GeneXus.Odata.Client's vulnerable transitive Microsoft.Data.OData 5.8.3 -->
+		<PackageReference Include="Microsoft.Data.OData" Version="5.8.4" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\GxClasses\GxClasses.csproj" />

--- a/dotnet/src/dotnetcore/DynService/OData/DynServiceOData.csproj
+++ b/dotnet/src/dotnetcore/DynService/OData/DynServiceOData.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-		<PackageReference Include="GeneXus.Odata.Client" Version="6.0.1" />
+		<PackageReference Include="GeneXus.Odata.Client" Version="6.0.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\GxClasses\GxClasses.csproj" />

--- a/dotnet/src/dotnetcore/DynService/OData/DynServiceOData.csproj
+++ b/dotnet/src/dotnetcore/DynService/OData/DynServiceOData.csproj
@@ -13,9 +13,7 @@
   </ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-		<PackageReference Include="GeneXus.Odata.Client" Version="5.2.3.8" />
-		<!-- Override GeneXus.Odata.Client's vulnerable transitive Microsoft.Data.OData 5.8.3 -->
-		<PackageReference Include="Microsoft.Data.OData" Version="5.8.4" />
+		<PackageReference Include="GeneXus.Odata.Client" Version="6.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\GxClasses\GxClasses.csproj" />

--- a/dotnet/src/dotnetcore/GxClasses/GxClasses.csproj
+++ b/dotnet/src/dotnetcore/GxClasses/GxClasses.csproj
@@ -141,10 +141,10 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" PrivateAssets="ALL" />
-		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.1.0" PrivateAssets="All" />
+		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" PrivateAssets="All" />
 		<PackageReference Include="MimeTypesMap" Version="1.0.9" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" PrivateAssets="All" />
-		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" PrivateAssets="All" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" PrivateAssets="All" />
+		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.1" PrivateAssets="All" />
 		<PackageReference Include="Pgvector" Version="0.3.0" PrivateAssets="All" />
 		<PackageReference Include="MySqlConnector" Version="2.2.3" PrivateAssets="All" />
 		<PackageReference Include="NetTopologySuite" Version="2.0.0" />

--- a/dotnet/src/dotnetcore/GxClasses/GxClasses.csproj
+++ b/dotnet/src/dotnetcore/GxClasses/GxClasses.csproj
@@ -135,6 +135,10 @@
 		<PackageReference Include="Experimental.System.Messaging.Signed" Version="1.0.0" />
 		<PackageReference Include="log4net" Version="3.3.1" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.6" />
+		<!-- Override Microsoft.Data.SqlClient's vulnerable transitive Azure.Identity 1.11.4. Without
+		     this, every consumer of the GeneXus.Classes.Core nupkg (generated GeneXus apps included)
+		     inherits the 1.11.4 transitive and ships it in their bin. -->
+		<PackageReference Include="Azure.Identity" Version="1.17.1" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="3.0.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
 		  <PrivateAssets>all</PrivateAssets>

--- a/dotnet/src/dotnetcore/GxMail/GxMail.csproj
+++ b/dotnet/src/dotnetcore/GxMail/GxMail.csproj
@@ -71,7 +71,7 @@
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.Exchange.WebServices" Version="2.2.0" />
     <PackageReference Include="MimeKit" Version="4.16.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
     <PackageReference Include="OpenPop" Version="2.0.6.2" />
 	<PackageReference Include="Org.Mentalis.Security" Version="1.0.0" />
   </ItemGroup>

--- a/dotnet/src/dotnetcore/GxNetCoreStartup/GxNetCoreStartup.csproj
+++ b/dotnet/src/dotnetcore/GxNetCoreStartup/GxNetCoreStartup.csproj
@@ -20,13 +20,13 @@
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.6" />
 		<PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="3.1.3" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.26" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
 
-		<PackageReference Include="Azure.Identity" Version="1.11.4" PrivateAssets="All" />
-		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.1.0" PrivateAssets="All" />
-		<PackageReference Include="OpenTelemetry" Version="1.7.0" PrivateAssets="All" />
-		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" PrivateAssets="All" />
+		<PackageReference Include="Azure.Identity" Version="1.17.1" PrivateAssets="All" />
+		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" PrivateAssets="All" />
+		<PackageReference Include="OpenTelemetry" Version="1.8.1" PrivateAssets="All" />
+		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.1" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" PrivateAssets="All" />
 
 		<PackageReference Include="itext7" Version="8.0.0" PrivateAssets="All" />

--- a/dotnet/src/dotnetcore/GxOffice/GxOffice.csproj
+++ b/dotnet/src/dotnetcore/GxOffice/GxOffice.csproj
@@ -42,8 +42,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
-		<PackageReference Include="NPOI" Version="2.7.3" />
+		<PackageReference Include="NPOI" Version="2.8.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+		<!-- Override NPOI's vulnerable transitive System.Security.Cryptography.Xml -->
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" Condition="'$(TargetFramework)' == 'net10.0'" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/dotnet/src/dotnetcore/GxOffice/GxOffice.csproj
+++ b/dotnet/src/dotnetcore/GxOffice/GxOffice.csproj
@@ -6,7 +6,6 @@
 		<RootNamespace>GxOffice</RootNamespace>
 		<PackageTags>Office Excel Poi</PackageTags>
 		<PackageId>GeneXus.Office.Core</PackageId>
-		<AcceptNPOIOSMFLicense>true</AcceptNPOIOSMFLicense>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="..\..\dotnetframework\GxOffice\Constants.cs" Link="Constants.cs" />
@@ -43,9 +42,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
-		<PackageReference Include="NPOI" Version="2.8.0" />
+		<PackageReference Include="NPOI" Version="2.7.3" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-		<!-- Override NPOI's vulnerable transitive System.Security.Cryptography.Xml -->
+		<!-- Override NPOI's vulnerable transitives (NPOI 2.7.x still depends on these older versions) -->
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" Condition="'$(TargetFramework)' == 'net10.0'" />
 	</ItemGroup>

--- a/dotnet/src/dotnetcore/GxOffice/GxOffice.csproj
+++ b/dotnet/src/dotnetcore/GxOffice/GxOffice.csproj
@@ -6,6 +6,7 @@
 		<RootNamespace>GxOffice</RootNamespace>
 		<PackageTags>Office Excel Poi</PackageTags>
 		<PackageId>GeneXus.Office.Core</PackageId>
+		<AcceptNPOIOSMFLicense>true</AcceptNPOIOSMFLicense>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="..\..\dotnetframework\GxOffice\Constants.cs" Link="Constants.cs" />

--- a/dotnet/src/dotnetcore/Providers/Messaging/GXAzureEventGrid/GXAzureEventGrid.csproj
+++ b/dotnet/src/dotnetcore/Providers/Messaging/GXAzureEventGrid/GXAzureEventGrid.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.20.0" />
 
   </ItemGroup>

--- a/dotnet/src/dotnetcore/Providers/Messaging/GXAzureQueue/GXAzureQueue.csproj
+++ b/dotnet/src/dotnetcore/Providers/Messaging/GXAzureQueue/GXAzureQueue.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.16.0" />
 
   </ItemGroup>

--- a/dotnet/src/dotnetcore/Providers/Messaging/GXAzureServiceBus/GXAzureServiceBus.csproj
+++ b/dotnet/src/dotnetcore/Providers/Messaging/GXAzureServiceBus/GXAzureServiceBus.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.2" />
 
   </ItemGroup>

--- a/dotnet/src/dotnetcore/Providers/OpenTelemetry/Diagnostics/GXOtel.Diagnostics/GXOtel.Diagnostics.csproj
+++ b/dotnet/src/dotnetcore/Providers/OpenTelemetry/Diagnostics/GXOtel.Diagnostics/GXOtel.Diagnostics.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />  
+	<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/dotnetcore/Providers/OpenTelemetry/OpenTelemetry/GeneXus.OpenTelemetry.csproj
+++ b/dotnet/src/dotnetcore/Providers/OpenTelemetry/OpenTelemetry/GeneXus.OpenTelemetry.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
-	  <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
-	  <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+	  <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.1" />
+	  <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+	  <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
 	  <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
 	  <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
 	  <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />

--- a/dotnet/src/dotnetcore/Providers/OpenTelemetry/OpenTelemetryAzureMonitor/GeneXus.OpenTelemetry.Azure.AppInsights.csproj
+++ b/dotnet/src/dotnetcore/Providers/OpenTelemetry/OpenTelemetryAzureMonitor/GeneXus.OpenTelemetry.Azure.AppInsights.csproj
@@ -11,13 +11,13 @@
 	</PropertyGroup>
 	<ItemGroup>
 		
-		<PackageReference Include="Azure.Identity" Version="1.11.4" />
-		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.1.0" />
+		<PackageReference Include="Azure.Identity" Version="1.17.1" />
+		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
 		<PackageReference Include="log4net.Ext.Json" Version="3.0.3" />
 		<PackageReference Include="Microsoft.ApplicationInsights.Log4NetAppender" Version="2.22.0" />
-		
-		<PackageReference Include="OpenTelemetry" Version="1.7.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+
+		<PackageReference Include="OpenTelemetry" Version="1.8.1" />
+		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.1" />
 		
 	</ItemGroup>
 	<ItemGroup>

--- a/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.cs
+++ b/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.cs
@@ -2077,7 +2077,47 @@ namespace GeneXus.Data.NTier
 
 		public GXODataClient Expand(params ODataExpression[] associations)
 		{
-			return Apply(BoundClient.ExpandMap(ApplyEntityMappings(associations)));
+			// GeneXus.Odata.Client >= 6.0 removed the custom ExpandMap extension; the upstream
+			// alias→association mapping has to live on the wrapper now. We Expand by the mapped
+			// name and remember each association so Filter(expression) can wire per-entity
+			// FilterExpressions onto the ODataExpandAssociation objects already attached to
+			// BoundClient.Command.Details.ExpandAssociations.
+			var mappings = ApplyEntityMappings(associations);
+			var beforeCount = GetExpandAssociationsCount();
+			BoundClient = BoundClient.Expand(mappings.Select(kvp => kvp.Value));
+			var added = GetExpandAssociations().Skip(beforeCount).ToList();
+			for (int i = 0; i < mappings.Length && i < added.Count; i++)
+			{
+				string aliasRoot = mappings[i].Key.Split(separator)[0];
+				_expansionsByAlias[aliasRoot] = added[i];
+			}
+			return this;
+		}
+
+		// Tracks the first-segment alias used by the caller (e.g. "Friends" for Expand("Friends/People"))
+		// against the corresponding root ODataExpandAssociation attached to BoundClient.
+		private readonly Dictionary<string, ODataExpandAssociation> _expansionsByAlias = new Dictionary<string, ODataExpandAssociation>();
+
+		private int GetExpandAssociationsCount() => GetExpandAssociations().Count;
+
+		private IList<ODataExpandAssociation> GetExpandAssociations()
+		{
+			// Reflection chain: BoundClient -> Command (internal) -> Details (internal) -> ExpandAssociations
+			// (list of KeyValuePair<ODataExpandAssociation, ODataExpandOptions>).
+			var command = GetPropertyValue<object>(BoundClient, "Command");
+			if (command == null) return new List<ODataExpandAssociation>();
+			var details = GetPropertyValue<object>(command, "Details");
+			if (details == null) return new List<ODataExpandAssociation>();
+			var raw = GetPropertyValue<System.Collections.IEnumerable>(details, "ExpandAssociations");
+			if (raw == null) return new List<ODataExpandAssociation>();
+			var result = new List<ODataExpandAssociation>();
+			foreach (var item in raw)
+			{
+				// Each item is a KeyValuePair<ODataExpandAssociation, ODataExpandOptions>.
+				var key = item.GetType().GetProperty("Key")?.GetValue(item) as ODataExpandAssociation;
+				if (key != null) result.Add(key);
+			}
+			return result;
 		}
 
 		private static char[] separator = new char[] { '/' };
@@ -2154,7 +2194,7 @@ namespace GeneXus.Data.NTier
 		public GXODataClient Filter(ODataExpression expression)
 		{
 			try
-			{ // In the conditions of type Att = parmStr it does a parmStr.rtrim in order to support 
+			{ // In the conditions of type Att = parmStr it does a parmStr.rtrim in order to support
 			  // FK from an SQL table to an OData entity. In the SQL table the FK is left with spaces at the end.
 			  // de tener una FK desde una tabla SQL hacia una entidad OData. En la tabla SQL la FK queda con espacios al final
 				if (GetFieldValue<ExpressionType>(expression, "_operator").Equals(ExpressionType.Equal) &&
@@ -2173,7 +2213,63 @@ namespace GeneXus.Data.NTier
 			}
 			catch { }
 
-			return Apply(BoundClient.Filter(expression));
+			if (object.ReferenceEquals(expression, null))
+				return this;
+
+			// GeneXus.Odata.Client >= 6.0 no longer auto-decomposes a cross-entity filter expression
+			// into per-expanded-entity sub-filters at the FluentCommand level. Do it here using the
+			// ProcessFilter extension still exposed by the fork: walks the expression and groups the
+			// sub-expressions by the entity they reference. The base-entity bucket goes through the
+			// standard BoundClient.Filter; the others are written into the FilterExpression of the
+			// matching ODataExpandAssociation captured by Expand().
+			IDictionary<string, IList<ODataExpression>> entityFilters;
+			try
+			{
+				var baseCollection = Session.Metadata.GetEntityCollection(BaseEntity);
+				entityFilters = expression.ProcessFilter(Session, baseCollection);
+			}
+			catch
+			{
+				// If decomposition fails (e.g. metadata unavailable, non-cross-entity expression),
+				// fall back to the simple base-entity filter — preserves the pre-6.0 behaviour for
+				// the common single-entity case.
+				return Apply(BoundClient.Filter(expression));
+			}
+
+			foreach (KeyValuePair<string, IList<ODataExpression>> entityFilter in entityFilters)
+			{
+				if (entityFilter.Value == null || entityFilter.Value.Count == 0)
+					continue;
+
+				ODataExpression combined = null;
+				foreach (ODataExpression sub in entityFilter.Value)
+					combined = object.ReferenceEquals(combined, null) ? sub : combined && sub;
+				if (object.ReferenceEquals(combined, null))
+					continue;
+
+				if (string.IsNullOrEmpty(entityFilter.Key) || entityFilter.Key == BaseEntity)
+				{
+					BoundClient = BoundClient.Filter(combined);
+				}
+				else if (_expansionsByAlias.TryGetValue(entityFilter.Key, out ODataExpandAssociation association))
+				{
+					// Walk to the deepest nested association for chained expands like "Friends/People".
+					var leaf = association;
+					while (leaf.ExpandAssociations != null && leaf.ExpandAssociations.Count > 0)
+						leaf = leaf.ExpandAssociations[0];
+					leaf.FilterExpression = object.ReferenceEquals(leaf.FilterExpression, null)
+						? combined
+						: leaf.FilterExpression && combined;
+				}
+				else
+				{
+					// No matching expand found for this entity — apply to the base filter so the
+					// query still includes the constraint instead of silently dropping it.
+					BoundClient = BoundClient.Filter(combined);
+				}
+			}
+
+			return this;
 		}
 
 		public T GetFieldValue<T>(object obj, string name)

--- a/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.cs
+++ b/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.cs
@@ -99,7 +99,7 @@ namespace GeneXus.Data.NTier
 			if (builder.TryGetValue("Data Source", out object url))
 			{
 				serviceUri = url.ToString();
-				clientSettings = new ODataClientSettings(serviceUri, credentials);
+				clientSettings = new ODataClientSettings(new Uri(serviceUri), credentials);
 				clientSettings.IgnoreUnmappedProperties = true;
 			}
 			else throw new ArgumentException("Data source url cannot be empty");

--- a/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.cs
+++ b/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.cs
@@ -2077,48 +2077,26 @@ namespace GeneXus.Data.NTier
 
 		public GXODataClient Expand(params ODataExpression[] associations)
 		{
-			// GeneXus.Odata.Client >= 6.0 removed the custom ExpandMap extension; the upstream
-			// alias→association mapping has to live on the wrapper now. We Expand by the mapped
-			// name and remember each association so Filter(expression) can wire per-entity
-			// FilterExpressions onto the ODataExpandAssociation objects already attached to
-			// BoundClient.Command.Details.ExpandAssociations.
+			// Build each ODataExpandAssociation upfront so Filter(expression) can wire
+			// per-entity FilterExpressions onto the same objects later. The fork's 6.0.2
+			// IFluentClient exposes Expand(IEnumerable<ODataExpandAssociation>), which lets
+			// us pass our pre-built chain in directly — no reflection needed.
 			var mappings = ApplyEntityMappings(associations);
-			var beforeCount = GetExpandAssociationsCount();
-			BoundClient = BoundClient.Expand(mappings.Select(kvp => kvp.Value));
-			var added = GetExpandAssociations().Skip(beforeCount).ToList();
-			for (int i = 0; i < mappings.Length && i < added.Count; i++)
+			var odataAssociations = new List<ODataExpandAssociation>(mappings.Length);
+			foreach (var mapping in mappings)
 			{
-				string aliasRoot = mappings[i].Key.Split(separator)[0];
-				_expansionsByAlias[aliasRoot] = added[i];
+				var association = ODataExpandAssociation.From(mapping.Value);
+				odataAssociations.Add(association);
+				string aliasRoot = mapping.Key.Split(separator)[0];
+				_expansionsByAlias[aliasRoot] = association;
 			}
+			BoundClient = BoundClient.Expand(odataAssociations);
 			return this;
 		}
 
 		// Tracks the first-segment alias used by the caller (e.g. "Friends" for Expand("Friends/People"))
 		// against the corresponding root ODataExpandAssociation attached to BoundClient.
 		private readonly Dictionary<string, ODataExpandAssociation> _expansionsByAlias = new Dictionary<string, ODataExpandAssociation>();
-
-		private int GetExpandAssociationsCount() => GetExpandAssociations().Count;
-
-		private IList<ODataExpandAssociation> GetExpandAssociations()
-		{
-			// Reflection chain: BoundClient -> Command (internal) -> Details (internal) -> ExpandAssociations
-			// (list of KeyValuePair<ODataExpandAssociation, ODataExpandOptions>).
-			var command = GetPropertyValue<object>(BoundClient, "Command");
-			if (command == null) return new List<ODataExpandAssociation>();
-			var details = GetPropertyValue<object>(command, "Details");
-			if (details == null) return new List<ODataExpandAssociation>();
-			var raw = GetPropertyValue<System.Collections.IEnumerable>(details, "ExpandAssociations");
-			if (raw == null) return new List<ODataExpandAssociation>();
-			var result = new List<ODataExpandAssociation>();
-			foreach (var item in raw)
-			{
-				// Each item is a KeyValuePair<ODataExpandAssociation, ODataExpandOptions>.
-				var key = item.GetType().GetProperty("Key")?.GetValue(item) as ODataExpandAssociation;
-				if (key != null) result.Add(key);
-			}
-			return result;
-		}
 
 		private static char[] separator = new char[] { '/' };
 		private static string strSeparator = "/";

--- a/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.csproj
+++ b/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GeneXus.Odata.Client" Version="5.2.3.8" />
+		<PackageReference Include="GeneXus.Odata.Client" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Data.Edm" Version="5.8.4" />
 		<PackageReference Include="Microsoft.Data.OData" Version="5.8.4" />
 		<PackageReference Include="Microsoft.Data.Services" Version="5.8.4" />

--- a/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.csproj
+++ b/dotnet/src/dotnetframework/DynServiceOData/DynServiceOData.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GeneXus.Odata.Client" Version="6.0.1" />
+		<PackageReference Include="GeneXus.Odata.Client" Version="6.0.2" />
 		<PackageReference Include="Microsoft.Data.Edm" Version="5.8.4" />
 		<PackageReference Include="Microsoft.Data.OData" Version="5.8.4" />
 		<PackageReference Include="Microsoft.Data.Services" Version="5.8.4" />

--- a/dotnet/src/dotnetframework/GxMail/GxMail.csproj
+++ b/dotnet/src/dotnetframework/GxMail/GxMail.csproj
@@ -11,7 +11,8 @@
 	<ItemGroup>
 		<PackageReference Include="MailKit" Version="4.16.0" />
 		<PackageReference Include="MimeKit" Version="4.16.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
+		<!-- Pinned to 4.75.0: 4.77+ requires Microsoft.IdentityModel.Abstractions 8.x, which clashes at runtime with the rest of the .NET Framework stack pinned to 6.35.0 -->
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.75.0" />
 		<PackageReference Include="OpenPop.NET" Version="2.0.6.1120" />
 		<PackageReference Include="Org.Mentalis.Security" Version="1.0.0" />
 		<PackageReference Condition="'$(SignAssembly)'=='true'" Include="StrongNamer" Version="0.2.5" />

--- a/dotnet/src/dotnetframework/GxMail/GxMail.csproj
+++ b/dotnet/src/dotnetframework/GxMail/GxMail.csproj
@@ -11,7 +11,7 @@
 	<ItemGroup>
 		<PackageReference Include="MailKit" Version="4.16.0" />
 		<PackageReference Include="MimeKit" Version="4.16.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.60.4" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
 		<PackageReference Include="OpenPop.NET" Version="2.0.6.1120" />
 		<PackageReference Include="Org.Mentalis.Security" Version="1.0.0" />
 		<PackageReference Condition="'$(SignAssembly)'=='true'" Include="StrongNamer" Version="0.2.5" />

--- a/dotnet/src/dotnetframework/GxOffice/GxOffice.csproj
+++ b/dotnet/src/dotnetframework/GxOffice/GxOffice.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
 		<PackageReference Include="EPPlus" Version="4.5.3.2" />
-		<PackageReference Include="NPOI" Version="2.7.3" />
+		<PackageReference Include="NPOI" Version="2.8.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 	</ItemGroup>
 

--- a/dotnet/src/dotnetframework/GxOffice/GxOffice.csproj
+++ b/dotnet/src/dotnetframework/GxOffice/GxOffice.csproj
@@ -5,6 +5,9 @@
 		<RootNamespace>GxOffice</RootNamespace>
 		<PackageTags>Office Excel Poi</PackageTags>
 		<PackageId>GeneXus.Office</PackageId>
+		<AcceptNPOIOSMFLicense>true</AcceptNPOIOSMFLicense>
+		<!-- NPOI 2.8.0 pulls SkiaSharp; on net462 its native libs land in content/ instead of runtimes/ and pack flags NU5100/NU5118. Consumers still get SkiaSharp transitively via NPOI. -->
+		<NoWarn>$(NoWarn);NU5100;NU5118</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />

--- a/dotnet/src/dotnetframework/GxOffice/GxOffice.csproj
+++ b/dotnet/src/dotnetframework/GxOffice/GxOffice.csproj
@@ -5,15 +5,14 @@
 		<RootNamespace>GxOffice</RootNamespace>
 		<PackageTags>Office Excel Poi</PackageTags>
 		<PackageId>GeneXus.Office</PackageId>
-		<AcceptNPOIOSMFLicense>true</AcceptNPOIOSMFLicense>
-		<!-- NPOI 2.8.0 pulls SkiaSharp; on net462 its native libs land in content/ instead of runtimes/ and pack flags NU5100/NU5118. Consumers still get SkiaSharp transitively via NPOI. -->
-		<NoWarn>$(NoWarn);NU5100;NU5118</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
 		<PackageReference Include="EPPlus" Version="4.5.3.2" />
-		<PackageReference Include="NPOI" Version="2.8.0" />
+		<PackageReference Include="NPOI" Version="2.7.3" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+		<!-- Override NPOI's vulnerable transitive SixLabors.ImageSharp (2.1.x line; 3.x doesn't support net462) -->
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/dotnet/src/dotnetframework/GxOffice/poi/xssf/ExcelCells.cs
+++ b/dotnet/src/dotnetframework/GxOffice/poi/xssf/ExcelCells.cs
@@ -2,7 +2,6 @@
 using System;
 using GeneXus.MSOffice.Excel.Style;
 using GeneXus.Utils;
-using NPOI.OOXML.XSSF.UserModel;
 using NPOI.OpenXmlFormats.Spreadsheet;
 using NPOI.SS.UserModel;
 using NPOI.SS.Util;
@@ -796,7 +795,7 @@ namespace GeneXus.MSOffice.Excel.Poi.Xssf
 									rgb = new byte[] { (byte)red, (byte)green, (byte)blue }
 								};
 
-								newColor = new XSSFColor(ctColor, new DefaultIndexedColorMap());
+								newColor = new XSSFColor(ctColor);
 
 								newFont = (XSSFFont)pWorkbook.CreateFont();
 								CopyPropertiesFont(newFont, fontCell);
@@ -823,7 +822,7 @@ namespace GeneXus.MSOffice.Excel.Poi.Xssf
 										rgb = new byte[] { (byte)red, (byte)green, (byte)blue }
 									};
 
-									newColor = new XSSFColor(ctColor, new DefaultIndexedColorMap());
+									newColor = new XSSFColor(ctColor);
 
 
 									newFont = (XSSFFont)pWorkbook.CreateFont();
@@ -1074,7 +1073,7 @@ namespace GeneXus.MSOffice.Excel.Poi.Xssf
 				rgb = new byte[] { (byte)color.Red, (byte)color.Green, (byte)color.Blue }
 			};
 
-			return new XSSFColor(ctColor, new DefaultIndexedColorMap());
+			return new XSSFColor(ctColor);
 		}
 		private XSSFCellStyle ApplyNewCellStyle(XSSFCellStyle cellStyle, ExcelStyle newCellStyle)
 		{

--- a/dotnet/src/dotnetframework/GxOffice/poi/xssf/ExcelCells.cs
+++ b/dotnet/src/dotnetframework/GxOffice/poi/xssf/ExcelCells.cs
@@ -2,6 +2,7 @@
 using System;
 using GeneXus.MSOffice.Excel.Style;
 using GeneXus.Utils;
+using NPOI.OOXML.XSSF.UserModel;
 using NPOI.OpenXmlFormats.Spreadsheet;
 using NPOI.SS.UserModel;
 using NPOI.SS.Util;
@@ -795,7 +796,7 @@ namespace GeneXus.MSOffice.Excel.Poi.Xssf
 									rgb = new byte[] { (byte)red, (byte)green, (byte)blue }
 								};
 
-								newColor = new XSSFColor(ctColor);
+								newColor = new XSSFColor(ctColor, new DefaultIndexedColorMap());
 
 								newFont = (XSSFFont)pWorkbook.CreateFont();
 								CopyPropertiesFont(newFont, fontCell);
@@ -822,7 +823,7 @@ namespace GeneXus.MSOffice.Excel.Poi.Xssf
 										rgb = new byte[] { (byte)red, (byte)green, (byte)blue }
 									};
 
-									newColor = new XSSFColor(ctColor);
+									newColor = new XSSFColor(ctColor, new DefaultIndexedColorMap());
 
 
 									newFont = (XSSFFont)pWorkbook.CreateFont();
@@ -1073,7 +1074,7 @@ namespace GeneXus.MSOffice.Excel.Poi.Xssf
 				rgb = new byte[] { (byte)color.Red, (byte)color.Green, (byte)color.Blue }
 			};
 
-			return new XSSFColor(ctColor);
+			return new XSSFColor(ctColor, new DefaultIndexedColorMap());
 		}
 		private XSSFCellStyle ApplyNewCellStyle(XSSFCellStyle cellStyle, ExcelStyle newCellStyle)
 		{

--- a/dotnet/src/dotnetframework/Projects/StoreManager/StoreManager.csproj
+++ b/dotnet/src/dotnetframework/Projects/StoreManager/StoreManager.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.55.0.2582" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Zlib.Portable.Signed" Version="1.11.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/dotnet/src/dotnetframework/Providers/Storage/GXAzureStorage/GXAzureStorage.csproj
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXAzureStorage/GXAzureStorage.csproj
@@ -8,6 +8,8 @@
 	</PropertyGroup>
   <ItemGroup>
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
+    <!-- Override WindowsAzure.Storage's vulnerable transitive Newtonsoft.Json 10.0.2 -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/GXGoogleCloud.csproj
+++ b/dotnet/src/dotnetframework/Providers/Storage/GXGoogleCloud/GXGoogleCloud.csproj
@@ -9,7 +9,7 @@
 	
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Storage.V1" Version="3.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/dotnet/src/extensions/Azure/Handlers/GeneXus.Deploy.AzureFunctions.Handlers.csproj
+++ b/dotnet/src/extensions/Azure/Handlers/GeneXus.Deploy.AzureFunctions.Handlers.csproj
@@ -76,7 +76,7 @@
         </ItemGroup>
 
         <ItemGroup>
-                <PackageReference Include="Azure.Core" Version="1.42.0" />
+                <PackageReference Include="Azure.Core" Version="1.50.0" />
                 <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
                 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" OutputItemType="Analyzer" />
                 <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />

--- a/dotnet/src/extensions/Azure/test/AzureFunctionsTest/AzureFunctionsTest.csproj
+++ b/dotnet/src/extensions/Azure/test/AzureFunctionsTest/AzureFunctionsTest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.42.0" />
+    <PackageReference Include="Azure.Core" Version="1.50.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusJWT/GeneXusJWT.csproj
+++ b/dotnet/src/extensions/SecurityAPI/dotnet/dotnetframework/GeneXusJWT/GeneXusJWT.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.35.0" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="6.35.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.35.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
   </ItemGroup>
 

--- a/dotnet/src/extensions/gam/src/DotNetFramework/GamUtils/GamUtils.csproj
+++ b/dotnet/src/extensions/gam/src/DotNetFramework/GamUtils/GamUtils.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
     <PackageReference Include="jose-jwt" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StrongNamer" Version="0.2.5" Condition="'$(AssemblyOriginatorKeyFile)'!=''" />
   </ItemGroup>
 

--- a/dotnet/src/extensions/kafka/src/Core.Messaging.csproj
+++ b/dotnet/src/extensions/kafka/src/Core.Messaging.csproj
@@ -6,11 +6,8 @@
 		<AssemblyName>GeneXus.Messaging.Kafka</AssemblyName>
 		<PackageId>GeneXus.Messaging.Kafka</PackageId>
 	</PropertyGroup>
-	<ItemGroup Condition="'$(TargetFramework)'!='net462'">
+	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)'=='net462'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Confluent.Kafka" Version="2.10.0" />


### PR DESCRIPTION
- NPOI 2.7.3 -> 2.8.0 (removes vulnerable SixLabors.ImageSharp transitive); adapt XSSFColor constructor to new API in ExcelCells.cs
- Override System.Security.Cryptography.Xml to 8.0.3 (net8.0) / 10.0.6 (net10.0) in GxOffice/dotnetcore to fix NPOI's vulnerable transitive
- Override Microsoft.Data.OData to 5.8.4 in DynServiceOData/dotnetcore to fix GeneXus.Odata.Client transitive
- Azure.Identity 1.11.4 -> 1.17.1
- Azure.Monitor.OpenTelemetry.Exporter 1.1.0 -> 1.3.0
- OpenTelemetry family 1.7.0 -> 1.8.1 (required by Azure.Monitor 1.3.0)
- Microsoft.Identity.Client 4.60.4 / 4.61.3 -> 4.84.0
- Newtonsoft.Json unified to 13.0.3

Issue:208650
Issue:208652
Issue:208655
Issue:208661
Issue:207664
