### PR TITLE
Add GXVirtualPathCasingModule to enforce canonical application path casing

### DIFF
--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpModules.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpModules.cs
@@ -316,9 +316,9 @@ namespace GeneXus.Http.HttpModules
         }
         #endregion
     }
-	public class GXCanonicalAppCasingModule : IHttpModule
+	public class GXVirtualPathCasingModule : IHttpModule
 	{
-		private static readonly IGXLogger log = GXLoggerFactory.GetLogger<GXCanonicalAppCasingModule>();
+		private static readonly IGXLogger log = GXLoggerFactory.GetLogger<GXVirtualPathCasingModule>();
 
 		public void Init(HttpApplication context)
 		{

--- a/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpModules.cs
+++ b/dotnet/src/dotnetframework/GxClasses/Middleware/GXHttpModules.cs
@@ -316,6 +316,41 @@ namespace GeneXus.Http.HttpModules
         }
         #endregion
     }
+	public class GXCanonicalAppCasingModule : IHttpModule
+	{
+		private static readonly IGXLogger log = GXLoggerFactory.GetLogger<GXCanonicalAppCasingModule>();
+
+		public void Init(HttpApplication context)
+		{
+			context.BeginRequest += OnBeginRequest;
+		}
+
+		public void Dispose()
+		{
+		}
+
+		private static void OnBeginRequest(object sender, EventArgs e)
+		{
+			HttpContext context = ((HttpApplication)sender).Context;
+			string appPath = HttpRuntime.AppDomainAppVirtualPath;
+			if (string.IsNullOrEmpty(appPath) || appPath == "/")
+				return;
+
+			string rawUrl = context.Request.RawUrl;
+			if (rawUrl == null)
+				return;
+
+			if (!rawUrl.StartsWith(appPath, StringComparison.Ordinal) &&
+				rawUrl.StartsWith(appPath, StringComparison.OrdinalIgnoreCase))
+			{
+				string canonical = appPath + rawUrl.Substring(appPath.Length);
+				GXLogging.Debug(log, "Redirecting non-canonical app path '", rawUrl, "' to '", canonical, "'");
+#pragma warning disable SCS0027 // Open redirect: target is built from AppDomainAppVirtualPath (server config) and the original request path, always same-origin relative URL
+				context.Response.RedirectPermanent(canonical, true);
+#pragma warning restore SCS0027
+			}
+		}
+	}
 	public class GXRewriter : IHttpModule
 	{
 		private static readonly IGXLogger log = GXLoggerFactory.GetLogger<GXRewriter>();


### PR DESCRIPTION
HttpModule that redirects requests whose virtual path casing differs from the IIS-configured application path to the canonical casing. The canonical path is taken from AppDomainAppVirtualPath, so it works for any app without hardcoding the name.

Issue:208692